### PR TITLE
platform/local: consolidate namespace entering code

### DIFF
--- a/platform/local/nsdialer.go
+++ b/platform/local/nsdialer.go
@@ -18,7 +18,6 @@ package local
 
 import (
 	"net"
-	"runtime"
 
 	"github.com/vishvananda/netns"
 
@@ -45,19 +44,11 @@ func NewNsDialer(ns netns.NsHandle) *NsDialer {
 }
 
 func (d *NsDialer) Dial(network, address string) (net.Conn, error) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
-	origns, err := netns.Get()
+	nsExit, err := NsEnter(d.NsHandle)
 	if err != nil {
 		return nil, err
 	}
-	defer netns.Set(origns)
-
-	err = netns.Set(d.NsHandle)
-	if err != nil {
-		return nil, err
-	}
+	defer nsExit()
 
 	return d.RetryDialer.Dial(network, address)
 }

--- a/platform/local/nsenter.go
+++ b/platform/local/nsenter.go
@@ -1,0 +1,64 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package local
+
+import (
+	"runtime"
+
+	"github.com/vishvananda/netns"
+)
+
+// NsEnter locks the current goroutine the OS thread and switches to a
+// new network namespace. The returned function must be called in order
+// to restore the previous state and unlock the thread.
+func NsEnter(ns netns.NsHandle) (func() error, error) {
+	runtime.LockOSThread()
+
+	origns, err := netns.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	err = netns.Set(ns)
+	if err != nil {
+		origns.Close()
+		return nil, err
+	}
+
+	return func() error {
+		defer runtime.UnlockOSThread()
+		defer origns.Close()
+		if err := netns.Set(origns); err != nil {
+			return err
+		}
+		return nil
+	}, nil
+}
+
+// NsCreate returns a handle to a new network namespace.
+// NsEnter must be used to safely enter and exit the new namespace.
+func NsCreate() (netns.NsHandle, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	origns, err := netns.Get()
+	if err != nil {
+		return netns.None(), err
+	}
+	defer origns.Close()
+	defer netns.Set(origns)
+
+	return netns.New()
+}


### PR DESCRIPTION
Creating and switching namespaces, which are local to the OS thread, is
rather awkward in Go. Implement the goo once and fix a file descriptor
leak in the process, previously origns was never being closed.