### PR TITLE
cmd/kolalet: add support for running native go test code

### DIFF
--- a/cmd/kolalet/kolalet.go
+++ b/cmd/kolalet/kolalet.go
@@ -1,0 +1,71 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/coreos/mantle/cli"
+	"github.com/coreos/mantle/kola"
+)
+
+const (
+	cliName        = "kolalet"
+	cliDescription = "Native code runner for kola"
+	// http://en.wikipedia.org/wiki/Kola_Superdeep_Borehole
+)
+
+// main test harness
+var cmdRun = &cli.Command{
+	Name:    "run",
+	Summary: "Run native tests a group at a time",
+	Run:     Run,
+}
+
+func init() {
+	cli.Register(cmdRun)
+}
+
+func main() {
+	cli.Run(cliName, cliDescription)
+}
+
+// test runner
+func Run(args []string) int {
+	if len(args) != 1 {
+		fmt.Fprintf(os.Stderr, "FAIL: Extra arguements specified. Usage: 'kolalet run <test group name>'\n")
+		return 2
+	}
+
+	// find test with matching name
+	group, ok := kola.Groups[args[0]]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "FAIL: test group not found\n")
+		return 1
+	}
+
+	var ranTests int //count successful tests
+	for _, f := range group.NativeTests {
+		ranTests++
+
+		err := f()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "FAIL: on native test %v: %v", ranTests, err)
+			return 1
+		}
+	}
+	return 0
+}

--- a/kola/etcdregistry.go
+++ b/kola/etcdregistry.go
@@ -14,32 +14,32 @@
 
 package kola
 
-import "github.com/coreos/mantle/kola/tests/etcd"
+import (
+	"github.com/coreos/mantle/kola/tests/etcd"
+	"github.com/coreos/mantle/platform"
+)
 
-//register new tests here
-// "$name" and "$discovery" are substituted in the cloud config during cluster creation
 func init() {
-	Tests = append(Tests, []Test{
-		// test etcd discovery with 0.4.7
-		Test{
-			Run:         etcd.DiscoveryV1,
-			ClusterSize: 3,
-			Name:        "Etcd1Discovery",
-			CloudConfig: `#cloud-config
+	// test etcd discovery with 0.4.7
+	Register(&TestGroup{
+		ClusterTests: []func(platform.Cluster) error{etcd.DiscoveryV1},
+		ClusterSize:  3,
+		Name:         "Etcd1Discovery",
+		CloudConfig: `#cloud-config
 coreos:
   etcd:
     name: $name
     discovery: $discovery
     addr: $public_ipv4:4001
     peer-addr: $private_ipv4:7001`,
-		},
+	})
 
-		// test etcd discovery with 2.0 with new cloud config
-		Test{
-			Run:         etcd.DiscoveryV2,
-			ClusterSize: 3,
-			Name:        "Etcd2Discovery",
-			CloudConfig: `#cloud-config
+	// test etcd discovery with 2.0 with new cloud config
+	Register(&TestGroup{
+		ClusterTests: []func(platform.Cluster) error{etcd.DiscoveryV2},
+		ClusterSize:  3,
+		Name:         "Etcd2Discovery",
+		CloudConfig: `#cloud-config
 
 coreos:
   etcd2:
@@ -49,6 +49,5 @@ coreos:
     initial-advertise-peer-urls: http://$private_ipv4:2380
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
     listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001`,
-		},
-	}...)
+	})
 }

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -24,18 +24,32 @@ import (
 	"github.com/coreos/mantle/platform"
 )
 
-// tests should register by adding init() functions to this package
-var Tests []Test
-
-type Test struct {
-	Run         func(platform.Cluster) error
-	Name        string //Should be uppercase and unique
-	CloudConfig string
-	ClusterSize int
-	Platforms   []string // whitelist of platforms to run test against -- defaults to all
+// Defines a group of tests to run on a cluster instance. These tests are
+// repeated on a new cluster for each platform. Cluster test functions are run
+// first using the platform.Cluster interface. Then the series of native code
+// tests are run on each member of the cluster.
+type TestGroup struct {
+	ClusterTests []func(platform.Cluster) error // run sequentially accross cluster
+	NativeTests  []func() error                 // run sequentially per machine
+	Name         string                         // should be uppercase and unique
+	CloudConfig  string
+	ClusterSize  int
+	Platforms    []string // whitelist of platforms to run tests against -- defaults to all
 }
 
-// runs and sets up environment for tests specified in etcdtests pkg
+// map names to test groups
+var Groups = map[string]*TestGroup{}
+
+// error if we register existing name
+func Register(t *TestGroup) {
+	_, ok := Groups[t.Name]
+	if ok {
+		panic("testgroup already registered with same name")
+	}
+	Groups[t.Name] = t
+}
+
+// Test runner
 func RunTests(args []string) int {
 	if len(args) > 1 {
 		fmt.Fprintf(os.Stderr, "Extra arguements specified. Usage: 'kola run [glob pattern]'\n")
@@ -48,8 +62,8 @@ func RunTests(args []string) int {
 		pattern = "*" // run all tests by default
 	}
 
-	var ranTests int //count sucessful tests
-	for _, t := range Tests {
+	var ranTests int //count successful tests
+	for _, t := range Groups {
 		match, err := filepath.Match(pattern, t.Name)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
@@ -64,21 +78,22 @@ func RunTests(args []string) int {
 		}
 
 		for _, pltfrm := range t.Platforms {
-			err := runTest(t, pltfrm)
+			err := runTestGroup(t, pltfrm)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "%v failed on %v: %v\n", t.Name, pltfrm, err)
 				return 1
 			}
-			fmt.Printf("test %v ran successfully on %v\n", t.Name, pltfrm)
+			fmt.Printf("test group %v ran successfully on %v\n", t.Name, pltfrm)
 			ranTests++
 		}
 	}
-	fmt.Fprintf(os.Stderr, "All %v test(s) ran successfully!\n", ranTests)
+	fmt.Fprintf(os.Stderr, "All %v test groups ran successfully!\n", ranTests)
 	return 0
 }
 
-// starts a cluster and runs the test
-func runTest(t Test, pltfrm string) (err error) {
+// starts a cluster and runs all tests until first error
+func runTestGroup(t *TestGroup, pltfrm string) error {
+	var err error
 	var cluster platform.Cluster
 	if pltfrm == "qemu" {
 		cluster, err = platform.NewQemuCluster(*QemuImage)
@@ -112,9 +127,67 @@ func runTest(t Test, pltfrm string) (err error) {
 		fmt.Fprintf(os.Stderr, "%v instance up\n", pltfrm)
 	}
 
-	// run test
-	err = t.Run(cluster)
-	return err
+	// run tests
+	if t.ClusterTests != nil {
+		for _, f := range t.ClusterTests {
+			err = f(cluster)
+			if err != nil {
+				return fmt.Errorf("FAIL in group %v: %v", t.Name, err)
+			}
+		}
+	}
+
+	if t.NativeTests != nil {
+		// drop binary
+		for _, m := range cluster.Machines() {
+			err = scpFile(m, "./kolalet")
+			if err != nil {
+				return fmt.Errorf("FAIL dropping kolalet binaries: %v", err)
+			}
+
+			_, err := m.SSH("chmod +x ./kolalet")
+			if err != nil {
+				return fmt.Errorf("FAIL dropping kolalet binaries: %v", err)
+			}
+		}
+
+		// run native tests
+		for _, m := range cluster.Machines() {
+			b, err := m.SSH("./kolalet run " + t.Name)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "%s\n", b)
+		}
+	}
+
+	return nil
+}
+
+// scpFile copies file from src path to ~/ on machine
+func scpFile(m platform.Machine, src string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	session, err := m.SSHSession()
+	if err != nil {
+		return fmt.Errorf("Error establishing ssh session: %v", err)
+	}
+	defer session.Close()
+
+	// machine reads file from stdin
+	session.Stdin = in
+
+	// cat file to fs
+	_, filename := filepath.Split(src)
+	_, err = session.CombinedOutput(fmt.Sprintf("cat > ./%s", filename))
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // replaces $discovery with discover url in etcd cloud config and

--- a/kola/miscregistry.go
+++ b/kola/miscregistry.go
@@ -14,18 +14,19 @@
 
 package kola
 
-import "github.com/coreos/mantle/kola/tests/misc"
+import (
+	"github.com/coreos/mantle/kola/tests/misc"
+	"github.com/coreos/mantle/platform"
+)
 
 //register new tests here
 // "$name" and "$discovery" are substituted in the cloud config during cluster creation
 func init() {
-	Tests = append(Tests, []Test{
-		// test etcd discovery with 0.4.7
-		Test{
-			Run:         misc.NFS,
-			ClusterSize: 0,
-			Name:        "NFS",
-			Platforms:   []string{"qemu"},
-		},
-	}...)
+	// test etcd discovery with 0.4.7
+	Register(&TestGroup{
+		ClusterTests: []func(platform.Cluster) error{misc.NFS},
+		ClusterSize:  0,
+		Name:         "NFS",
+		Platforms:    []string{"qemu"},
+	})
 }


### PR DESCRIPTION
Kolalet binaries are dropped onto newly created machines by the test
harness. Tests are now registered as a Group. Each group gets its own
cluster and will sequentially run a list of cluster wide tests that have
access to the platform.Cluster interface. A list of native test
functions are then run on each node of the cluster via the kolalet
binary.

This commit will be used to port the coretest series of tests. https://github.com/coreos/mantle/issues/6

Right now kolalet binaries are just expected to be in the working dir from which kola is run. After the coretest work I'll followup with a PR into overlay to get the kolalet binary built into the SDK.