### PR TITLE
Logging cleanup

### DIFF
--- a/kola/tests/coretest/fleet.go
+++ b/kola/tests/coretest/fleet.go
@@ -36,8 +36,7 @@ func init() {
 		var err error
 		fleetctlTimeout, err = time.ParseDuration(timeout)
 		if err != nil {
-			fmt.Printf("Failed parsing FLEETCTL_TIMEOUT: %v\n", err)
-			os.Exit(1)
+			plog.Fatalf("Failed parsing FLEETCTL_TIMEOUT: %v", err)
 		}
 	} else {
 		fleetctlTimeout = defaultFleetctlTimeout

--- a/kola/tests/coretest/testgroupglue.go
+++ b/kola/tests/coretest/testgroupglue.go
@@ -1,17 +1,17 @@
 package coretest
 
 import (
-	"fmt"
-
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/coreos/pkg/capnslog"
 	"github.com/coreos/mantle/platform"
 )
+
+var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "kola/tests/coretest")
 
 // run various native functions that only require a single machine
 func LocalTests(c platform.TestCluster) error {
 	tests := c.ListNativeFunctions()
 	for _, name := range tests {
-
-		fmt.Printf("running %v...\n", name)
+		plog.Noticef("running %v...", name)
 		err := c.RunNative(name, c.Machines()[0])
 		if err != nil {
 			return err
@@ -24,7 +24,7 @@ func LocalTests(c platform.TestCluster) error {
 func ClusterTests(c platform.TestCluster) error {
 	tests := c.ListNativeFunctions()
 	for _, name := range tests {
-		fmt.Printf("running %v...\n", name)
+		plog.Noticef("running %v...", name)
 		err := c.RunNative(name, c.Machines()[0])
 		if err != nil {
 			return err
@@ -38,7 +38,7 @@ func ClusterTests(c platform.TestCluster) error {
 func InternetTests(c platform.TestCluster) error {
 	tests := c.ListNativeFunctions()
 	for _, name := range tests {
-		fmt.Printf("running %v...\n", name)
+		plog.Noticef("running %v...", name)
 		err := c.RunNative(name, c.Machines()[0])
 		if err != nil {
 			return err

--- a/kola/tests/misc/nfs.go
+++ b/kola/tests/misc/nfs.go
@@ -17,14 +17,16 @@ package misc
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"path"
 	"time"
 
 	"github.com/coreos/mantle/platform"
 
 	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/coreos/coreos-cloudinit/config"
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/coreos/pkg/capnslog"
 )
+
+var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "util")
 
 // Test that the kernel NFS server and client work within CoreOS.
 func NFS(c platform.TestCluster) error {
@@ -66,7 +68,7 @@ func NFS(c platform.TestCluster) error {
 
 	defer m1.Destroy()
 
-	log.Printf("NFS server booted.")
+	plog.Info("NFS server booted.")
 
 	/* poke a file in /tmp */
 	tmp, err := m1.SSH("mktemp")
@@ -74,7 +76,7 @@ func NFS(c platform.TestCluster) error {
 		return fmt.Errorf("Machine.SSH: %s", err)
 	}
 
-	log.Printf("Test file %q created on server.", tmp)
+	plog.Infof("Test file %q created on server.", tmp)
 
 	/* client machine */
 
@@ -116,18 +118,18 @@ Options=defaults,noexec
 
 	defer m2.Destroy()
 
-	log.Printf("NFS client booted.")
+	plog.Info("NFS client booted.")
 
 	var lsmnt []byte
 
-	log.Printf("Waiting for NFS mount on client...")
+	plog.Info("Waiting for NFS mount on client...")
 
 	/* there's probably a better wait to check the mount */
 	for i := 0; i < 5; i++ {
 		lsmnt, _ = m2.SSH("ls /mnt")
 
 		if len(lsmnt) != 0 {
-			log.Printf("Got NFS mount.")
+			plog.Info("Got NFS mount.")
 			break
 		}
 
@@ -141,8 +143,6 @@ Options=defaults,noexec
 	if bytes.Contains(lsmnt, []byte(path.Base(string(tmp)))) != true {
 		return fmt.Errorf("Client /mnt did not contain file %q from server /tmp -- /mnt: %s", tmp, lsmnt)
 	}
-
-	log.Printf("NFS test passed.")
 
 	return nil
 }

--- a/util/logio.go
+++ b/util/logio.go
@@ -1,0 +1,34 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"bufio"
+	"io"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/coreos/pkg/capnslog"
+)
+
+var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "util")
+
+func LogFrom(l capnslog.LogLevel, r io.Reader) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		plog.Log(l, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		plog.Errorf("Reading %s failed: %v", r, err)
+	}
+}


### PR DESCRIPTION
Lots of individual tests make excessive noise but in many cases we now have sane default output!

```
2015/06/2 16:43:00 kola: === RUN NFS on qemu
2015/06/2 16:43:11 kola: --- PASS: NFS on qemu (10.603s)
2015/06/2 16:43:11 kola: === RUN coretestsLocal on qemu
2015/06/2 16:43:17 kola/tests/coretest: running ServicesActive...
2015/06/2 16:43:17 kola/tests/coretest: running ReadOnly...
2015/06/2 16:43:17 kola/tests/coretest: running CloudConfig...
2015/06/2 16:43:17 kola/tests/coretest: running Script...
2015/06/2 16:43:17 kola/tests/coretest: running PortSSH...
2015/06/2 16:43:17 kola/tests/coretest: running DbusPerms...
2015/06/2 16:43:17 kola/tests/coretest: running Symlink...
2015/06/2 16:43:17 kola/tests/coretest: running UpdateEngineKeys...
2015/06/2 16:43:17 kola: --- PASS: coretestsLocal on qemu (6.533s)
2015/06/2 16:43:17 kola: === RUN coretestsCluster on qemu
2015/06/2 16:43:32 kola/tests/coretest: running EtcdUpdateValue...
2015/06/2 16:43:32 kola: --- FAIL: coretestsCluster on qemu (14.932s)
2015/06/2 16:43:32 kola:         kolet: on native test EtcdUpdateValue: curl set failed with error: exit status 7
```
