### PR TITLE
flag cleanup

### DIFF
--- a/cmd/kola/bootchart.go
+++ b/cmd/kola/bootchart.go
@@ -47,7 +47,18 @@ func runBootchart(args []string) int {
 		return 2
 	}
 
-	cluster, err := platform.NewQemuCluster()
+	var (
+		cluster platform.Cluster
+		err     error
+	)
+	if *kolaPlatform == "qemu" {
+		cluster, err = platform.NewQemuCluster(*qemuImage)
+	} else if *kolaPlatform == "gce" {
+		cluster, err = platform.NewGCECluster(gceOpts())
+	} else {
+		fmt.Fprintf(os.Stderr, "Invalid platform: %v", *kolaPlatform)
+	}
+
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Cluster failed: %v\n", err)
 		return 1

--- a/cmd/kola/etcd.go
+++ b/cmd/kola/etcd.go
@@ -65,9 +65,11 @@ func runEtcd(args []string) int {
 func runTest(t etcdtests.Test) (err error) {
 	var cluster platform.Cluster
 	if *kolaPlatform == "qemu" {
-		cluster, err = platform.NewQemuCluster()
+		cluster, err = platform.NewQemuCluster(*qemuImage)
 	} else if *kolaPlatform == "gce" {
-		cluster, err = platform.NewGCECluster()
+		cluster, err = platform.NewGCECluster(gceOpts())
+	} else {
+		fmt.Fprintf(os.Stderr, "Invalid platform: %v", *kolaPlatform)
 	}
 
 	if err != nil {

--- a/cmd/kola/kola.go
+++ b/cmd/kola/kola.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 
 	"github.com/coreos/mantle/cli"
+	"github.com/coreos/mantle/platform"
 )
 
 const (
@@ -26,7 +27,33 @@ const (
 	// http://en.wikipedia.org/wiki/Kola_Superdeep_Borehole
 )
 
-var kolaPlatform = flag.String("platform", "qemu", "compute platform to run kola tests on")
+var (
+	kolaPlatform = flag.String("platform", "qemu", "compute platform to run kola tests on")
+
+	qemuImage = flag.String("qemu.image",
+		"/mnt/host/source/src/build/images/amd64-usr/latest/coreos_production_image.bin",
+		"Base disk image for QEMU based tests.")
+
+	gceImage       = flag.String("gce.image", "", "GCE image")
+	gceProject     = flag.String("gce.project", "coreos-gce-testing", "GCE project")
+	gceZone        = flag.String("gce.zone", "us-central1-a", "GCE zone")
+	gceMachineType = flag.String("gce.machine", "n1-standard-1", "GCE machine type")
+	gceDisk        = flag.String("gce.disk", "pd-ssd", "GCE disk type")
+	gceBaseName    = flag.String("gce.basename", "kola", "GCE instance names will be generated from this")
+	gceNetwork     = flag.String("gce.network", "default", "GCE network")
+)
+
+func gceOpts() *platform.GCEOpts {
+	return &platform.GCEOpts{
+		Image:       *gceImage,
+		Project:     *gceProject,
+		Zone:        *gceZone,
+		MachineType: *gceMachineType,
+		DiskType:    *gceDisk,
+		BaseName:    *gceBaseName,
+		Network:     *gceNetwork,
+	}
+}
 
 func main() {
 	cli.Run(cliName, cliDescription)

--- a/cmd/kola/nfs.go
+++ b/cmd/kola/nfs.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"os"
 	"path"
 	"time"
 
@@ -46,7 +47,18 @@ func runNfs(args []string) int {
 		return 2
 	}
 
-	c, err := platform.NewQemuCluster()
+	var (
+		c   platform.Cluster
+		err error
+	)
+	if *kolaPlatform == "qemu" {
+		c, err = platform.NewQemuCluster(*qemuImage)
+	} else if *kolaPlatform == "gce" {
+		c, err = platform.NewGCECluster(gceOpts())
+	} else {
+		fmt.Fprintf(os.Stderr, "Invalid platform: %v", *kolaPlatform)
+	}
+
 	if err != nil {
 		log.Printf("NewQemuCluster: %s", err)
 		return 2

--- a/cmd/kola/qemu.go
+++ b/cmd/kola/qemu.go
@@ -44,7 +44,7 @@ func runQemu(args []string) int {
 		return 2
 	}
 
-	cluster, err := platform.NewQemuCluster()
+	cluster, err := platform.NewQemuCluster(*qemuImage)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Cluster failed: %v\n", err)
 		return 1

--- a/platform/gce.go
+++ b/platform/gce.go
@@ -282,8 +282,8 @@ func GCECreateVM(opts *GCEOpts) (*gceMachine, error) {
 		return nil, fmt.Errorf("Failed to create new VM: %v\n", err)
 	}
 
-	fmt.Printf("Instance %v requested\n", name)
-	fmt.Printf("Waiting for creation to finish...\n")
+	fmt.Fprintf(os.Stderr, "Instance %v requested\n", name)
+	fmt.Fprintf(os.Stderr, "Waiting for creation to finish...\n")
 
 	// wait for creation to finish
 	err = gceWaitVM(computeService, opts.Project, opts.Zone, op.Name)


### PR DESCRIPTION
Global flags in platform were polluting the help options in plume since plume sets its own flags in subcommands. To fix this for now, the global flags go into the main kola package itself. The platform package gets access to the flags from an options struct already used by plume. 

Kola tests nfs and bootchart are also platform aware and run on both without issue.