### PR TITLE
Gce plume

### DIFF
--- a/cmd/plume/create.go
+++ b/cmd/plume/create.go
@@ -1,0 +1,110 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/coreos/mantle/auth"
+	"github.com/coreos/mantle/cli"
+)
+
+var (
+	cmdCreate = &cli.Command{
+
+		Name:        "create-instances",
+		Summary:     "Create cluster on GCE",
+		Usage:       "-image <gce image name> -n <number of instances>",
+		Description: "Upload os image to Google Storage bucket and create image in GCE",
+		Flags:       *flag.NewFlagSet("create", flag.ExitOnError),
+		Run:         runCreate,
+	}
+	createProject      string
+	createZone         string
+	createMachine      string
+	createBaseName     string
+	createImageName    string
+	createConfig       string
+	createNumInstances int
+)
+
+func init() {
+	cmdCreate.Flags.StringVar(&createProject, "project", "coreos-gce-testing", "found in developers console")
+	cmdCreate.Flags.StringVar(&createZone, "zone", "us-central1-a", "gce zone")
+	cmdCreate.Flags.StringVar(&createMachine, "machine", "n1-standard-1", "gce machine type")
+	cmdCreate.Flags.StringVar(&createBaseName, "name", "", "prefix for instances")
+	cmdCreate.Flags.StringVar(&createImageName, "image", "", "GCE image name")
+	cmdCreate.Flags.StringVar(&createConfig, "config", "", "path to cloud config file")
+	cmdCreate.Flags.IntVar(&createNumInstances, "n", 1, "number of instances")
+	cli.Register(cmdCreate)
+}
+
+func runCreate(args []string) int {
+	if len(args) != 0 {
+		fmt.Fprintf(os.Stderr, "Unrecognized args in plume create-instances: %v\n", args)
+		return 2
+	}
+
+	if createImageName == "" {
+		fmt.Fprintf(os.Stderr, "Must specifcy GCE image with '-image' flag\n")
+		return 2
+	}
+	// if base name is unspecified use image name
+	if createBaseName == "" {
+		createBaseName = createImageName
+	}
+
+	var cloudConfig string
+	if createConfig != "" {
+		b, err := ioutil.ReadFile(createConfig)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Could not read cloud config file: %v\n", err)
+			return 1
+		}
+		cloudConfig = string(b)
+	}
+
+	client, err := auth.GoogleClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Authentication failed: %v\n", err)
+		return 1
+	}
+
+	var vms []*gceVM
+	for i := 0; i < createNumInstances; i++ {
+		name, err := nextName(client, createProject, createZone, createBaseName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed creating name for vm: %v\n", err)
+			return 1
+		}
+		vm, err := createVM(client, createProject, createZone, createMachine, name, createImageName, cloudConfig)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed creating vm: %v\n", err)
+			return 1
+		}
+		vms = append(vms, vm)
+		fmt.Printf("Instance %v created\n", name)
+	}
+	fmt.Printf("All instances created, add your ssh keys here: https://console.developers.google.com/project/%v/compute/metadata/sshKeys\n", createProject)
+	for _, vm := range vms {
+		fmt.Printf("To access %v use cmd:\n", vm.name)
+		fmt.Printf("ssh -o UserKnownHostsFile=/dev/null -o CheckHostIP=no -o StrictHostKeyChecking=no core@%v\n", vm.extIP)
+	}
+
+	return 0
+}

--- a/cmd/plume/destroy.go
+++ b/cmd/plume/destroy.go
@@ -1,0 +1,82 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/coreos/mantle/auth"
+	"github.com/coreos/mantle/cli"
+)
+
+var (
+	cmdDestroy = &cli.Command{
+
+		Name:        "destroy-instances",
+		Summary:     "destroy cluster on GCE",
+		Usage:       "-prefix=<prefix> ",
+		Description: "Destroy GCE instances based on name prefix.",
+		Flags:       *flag.NewFlagSet("upload", flag.ExitOnError),
+		Run:         runDestroy,
+	}
+	destroyProject string
+	destroyZone    string
+	destroyPrefix  string
+)
+
+func init() {
+	cmdDestroy.Flags.StringVar(&destroyProject, "project", "coreos-gce-testing", "found in developers console")
+	cmdDestroy.Flags.StringVar(&destroyZone, "zone", "us-central1-a", "gce zone")
+	cmdDestroy.Flags.StringVar(&destroyPrefix, "prefix", "", "prefix of name for instances to destroy")
+	cli.Register(cmdDestroy)
+}
+
+func runDestroy(args []string) int {
+	if len(args) != 0 {
+		fmt.Fprintf(os.Stderr, "Unrecognized args in plume list cmd: %v\n", args)
+		return 2
+	}
+
+	// avoid wiping out all instances in project or mishaps with short destroyPrefixes
+	if destroyPrefix == "" || len(destroyPrefix) < 2 {
+		fmt.Fprintf(os.Stderr, "Please specify a prefix of length 2 or greater with -prefix\n")
+		return 1
+	}
+
+	client, err := auth.GoogleClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Authentication failed: %v\n", err)
+		return 1
+	}
+
+	vms, err := listVMs(client, destroyProject, destroyZone, destroyPrefix)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed listing vms: %v\n", err)
+		return 1
+	}
+	var count int
+	for _, vm := range vms {
+		err := destroyVM(client, destroyProject, destroyZone, vm.name)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed destroying vm: %v\n", err)
+			return 1
+		}
+		count++
+	}
+	fmt.Printf("%v instance(s) scheduled for deletion\n", count)
+	return 0
+}

--- a/cmd/plume/gce.go
+++ b/cmd/plume/gce.go
@@ -1,0 +1,257 @@
+// Copyright 2015 CoreOS, Inc.
+// Copyright 2015 The Go Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/google.golang.org/api/compute/v1"
+)
+
+type gceVM struct {
+	name  string
+	intIP string
+	extIP string
+}
+
+func (vm gceVM) String() string {
+	s := fmt.Sprintf("%v:\n", vm.name)
+	s += fmt.Sprintf(" int: %v\n", vm.intIP)
+	s += fmt.Sprintf(" ext: %v\n", vm.extIP)
+	return s
+}
+
+// Create image on GCE and return. Will not overwrite existing image.
+func createImage(client *http.Client, proj, name, source string) error {
+	computeService, err := compute.New(client)
+	if err != nil {
+		return err
+	}
+
+	image := &compute.Image{
+		Name: name,
+		RawDisk: &compute.ImageRawDisk{
+			Source: source,
+		},
+	}
+	_, err = computeService.Images.Insert(proj, image).Do()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Delete image on GCE and then recreate it.
+func forceCreateImage(client *http.Client, proj, name, source string) error {
+	// delete
+	computeService, err := compute.New(client)
+	if err != nil {
+		return fmt.Errorf("deleting image: %v", err)
+	}
+	_, err = computeService.Images.Delete(proj, name).Do()
+	if err != nil {
+		return fmt.Errorf("deleting image: %v", err)
+	}
+
+	// create
+	return createImage(client, proj, name, source)
+}
+
+func listVMs(client *http.Client, proj, zone, prefix string) ([]gceVM, error) {
+	var vms []gceVM
+	computeService, err := compute.New(client)
+	list, err := computeService.Instances.List(proj, zone).Do()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, inst := range list.Items {
+		if !strings.HasPrefix(inst.Name, prefix) {
+			continue
+		}
+		intIP, extIP := instanceIPs(inst)
+		vm := gceVM{
+			name:  inst.Name,
+			extIP: extIP,
+			intIP: intIP,
+		}
+		vms = append(vms, vm)
+	}
+	return vms, nil
+}
+
+func listImages(client *http.Client, proj, prefix string) ([]string, error) {
+	var images []string
+	computeService, err := compute.New(client)
+	list, err := computeService.Images.List(proj).Do()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, image := range list.Items {
+		if !strings.HasPrefix(image.Name, prefix) {
+			continue
+		}
+		images = append(images, image.Name)
+	}
+	return images, nil
+}
+
+// create gce VM and wait for creation to succeed. Some code snipped from:
+// https://github.com/golang/build/blob/master/buildlet/gce.go#L323
+func createVM(client *http.Client, proj, zone, machineType, name, imageName, cfg string) (*gceVM, error) {
+	computeService, err := compute.New(client)
+	if err != nil {
+		return nil, err
+	}
+
+	prefix := "https://www.googleapis.com/compute/v1/projects/" + proj
+	machType := prefix + "/zones/" + zone + "/machineTypes/" + machineType
+	diskType := "https://www.googleapis.com/compute/v1/projects/" + proj + "/zones/" + zone + "/diskTypes/pd-ssd"
+	// uses default network which for coreos-gce-testing has open ports for ssh and etcd
+	instance := &compute.Instance{
+		Name:        name,
+		MachineType: machType,
+		Metadata:    &compute.Metadata{},
+		Disks: []*compute.AttachedDisk{
+			{
+				AutoDelete: true,
+				Boot:       true,
+				Type:       "PERSISTENT",
+				InitializeParams: &compute.AttachedDiskInitializeParams{
+					DiskName:    name,
+					SourceImage: "https://www.googleapis.com/compute/v1/projects/" + proj + "/global/images/" + imageName,
+					DiskType:    diskType,
+				},
+			},
+		},
+		NetworkInterfaces: []*compute.NetworkInterface{
+			&compute.NetworkInterface{
+				AccessConfigs: []*compute.AccessConfig{
+					&compute.AccessConfig{
+						Type: "ONE_TO_ONE_NAT",
+						Name: "External NAT",
+					},
+				},
+				Network: prefix + "/global/networks/default",
+			},
+		},
+	}
+	// add cloud config
+	if cfg != "" {
+		instance.Metadata.Items = append(instance.Metadata.Items, &compute.MetadataItems{
+			Key:   "user-data",
+			Value: cfg,
+		})
+	}
+
+	op, err := computeService.Instances.Insert(proj, zone, instance).Do()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create new VM: %v\n", err)
+	}
+	fmt.Printf("Instance %v requested\n", name)
+	fmt.Printf("Waiting for creation to finish...\n")
+
+	// wait for creation to finish
+OpLoop:
+	for {
+		time.Sleep(2 * time.Second)
+
+		op, err := computeService.ZoneOperations.Get(proj, zone, op.Name).Do()
+		if err != nil {
+			return nil, fmt.Errorf("Failed to get op %s: %v", op.Name, err)
+		}
+		switch op.Status {
+		case "PENDING", "RUNNING":
+			continue
+		case "DONE":
+			if op.Error != nil {
+				for _, operr := range op.Error.Errors {
+					return nil, fmt.Errorf("Error creating instance: %+v", operr)
+				}
+				return nil, fmt.Errorf("Failed to start.")
+			}
+			break OpLoop
+		default:
+			return nil, fmt.Errorf("Unknown create status %q: %+v", op.Status, op)
+		}
+	}
+
+	inst, err := computeService.Instances.Get(proj, zone, name).Do()
+	if err != nil {
+		return nil, fmt.Errorf("Error getting instance %s details after creation: %v", name, err)
+	}
+
+	intIP, extIP := instanceIPs(inst)
+	vm := &gceVM{
+		name:  name,
+		extIP: extIP,
+		intIP: intIP,
+	}
+
+	return vm, nil
+}
+
+func destroyVM(client *http.Client, proj, zone, name string) error {
+	computeService, err := compute.New(client)
+	if err != nil {
+		return err
+	}
+	_, err = computeService.Instances.Delete(proj, zone, name).Do()
+	return err
+}
+
+// snipped from: https://github.com/golang/build/blob/master/buildlet/gce.go#L323
+func instanceIPs(inst *compute.Instance) (intIP, extIP string) {
+	for _, iface := range inst.NetworkInterfaces {
+		if strings.HasPrefix(iface.NetworkIP, "10.") {
+			intIP = iface.NetworkIP
+		}
+		for _, accessConfig := range iface.AccessConfigs {
+			if accessConfig.Type == "ONE_TO_ONE_NAT" {
+				extIP = accessConfig.NatIP
+			}
+		}
+	}
+	return
+}
+
+// nextName returns the next available numbered name or the given base name.
+// snipped from: https://github.com/golang/build/blob/master/cmd/gomote/list.go
+func nextName(client *http.Client, proj, zone, base string) (string, error) {
+	vms, err := listVMs(client, proj, zone, base)
+	if err != nil {
+		return "", fmt.Errorf("error listing VMs: %v", err)
+	}
+	matches := map[string]bool{}
+	for _, vm := range vms {
+		if strings.HasPrefix(vm.name, base) {
+			matches[vm.name] = true
+		}
+	}
+	if len(matches) == 0 || !matches[base] {
+		return base, nil
+	}
+	for i := 1; ; i++ {
+		next := fmt.Sprintf("%v-%v", base, i)
+		if !matches[next] {
+			return next, nil
+		}
+	}
+}

--- a/cmd/plume/image.go
+++ b/cmd/plume/image.go
@@ -1,0 +1,67 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/coreos/mantle/auth"
+	"github.com/coreos/mantle/cli"
+)
+
+var (
+	cmdImage = &cli.Command{
+
+		Name:        "list-images",
+		Summary:     "List images in GCE",
+		Usage:       " -prefix=<prefix>",
+		Description: "List images in GCE",
+		Flags:       *flag.NewFlagSet("image", flag.ExitOnError),
+		Run:         runImage,
+	}
+	imageProject string
+	imagePrefix  string
+)
+
+func init() {
+	cmdImage.Flags.StringVar(&imageProject, "project", "coreos-gce-testing", "found in developers console")
+	cmdImage.Flags.StringVar(&imagePrefix, "prefix", "", "prefix to filter list by")
+	cli.Register(cmdImage)
+}
+
+func runImage(args []string) int {
+	if len(args) != 0 {
+		fmt.Fprintf(os.Stderr, "Unrecognized args in plume list cmd: %v\n", args)
+		return 2
+	}
+
+	client, err := auth.GoogleClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Authentication failed: %v\n", err)
+		return 1
+	}
+
+	images, err := listImages(client, imageProject, imagePrefix)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed listing images: %v\n", err)
+		return 1
+	}
+	for _, image := range images {
+		fmt.Printf("%v\n", image)
+	}
+	return 0
+}

--- a/cmd/plume/list.go
+++ b/cmd/plume/list.go
@@ -1,0 +1,70 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/coreos/mantle/auth"
+	"github.com/coreos/mantle/cli"
+)
+
+var (
+	cmdList = &cli.Command{
+
+		Name:        "list-instances",
+		Summary:     "List instances on GCE",
+		Usage:       "-prefix=<prefix>",
+		Description: " os image to Google Storage bucket and create image in GCE",
+		Flags:       *flag.NewFlagSet("list", flag.ExitOnError),
+		Run:         runList,
+	}
+	listProject string
+	listZone    string
+	listPrefix  string
+)
+
+func init() {
+	cmdList.Flags.StringVar(&listProject, "project", "coreos-gce-testing", "found in developers console")
+	cmdList.Flags.StringVar(&listZone, "zone", "us-central1-a", "gce zone")
+	cmdList.Flags.StringVar(&listPrefix, "prefix", "", "prefix to filter list by")
+	cli.Register(cmdList)
+}
+
+func runList(args []string) int {
+	if len(args) != 0 {
+		fmt.Fprintf(os.Stderr, "Unrecognized args in plume list cmd: %v\n", args)
+		return 2
+	}
+
+	client, err := auth.GoogleClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Authentication failed: %v\n", err)
+		return 1
+	}
+
+	vms, err := listVMs(client, listProject, listZone, listPrefix)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed listing vms: %v\n", err)
+		return 1
+	}
+	for _, vm := range vms {
+		fmt.Printf("%v\n", vm)
+	}
+	return 0
+
+}


### PR DESCRIPTION
This adds the all the basic commands necessary to create and destroy clusters on GCE. 

Most commands have extra optional parameters, but relying on default flag usage looks like
`plume upload`
`plume create-instances -image=<imagename> -n 3`
`plume list-instances`
`plume destroy-instances -prefix=<$USER>`
`plume list-images`

`create-instances` would in most cases specify a cloud-config filepath.

I prefixed the subcommand flag variables to avoid confusion and collision. Alternative approaches would be moving each subcommand into a separate package (but still having to register them in `main`) or reworking the way the CLI works.

gce.go will eventually be migrated into platform for use with kola as well.