### PR TITLE
dnsmasq: advertise NTP via DHCP

### DIFF
--- a/platform/local/dnsmasq.go
+++ b/platform/local/dnsmasq.go
@@ -56,6 +56,10 @@ no-resolv
 no-hosts
 enable-ra
 
+# point NTP at this host (0.0.0.0 and :: are special)
+dhcp-option=option:ntp-server,0.0.0.0
+dhcp-option=option6:ntp-server,[::]
+
 {{range .Segments}}
 domain={{.BridgeName}}.local
 


### PR DESCRIPTION
mantle doesn't actually provide a ntp server but this is still useful
for checking whether the DHCP options are getting plumbed through
systemd-networkd to systemd-timesyncd.