### PR TITLE
Full gce support for kola

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -16,8 +16,8 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/coreos-cloudinit/config",
-			"Comment": "v1.3.1-4-g78b0f82",
-			"Rev": "78b0f82918260438dc188ac4fafa60cef76308bb"
+			"Comment": "v1.4.0-3-g4042920",
+			"Rev": "40429204ba955b0e7e8fb3c308d0067c84dd6cfb"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/client",

--- a/Godeps/_workspace/src/github.com/coreos/coreos-cloudinit/config/config.go
+++ b/Godeps/_workspace/src/github.com/coreos/coreos-cloudinit/config/config.go
@@ -37,6 +37,7 @@ type CloudConfig struct {
 
 type CoreOS struct {
 	Etcd      Etcd      `yaml:"etcd"`
+	Etcd2     Etcd2     `yaml:"etcd2"`
 	Flannel   Flannel   `yaml:"flannel"`
 	Fleet     Fleet     `yaml:"fleet"`
 	Locksmith Locksmith `yaml:"locksmith"`

--- a/Godeps/_workspace/src/github.com/coreos/coreos-cloudinit/config/config_test.go
+++ b/Godeps/_workspace/src/github.com/coreos/coreos-cloudinit/config/config_test.go
@@ -374,6 +374,7 @@ users:
     no_user_group: true
     system: y
     no_log_init: True
+    shell: /bin/sh
 `
 	cfg, err := NewCloudConfig(contents)
 	if err != nil {
@@ -440,6 +441,10 @@ users:
 
 	if !user.NoLogInit {
 		t.Errorf("Failed to parse no_log_init field")
+	}
+
+	if user.Shell != "/bin/sh" {
+		t.Errorf("Failed to parse shell field, got %q", user.Shell)
 	}
 }
 

--- a/Godeps/_workspace/src/github.com/coreos/coreos-cloudinit/config/etcd.go
+++ b/Godeps/_workspace/src/github.com/coreos/coreos-cloudinit/config/etcd.go
@@ -16,7 +16,7 @@ package config
 
 type Etcd struct {
 	Addr                     string  `yaml:"addr"                          env:"ETCD_ADDR"`
-	AdvertiseClientURLs      string  `yaml:"advertise_client_urls"         env:"ETCD_ADVERTISE_CLIENT_URLS"`
+	AdvertiseClientURLs      string  `yaml:"advertise_client_urls"         env:"ETCD_ADVERTISE_CLIENT_URLS"       deprecated:"etcd2 options no longer work for etcd"`
 	BindAddr                 string  `yaml:"bind_addr"                     env:"ETCD_BIND_ADDR"`
 	CAFile                   string  `yaml:"ca_file"                       env:"ETCD_CA_FILE"`
 	CertFile                 string  `yaml:"cert_file"                     env:"ETCD_CERT_FILE"`
@@ -26,26 +26,26 @@ type Etcd struct {
 	CorsOrigins              string  `yaml:"cors"                          env:"ETCD_CORS"`
 	DataDir                  string  `yaml:"data_dir"                      env:"ETCD_DATA_DIR"`
 	Discovery                string  `yaml:"discovery"                     env:"ETCD_DISCOVERY"`
-	DiscoveryFallback        string  `yaml:"discovery_fallback"            env:"ETCD_DISCOVERY_FALLBACK"`
-	DiscoverySRV             string  `yaml:"discovery_srv"                 env:"ETCD_DISCOVERY_SRV"`
-	DiscoveryProxy           string  `yaml:"discovery_proxy"               env:"ETCD_DISCOVERY_PROXY"`
-	ElectionTimeout          int     `yaml:"election_timeout"              env:"ETCD_ELECTION_TIMEOUT"`
-	ForceNewCluster          bool    `yaml:"force_new_cluster"             env:"ETCD_FORCE_NEW_CLUSTER"`
+	DiscoveryFallback        string  `yaml:"discovery_fallback"            env:"ETCD_DISCOVERY_FALLBACK"          deprecated:"etcd2 options no longer work for etcd"`
+	DiscoverySRV             string  `yaml:"discovery_srv"                 env:"ETCD_DISCOVERY_SRV"               deprecated:"etcd2 options no longer work for etcd"`
+	DiscoveryProxy           string  `yaml:"discovery_proxy"               env:"ETCD_DISCOVERY_PROXY"             deprecated:"etcd2 options no longer work for etcd"`
+	ElectionTimeout          int     `yaml:"election_timeout"              env:"ETCD_ELECTION_TIMEOUT"            deprecated:"etcd2 options no longer work for etcd"`
+	ForceNewCluster          bool    `yaml:"force_new_cluster"             env:"ETCD_FORCE_NEW_CLUSTER"           deprecated:"etcd2 options no longer work for etcd"`
 	GraphiteHost             string  `yaml:"graphite_host"                 env:"ETCD_GRAPHITE_HOST"`
-	HeartbeatInterval        int     `yaml:"heartbeat_interval"            env:"ETCD_HEARTBEAT_INTERVAL"`
+	HeartbeatInterval        int     `yaml:"heartbeat_interval"            env:"ETCD_HEARTBEAT_INTERVAL"          deprecated:"etcd2 options no longer work for etcd"`
 	HTTPReadTimeout          float64 `yaml:"http_read_timeout"             env:"ETCD_HTTP_READ_TIMEOUT"`
 	HTTPWriteTimeout         float64 `yaml:"http_write_timeout"            env:"ETCD_HTTP_WRITE_TIMEOUT"`
-	InitialAdvertisePeerURLs string  `yaml:"initial_advertise_peer_urls"   env:"ETCD_INITIAL_ADVERTISE_PEER_URLS"`
-	InitialCluster           string  `yaml:"initial_cluster"               env:"ETCD_INITIAL_CLUSTER"`
-	InitialClusterState      string  `yaml:"initial_cluster_state"         env:"ETCD_INITIAL_CLUSTER_STATE"`
-	InitialClusterToken      string  `yaml:"initial_cluster_token"         env:"ETCD_INITIAL_CLUSTER_TOKEN"`
+	InitialAdvertisePeerURLs string  `yaml:"initial_advertise_peer_urls"   env:"ETCD_INITIAL_ADVERTISE_PEER_URLS" deprecated:"etcd2 options no longer work for etcd"`
+	InitialCluster           string  `yaml:"initial_cluster"               env:"ETCD_INITIAL_CLUSTER"             deprecated:"etcd2 options no longer work for etcd"`
+	InitialClusterState      string  `yaml:"initial_cluster_state"         env:"ETCD_INITIAL_CLUSTER_STATE"       deprecated:"etcd2 options no longer work for etcd"`
+	InitialClusterToken      string  `yaml:"initial_cluster_token"         env:"ETCD_INITIAL_CLUSTER_TOKEN"       deprecated:"etcd2 options no longer work for etcd"`
 	KeyFile                  string  `yaml:"key_file"                      env:"ETCD_KEY_FILE"`
-	ListenClientURLs         string  `yaml:"listen_client_urls"            env:"ETCD_LISTEN_CLIENT_URLS"`
-	ListenPeerURLs           string  `yaml:"listen_peer_urls"              env:"ETCD_LISTEN_PEER_URLS"`
+	ListenClientURLs         string  `yaml:"listen_client_urls"            env:"ETCD_LISTEN_CLIENT_URLS"          deprecated:"etcd2 options no longer work for etcd"`
+	ListenPeerURLs           string  `yaml:"listen_peer_urls"              env:"ETCD_LISTEN_PEER_URLS"            deprecated:"etcd2 options no longer work for etcd"`
 	MaxResultBuffer          int     `yaml:"max_result_buffer"             env:"ETCD_MAX_RESULT_BUFFER"`
 	MaxRetryAttempts         int     `yaml:"max_retry_attempts"            env:"ETCD_MAX_RETRY_ATTEMPTS"`
-	MaxSnapshots             int     `yaml:"max_snapshots"                 env:"ETCD_MAX_SNAPSHOTS"`
-	MaxWALs                  int     `yaml:"max_wals"                      env:"ETCD_MAX_WALS"`
+	MaxSnapshots             int     `yaml:"max_snapshots"                 env:"ETCD_MAX_SNAPSHOTS"               deprecated:"etcd2 options no longer work for etcd"`
+	MaxWALs                  int     `yaml:"max_wals"                      env:"ETCD_MAX_WALS"                    deprecated:"etcd2 options no longer work for etcd"`
 	Name                     string  `yaml:"name"                          env:"ETCD_NAME"`
 	PeerAddr                 string  `yaml:"peer_addr"                     env:"ETCD_PEER_ADDR"`
 	PeerBindAddr             string  `yaml:"peer_bind_addr"                env:"ETCD_PEER_BIND_ADDR"`
@@ -56,7 +56,7 @@ type Etcd struct {
 	PeerKeyFile              string  `yaml:"peer_key_file"                 env:"ETCD_PEER_KEY_FILE"`
 	Peers                    string  `yaml:"peers"                         env:"ETCD_PEERS"`
 	PeersFile                string  `yaml:"peers_file"                    env:"ETCD_PEERS_FILE"`
-	Proxy                    string  `yaml:"proxy"                         env:"ETCD_PROXY"`
+	Proxy                    string  `yaml:"proxy"                         env:"ETCD_PROXY"                       deprecated:"etcd2 options no longer work for etcd"`
 	RetryInterval            float64 `yaml:"retry_interval"                env:"ETCD_RETRY_INTERVAL"`
 	Snapshot                 bool    `yaml:"snapshot"                      env:"ETCD_SNAPSHOT"`
 	SnapshotCount            int     `yaml:"snapshot_count"                env:"ETCD_SNAPSHOTCOUNT"`

--- a/Godeps/_workspace/src/github.com/coreos/coreos-cloudinit/config/etcd2.go
+++ b/Godeps/_workspace/src/github.com/coreos/coreos-cloudinit/config/etcd2.go
@@ -1,0 +1,44 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+type Etcd2 struct {
+	AdvertiseClientURLs      string `yaml:"advertise_client_urls"         env:"ETCD_ADVERTISE_CLIENT_URLS"`
+	CAFile                   string `yaml:"ca_file"                       env:"ETCD_CA_FILE"`
+	CertFile                 string `yaml:"cert_file"                     env:"ETCD_CERT_FILE"`
+	CorsOrigins              string `yaml:"cors"                          env:"ETCD_CORS"`
+	DataDir                  string `yaml:"data_dir"                      env:"ETCD_DATA_DIR"`
+	Discovery                string `yaml:"discovery"                     env:"ETCD_DISCOVERY"`
+	DiscoveryFallback        string `yaml:"discovery_fallback"            env:"ETCD_DISCOVERY_FALLBACK"`
+	DiscoverySRV             string `yaml:"discovery_srv"                 env:"ETCD_DISCOVERY_SRV"`
+	DiscoveryProxy           string `yaml:"discovery_proxy"               env:"ETCD_DISCOVERY_PROXY"`
+	ElectionTimeout          int    `yaml:"election_timeout"              env:"ETCD_ELECTION_TIMEOUT"`
+	HeartbeatInterval        int    `yaml:"heartbeat_interval"            env:"ETCD_HEARTBEAT_INTERVAL"`
+	InitialAdvertisePeerURLs string `yaml:"initial_advertise_peer_urls"   env:"ETCD_INITIAL_ADVERTISE_PEER_URLS"`
+	InitialCluster           string `yaml:"initial_cluster"               env:"ETCD_INITIAL_CLUSTER"`
+	InitialClusterState      string `yaml:"initial_cluster_state"         env:"ETCD_INITIAL_CLUSTER_STATE"`
+	InitialClusterToken      string `yaml:"initial_cluster_token"         env:"ETCD_INITIAL_CLUSTER_TOKEN"`
+	KeyFile                  string `yaml:"key_file"                      env:"ETCD_KEY_FILE"`
+	ListenClientURLs         string `yaml:"listen_client_urls"            env:"ETCD_LISTEN_CLIENT_URLS"`
+	ListenPeerURLs           string `yaml:"listen_peer_urls"              env:"ETCD_LISTEN_PEER_URLS"`
+	MaxSnapshots             int    `yaml:"max_snapshots"                 env:"ETCD_MAX_SNAPSHOTS"`
+	MaxWALs                  int    `yaml:"max_wals"                      env:"ETCD_MAX_WALS"`
+	Name                     string `yaml:"name"                          env:"ETCD_NAME"`
+	PeerCAFile               string `yaml:"peer_ca_file"                  env:"ETCD_PEER_CA_FILE"`
+	PeerCertFile             string `yaml:"peer_cert_file"                env:"ETCD_PEER_CERT_FILE"`
+	PeerKeyFile              string `yaml:"peer_key_file"                 env:"ETCD_PEER_KEY_FILE"`
+	Proxy                    string `yaml:"proxy"                         env:"ETCD_PROXY"`
+	SnapshotCount            int    `yaml:"snapshot_count"                env:"ETCD_SNAPSHOTCOUNT"`
+}

--- a/Godeps/_workspace/src/github.com/coreos/coreos-cloudinit/config/user.go
+++ b/Godeps/_workspace/src/github.com/coreos/coreos-cloudinit/config/user.go
@@ -29,4 +29,5 @@ type User struct {
 	NoUserGroup          bool     `yaml:"no_user_group"`
 	System               bool     `yaml:"system"`
 	NoLogInit            bool     `yaml:"no_log_init"`
+	Shell                string   `yaml:"shell"`
 }

--- a/Godeps/_workspace/src/github.com/coreos/coreos-cloudinit/config/validate/rules.go
+++ b/Godeps/_workspace/src/github.com/coreos/coreos-cloudinit/config/validate/rules.go
@@ -57,9 +57,9 @@ func checkEncoding(cfg node, report *Report) {
 			continue
 		}
 
-		c := f.Child("contents")
+		c := f.Child("content")
 		if _, err := config.DecodeContent(c.String(), e.String()); err != nil {
-			report.Error(c.line, fmt.Sprintf("contents cannot be decoded as %q", e.String()))
+			report.Error(c.line, fmt.Sprintf("content cannot be decoded as %q", e.String()))
 		}
 	}
 }
@@ -82,6 +82,9 @@ func checkNodeStructure(n, g node, r *Report) {
 	case reflect.Struct:
 		for _, cn := range n.children {
 			if cg := g.Child(cn.name); cg.IsValid() {
+				if msg := cg.field.Tag.Get("deprecated"); msg != "" {
+					r.Warning(cn.line, fmt.Sprintf("deprecated key %q (%s)", cn.name, msg))
+				}
 				checkNodeStructure(cn, cg, r)
 			} else {
 				r.Warning(cn.line, fmt.Sprintf("unrecognized key %q", cn.name))

--- a/Godeps/_workspace/src/github.com/coreos/coreos-cloudinit/config/validate/rules_test.go
+++ b/Godeps/_workspace/src/github.com/coreos/coreos-cloudinit/config/validate/rules_test.go
@@ -60,27 +60,27 @@ func TestCheckEncoding(t *testing.T) {
 	}{
 		{},
 		{
-			config: "write_files:\n  - encoding: base64\n    contents: aGVsbG8K",
+			config: "write_files:\n  - encoding: base64\n    content: aGVsbG8K",
 		},
 		{
-			config: "write_files:\n  - contents: !!binary aGVsbG8K",
+			config: "write_files:\n  - content: !!binary aGVsbG8K",
 		},
 		{
-			config:  "write_files:\n  - encoding: base64\n    contents: !!binary aGVsbG8K",
-			entries: []Entry{{entryError, `contents cannot be decoded as "base64"`, 3}},
+			config:  "write_files:\n  - encoding: base64\n    content: !!binary aGVsbG8K",
+			entries: []Entry{{entryError, `content cannot be decoded as "base64"`, 3}},
 		},
 		{
-			config: "write_files:\n  - encoding: base64\n    contents: !!binary YUdWc2JHOEsK",
+			config: "write_files:\n  - encoding: base64\n    content: !!binary YUdWc2JHOEsK",
 		},
 		{
-			config: "write_files:\n  - encoding: gzip\n    contents: !!binary H4sIAOC3tVQAA8tIzcnJ5wIAIDA6NgYAAAA=",
+			config: "write_files:\n  - encoding: gzip\n    content: !!binary H4sIAOC3tVQAA8tIzcnJ5wIAIDA6NgYAAAA=",
 		},
 		{
-			config: "write_files:\n  - encoding: gzip+base64\n    contents: H4sIAOC3tVQAA8tIzcnJ5wIAIDA6NgYAAAA=",
+			config: "write_files:\n  - encoding: gzip+base64\n    content: H4sIAOC3tVQAA8tIzcnJ5wIAIDA6NgYAAAA=",
 		},
 		{
-			config:  "write_files:\n  - encoding: custom\n    contents: hello",
-			entries: []Entry{{entryError, `contents cannot be decoded as "custom"`, 3}},
+			config:  "write_files:\n  - encoding: custom\n    content: hello",
+			entries: []Entry{{entryError, `content cannot be decoded as "custom"`, 3}},
 		},
 	}
 
@@ -117,6 +117,15 @@ func TestCheckStructure(t *testing.T) {
 		},
 		{
 			config: "coreos:\n  etcd:\n    discovery: good",
+		},
+
+		// Test for deprecated keys
+		{
+			config: "coreos:\n  etcd:\n    addr: hi",
+		},
+		{
+			config:  "coreos:\n  etcd:\n    proxy: hi",
+			entries: []Entry{{entryWarning, "deprecated key \"proxy\" (etcd2 options no longer work for etcd)", 3}},
 		},
 
 		// Test for error on list of nodes

--- a/cmd/kola/etcd.go
+++ b/cmd/kola/etcd.go
@@ -56,14 +56,20 @@ func runEtcd(args []string) int {
 			fmt.Fprintf(os.Stderr, "%v failed: %v\n", t.Name, err)
 			return 1
 		}
-		fmt.Printf("Test %v ran successfully\n", t.Name)
+		fmt.Printf("test %v ran successfully\n", t.Name)
 	}
-	fmt.Fprintf(os.Stderr, "etcd tests ran successfully!\n")
+	fmt.Fprintf(os.Stderr, "All etcd tests ran successfully!\n")
 	return 0
 }
 
-func runTest(t etcdtests.Test) error {
-	cluster, err := platform.NewQemuCluster()
+func runTest(t etcdtests.Test) (err error) {
+	var cluster platform.Cluster
+	if *kolaPlatform == "qemu" {
+		cluster, err = platform.NewQemuCluster()
+	} else if *kolaPlatform == "gce" {
+		cluster, err = platform.NewGCECluster()
+	}
+
 	if err != nil {
 		return fmt.Errorf("Cluster failed: %v", err)
 	}
@@ -85,11 +91,11 @@ func runTest(t etcdtests.Test) error {
 		if err != nil {
 			return fmt.Errorf("Cluster failed starting machine: %v", err)
 		}
-		fmt.Fprintf(os.Stderr, "qemu instance up\n")
+		fmt.Fprintf(os.Stderr, "%v instance up\n", *kolaPlatform)
 	}
 
 	// run test
-	err = t.Run(cluster)
+	err = t.Run(cluster, t.EtcdVersion)
 	return err
 }
 

--- a/cmd/kola/etcdtests/registry.go
+++ b/cmd/kola/etcdtests/registry.go
@@ -24,16 +24,9 @@ var Tests = []Test{
 		Run:         etcdDiscovery,
 		Discovery:   true,
 		ClusterSize: 3,
-		Name:        "etcdDiscovery--version1",
+		Name:        "etcd1 discovery",
+		EtcdVersion: 1,
 		CloudConfig: `#cloud-config
-write_files:
-  - path: /run/systemd/system/etcd.service.d/30-exec.conf
-    permissions: 0644
-    content: |
-      [Service]
-      ExecStart=
-      ExecStart=/usr/libexec/etcd/internal_versions/1/etcd
-
 coreos:
   etcd:
     name: $name
@@ -47,53 +40,26 @@ coreos:
 		Run:         etcdDiscovery,
 		Discovery:   true,
 		ClusterSize: 3,
-		Name:        "etcdDiscovery--version2--oldconfig",
+		Name:        "etcd2 discovery",
+		EtcdVersion: 2,
 		CloudConfig: `#cloud-config
-write_files:
-  - path: /run/systemd/system/etcd.service.d/30-exec.conf
-    permissions: 0644
-    content: |
-      [Service]
-      ExecStart=
-      ExecStart=/usr/libexec/etcd/internal_versions/2/etcd
 
 coreos:
-  etcd:
+  etcd2:
     name: $name
     discovery: $discovery
-    addr: $public_ipv4:4001
-    peer-addr: $private_ipv4:7001`,
-	},
-
-	// test etcd discovery with 2.0 but with old cloud config
-	Test{
-		Run:         etcdDiscovery,
-		Discovery:   true,
-		ClusterSize: 3,
-		Name:        "etcdDiscovery--version2",
-		CloudConfig: `#cloud-config
-write_files:
-  - path: /run/systemd/system/etcd.service.d/30-exec.conf
-    permissions: 0644
-    content: |
-      [Service]
-      ExecStart=
-      ExecStart=/usr/libexec/etcd/internal_versions/2/etcd
-coreos:
-  etcd:
-    name: $name
-    discovery: $discovery
-    listen-client-urls: http://0.0.0.0:4001,http://0.0.0.0:2379
-    advertise-client-urls: http://0.0.0.0:4001,http://0.0.0.0:2379
-    initial-advertise-peer-urls: http://$public_ipv4:2380
-    listen-peer-urls: http://$private_ipv4:2380`,
+    advertise-client-urls: http://$public_ipv4:2379
+    initial-advertise-peer-urls: http://$private_ipv4:2380
+    listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
+    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001`,
 	},
 }
 
 type Test struct {
-	Run         func(platform.Cluster) error
+	Run         func(platform.Cluster, int) error
 	Discovery   bool // set true to setup discovery endpoint
 	ClusterSize int
 	Name        string
 	CloudConfig string
+	EtcdVersion int
 }

--- a/cmd/kola/kola.go
+++ b/cmd/kola/kola.go
@@ -15,6 +15,8 @@
 package main
 
 import (
+	"flag"
+
 	"github.com/coreos/mantle/cli"
 )
 
@@ -23,6 +25,8 @@ const (
 	cliDescription = "The CoreOS Superdeep Borehole"
 	// http://en.wikipedia.org/wiki/Kola_Superdeep_Borehole
 )
+
+var kolaPlatform = flag.String("platform", "qemu", "compute platform to run kola tests on")
 
 func main() {
 	cli.Run(cliName, cliDescription)


### PR DESCRIPTION
Kola now has a platform flag that the etcd2 tests are aware of.

`sudo kola etcd`
and
`kola etcd -platform=gce -gce.image=pb-amd64-usr-653-0-0-2015-04-15-1702`

Will successfully run etcd (1 and 2) discovery on qemu and gce.