### PR TITLE
kolet: add support for native code in kola tests

### DIFF
--- a/cmd/kolet/kolet.go
+++ b/cmd/kolet/kolet.go
@@ -1,0 +1,71 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/coreos/mantle/cli"
+	"github.com/coreos/mantle/kola"
+)
+
+const (
+	cliName        = "kolet"
+	cliDescription = "Native code runner for kola"
+)
+
+// main test harness
+var cmdRun = &cli.Command{
+	Name:    "run",
+	Summary: "Run native tests a group at a time",
+	Run:     Run,
+}
+
+func init() {
+	cli.Register(cmdRun)
+}
+
+func main() {
+	cli.Run(cliName, cliDescription)
+}
+
+// test runner
+func Run(args []string) int {
+	if len(args) != 2 {
+		fmt.Fprintf(os.Stderr, "FAIL: Extra arguements specified. Usage: 'kolet run <test name> <func name>'\n")
+		return 2
+	}
+	testname, funcname := args[0], args[1]
+
+	// find test with matching name
+	test, ok := kola.Tests[testname]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "FAIL: test group not found\n")
+		return 1
+	}
+	// find native function in test
+	f, ok := test.NativeFuncs[funcname]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "FAIL: native function not found\n")
+		return 1
+	}
+	err := f()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: on native test %v: %v", funcname, err)
+		return 1
+	}
+	return 0
+}

--- a/kola/etcdregistry.go
+++ b/kola/etcdregistry.go
@@ -19,27 +19,26 @@ import "github.com/coreos/mantle/kola/tests/etcd"
 //register new tests here
 // "$name" and "$discovery" are substituted in the cloud config during cluster creation
 func init() {
-	Tests = append(Tests, []Test{
-		// test etcd discovery with 0.4.7
-		Test{
-			Run:         etcd.DiscoveryV1,
-			ClusterSize: 3,
-			Name:        "Etcd1Discovery",
-			CloudConfig: `#cloud-config
+	// test etcd discovery with 0.4.7
+	Register(&Test{
+		Run:         etcd.DiscoveryV1,
+		ClusterSize: 3,
+		Name:        "Etcd1Discovery",
+		CloudConfig: `#cloud-config
 coreos:
   etcd:
     name: $name
     discovery: $discovery
     addr: $public_ipv4:4001
     peer-addr: $private_ipv4:7001`,
-		},
+	})
 
-		// test etcd discovery with 2.0 with new cloud config
-		Test{
-			Run:         etcd.DiscoveryV2,
-			ClusterSize: 3,
-			Name:        "Etcd2Discovery",
-			CloudConfig: `#cloud-config
+	// test etcd discovery with 2.0 with new cloud config
+	Register(&Test{
+		Run:         etcd.DiscoveryV2,
+		ClusterSize: 3,
+		Name:        "Etcd2Discovery",
+		CloudConfig: `#cloud-config
 
 coreos:
   etcd2:
@@ -49,6 +48,5 @@ coreos:
     initial-advertise-peer-urls: http://$private_ipv4:2380
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
     listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001`,
-		},
-	}...)
+	})
 }

--- a/kola/miscregistry.go
+++ b/kola/miscregistry.go
@@ -19,13 +19,11 @@ import "github.com/coreos/mantle/kola/tests/misc"
 //register new tests here
 // "$name" and "$discovery" are substituted in the cloud config during cluster creation
 func init() {
-	Tests = append(Tests, []Test{
-		// test etcd discovery with 0.4.7
-		Test{
-			Run:         misc.NFS,
-			ClusterSize: 0,
-			Name:        "NFS",
-			Platforms:   []string{"qemu"},
-		},
-	}...)
+	// test etcd discovery with 0.4.7
+	Register(&Test{
+		Run:         misc.NFS,
+		ClusterSize: 0,
+		Name:        "NFS",
+		Platforms:   []string{"qemu"},
+	})
 }

--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -23,12 +23,12 @@ import (
 	"github.com/coreos/mantle/platform"
 )
 
-func DiscoveryV2(cluster platform.Cluster) error {
-	return discovery(cluster, 2)
+func DiscoveryV2(c platform.TestCluster) error {
+	return discovery(c, 2)
 }
 
-func DiscoveryV1(cluster platform.Cluster) error {
-	return discovery(cluster, 1)
+func DiscoveryV1(c platform.TestCluster) error {
+	return discovery(c, 1)
 }
 
 func discovery(cluster platform.Cluster, version int) error {

--- a/kola/tests/misc/nfs.go
+++ b/kola/tests/misc/nfs.go
@@ -27,7 +27,7 @@ import (
 )
 
 // Test that the kernel NFS server and client work within CoreOS.
-func NFS(c platform.Cluster) error {
+func NFS(c platform.TestCluster) error {
 	/* server machine */
 	c1 := config.CloudConfig{
 		CoreOS: config.CoreOS{

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -15,6 +15,8 @@
 package platform
 
 import (
+	"fmt"
+
 	"github.com/coreos/mantle/Godeps/_workspace/src/golang.org/x/crypto/ssh"
 	"github.com/coreos/mantle/util"
 )
@@ -37,4 +39,21 @@ type Cluster interface {
 	EtcdEndpoint() string
 	GetDiscoveryURL(size int) (string, error)
 	Destroy() error
+}
+
+// TestCluster embedds a Cluster to provide platform independant helper
+// methods.
+type TestCluster struct {
+	Name string
+	Cluster
+}
+
+// run a registered NativeFunc on a remote machine
+func (t *TestCluster) RunNative(funcName string, m Machine) error {
+	// scp and execute kolet on remote machine
+	b, err := m.SSH(fmt.Sprintf("./kolet run %q %q", t.Name, funcName))
+	if err != nil {
+		return fmt.Errorf("%v: %s", err, b)
+	}
+	return nil
 }


### PR DESCRIPTION
Kolet binaries are dropped onto newly created machines by the test harness and allow for running native helper or test functions within a test.

Tests can now define native functions it would like to have available. These tests can be run through the ugly closure passed along with the cluster. This closure is used over a struct + method to prevent an import cycle.

This functionality is useful in porting coretest into kola in future PRs.

Right now kolalet binaries are just expected to be in the working dir from which kola is run. Once kolet is in overlay kolet binaries will be in a standard location.