### PR TITLE
added gce-upload and gce-create from ore's upload cmd

### DIFF
--- a/cmd/plume/gcecreate.go
+++ b/cmd/plume/gcecreate.go
@@ -1,0 +1,154 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/url"
+	"strings"
+
+	"github.com/coreos/mantle/auth"
+	"github.com/coreos/mantle/cli"
+	"github.com/coreos/mantle/platform"
+)
+
+var (
+	cmdGCECreate = &cli.Command{
+
+		Name:        "gce-create",
+		Summary:     "Create gce image",
+		Usage:       "",
+		Description: "Create GCE image from os image in Google Storage bucket.",
+		Flags:       *flag.NewFlagSet("gceCreate", flag.ExitOnError),
+		Run:         runGCECreate,
+	}
+	gceCreateForce     bool
+	gceCreateFile      string
+	gceCreateProject   string
+	gceCreateImageName string
+)
+
+func init() {
+	cmdGCECreate.Flags.BoolVar(&gceCreateForce, "force", false, "set true to overwrite existing image with same name")
+	cmdGCECreate.Flags.StringVar(&gceCreateFile, "from-storage", "", "file from a google storage bucket <gs://bucket/prefix/name>")
+	cmdGCECreate.Flags.StringVar(&gceCreateProject, "project", "coreos-gce-testing", "Google Compute project ID")
+	cmdGCECreate.Flags.StringVar(&gceCreateImageName, "name", "", "name for uploaded image, defaults to translating the filename in the bucket")
+
+	cli.Register(cmdGCECreate)
+}
+
+func runGCECreate(args []string) int {
+	if len(args) != 0 {
+		log.Printf("Unrecognized args in gce-create cmd: %v\n", args)
+		return 2
+	}
+
+	if gceCreateFile == "" {
+		log.Printf("must specify 'from-storage' flag with a storage bucket")
+	}
+
+	gsURL, err := url.Parse(gceCreateFile)
+	if err != nil {
+		log.Printf("%v", err)
+		return 1
+	}
+	if gsURL.Scheme != "gs" {
+		log.Printf("URL missing gs:// scheme prefix: %v\n", gceCreateFile)
+		return 1
+	}
+	if gsURL.Host == "" {
+		log.Printf("URL missing bucket name %v\n", gceCreateFile)
+		return 1
+	}
+	if gsURL.Path == "" {
+		log.Printf("URL missing filepath: %v", gceCreateFile)
+		return 1
+	}
+
+	if gceCreateImageName == "" {
+		path := strings.TrimSuffix(gsURL.Path, ".tar.gz")
+		gceCreateImageName = gceSanitize(strings.TrimPrefix(path, "/"))
+	}
+
+	bucket := gsURL.Host
+	bucketPath := strings.TrimPrefix(gsURL.Path, "/")
+	imageName := gceCreateImageName
+
+	client, err := auth.GoogleClient()
+	if err != nil {
+		log.Printf("Authentication failed: %v", err)
+		return 1
+	}
+
+	// make sure file exists
+	exists, err := fileQuery(client, bucket, bucketPath)
+	if err != nil || !exists {
+		log.Printf("failed to find existance of storage image: %v", err)
+		return 1
+	}
+
+	log.Printf("Creating image in GCE: %v...\n", imageName)
+
+	// create image on gce
+	storageSrc := fmt.Sprintf("https://storage.googleapis.com/%v/%v", bucket, bucketPath)
+	err = platform.GCECreateImage(client, gceCreateProject, imageName, storageSrc)
+
+	// if image already exists ask to delete and try again
+	if err != nil && strings.HasSuffix(err.Error(), "alreadyExists") {
+		if gceCreateForce {
+			log.Println("forcing overwrite of existing image...")
+			err = platform.GCEForceCreateImage(client, gceCreateProject, imageName, storageSrc)
+		} else {
+			log.Printf("skipping upload, image %v already exists", imageName)
+			return 0
+		}
+	}
+
+	if err != nil {
+		log.Printf("Creating GCE image failed: %v", err)
+		return 1
+	}
+
+	return 0
+}
+
+// Converts an image name from Google Storage to an equivalent GCE image
+// name. NOTE: Not a fully generlized sanitizer for GCE. Designed for
+// the default version.txt name (ex: 633.1.0+2015-03-31-1538). See:
+// https://godoc.org/google.golang.org/api/compute/v1#Image
+func gceSanitize(name string) string {
+	if name == "" {
+		return name
+	}
+
+	// remove incompatible chars from version.txt
+	name = strings.Replace(name, ".", "-", -1)
+	name = strings.Replace(name, "+", "-", -1)
+
+	// remove forward slashes likely from prefix
+	name = strings.Replace(name, "/", "-", -1)
+
+	// ensure name starts with [a-z]
+	char := name[0]
+	if char >= 'a' && char <= 'z' {
+		return name
+	}
+	if char >= 'A' && char <= 'Z' {
+		return strings.ToLower(name[:1]) + name[1:]
+	}
+	return "v" + name
+}

--- a/cmd/plume/gceupload.go
+++ b/cmd/plume/gceupload.go
@@ -1,0 +1,197 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/google.golang.org/cloud"
+	"github.com/coreos/mantle/Godeps/_workspace/src/google.golang.org/cloud/storage"
+	"github.com/coreos/mantle/auth"
+	"github.com/coreos/mantle/cli"
+)
+
+var (
+	cmdGCEUpload = &cli.Command{
+
+		Name:        "gce-upload",
+		Summary:     "Upload gce image",
+		Usage:       "",
+		Description: "Upload os image to Google Storage bucket and create image in GCE. Intended for use in SDK.",
+		Flags:       *flag.NewFlagSet("gceUpload", flag.ExitOnError),
+		Run:         runGCEUpload,
+	}
+	gceUploadForce     bool
+	gceUploadBucket    string
+	gceUploadImageName string
+	gceUploadBoard     string
+	gceUploadFile      string
+)
+
+func init() {
+	cmdGCEUpload.Flags.BoolVar(&gceUploadForce, "force", false, "set true to overwrite existing image with same name")
+	cmdGCEUpload.Flags.StringVar(&gceUploadBucket, "bucket", "gs://users.developer.core-os.net", "gs://bucket/prefix/ prefix defaults to $USER")
+	cmdGCEUpload.Flags.StringVar(&gceUploadImageName, "name", "", "name for uploaded image, defaults to COREOS_VERSION")
+	cmdGCEUpload.Flags.StringVar(&gceUploadBoard, "board", "amd64-usr", "board used for naming with default prefix only")
+	cmdGCEUpload.Flags.StringVar(&gceUploadFile, "file",
+		"/mnt/host/source/src/build/images/amd64-usr/latest/coreos_production_gce.tar.gz",
+		"path_to_coreos_image (build with: ./image_to_vm.sh --format=gce ...)")
+	cli.Register(cmdGCEUpload)
+}
+
+func runGCEUpload(args []string) int {
+	if len(args) != 0 {
+		log.Printf("Unrecognized args in gce-upload cmd: %v\n", args)
+		return 2
+	}
+
+	// if an image name is unspecified try to use version.txt
+	if gceUploadImageName == "" {
+		gceUploadImageName = getImageVersion(gceUploadFile)
+		if gceUploadImageName == "" {
+			log.Printf("Unable to get version from image directory, provide a -name flag or include a version.txt in the image directory\n")
+			return 1
+		}
+	}
+
+	gsURL, err := url.Parse(gceUploadBucket)
+	if err != nil {
+		log.Printf("%v\n", err)
+		return 1
+	}
+	if gsURL.Scheme != "gs" {
+		log.Printf("URL missing gs:// scheme prefix: %v\n", gceUploadBucket)
+		return 1
+	}
+	if gsURL.Host == "" {
+		log.Printf("URL missing bucket name %v\n", gceUploadBucket)
+		return 1
+	}
+	// if prefix not specified default name to gs://bucket/$USER/$BOARD/$VERSION
+	if gsURL.Path == "" {
+		if user := os.Getenv("USER"); user != "" {
+			gsURL.Path = "/" + os.Getenv("USER")
+			gsURL.Path += "/" + gceUploadBoard
+		}
+	}
+
+	uploadBucket := gsURL.Host
+	imageNameGS := strings.TrimPrefix(gsURL.Path+"/"+gceUploadImageName, "/") + ".tar.gz"
+
+	client, err := auth.GoogleClient()
+	if err != nil {
+		log.Printf("Authentication failed: %v\n", err)
+		return 1
+	}
+
+	// check if this file is already uploaded
+	alreadyExists, err := fileQuery(client, uploadBucket, imageNameGS)
+	if err != nil {
+		log.Printf("Uploading image failed: %v\n", err)
+		return 1
+	}
+
+	if alreadyExists {
+		if !gceUploadForce {
+			log.Printf("skipping upload, file %v already exists on Google Storage.", imageNameGS)
+			return 0
+		} else {
+			log.Println("forcing image upload...")
+		}
+	}
+
+	err = writeFile(client, uploadBucket, gceUploadFile, imageNameGS)
+	if err != nil {
+		log.Printf("Uploading image failed: %v\n", err)
+		return 1
+	}
+
+	return 0
+}
+
+// Attempt to get version.txt from image build directory. Return "" if
+// unable to retrieve version.txt from directory.
+func getImageVersion(path string) string {
+	imageDir := filepath.Dir(path)
+	b, err := ioutil.ReadFile(filepath.Join(imageDir, "version.txt"))
+	if err != nil {
+		return ""
+	}
+
+	lines := strings.Split(string(b), "\n")
+	var version string
+	for _, str := range lines {
+		if strings.Contains(str, "COREOS_VERSION=") {
+			version = strings.TrimPrefix(str, "COREOS_VERSION=")
+			break
+		}
+	}
+	return version
+}
+
+// Write file to Google Storage
+func writeFile(client *http.Client, bucket, filename, destname string) error {
+	log.Printf("Writing %v to gs://%v ...\n", filename, bucket)
+	log.Printf("(Sometimes this takes a few mintues)\n")
+
+	// dummy value is used since a project name isn't necessary unless
+	// we are creating new buckets
+	ctx := cloud.NewContext("dummy", client)
+	wc := storage.NewWriter(ctx, bucket, destname)
+	wc.ContentType = "application/x-gzip"
+	wc.ACL = []storage.ACLRule{{storage.AllAuthenticatedUsers, storage.RoleReader}}
+
+	file, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = io.Copy(wc, file)
+	if err != nil {
+		return err
+	}
+	if err := wc.Close(); err != nil {
+		return err
+	}
+
+	log.Printf("Upload successful!\n")
+	return nil
+}
+
+// Test if file exists in Google Storage
+func fileQuery(client *http.Client, bucket, name string) (bool, error) {
+	ctx := cloud.NewContext("dummy", client)
+	query := &storage.Query{Prefix: name}
+
+	objects, err := storage.ListObjects(ctx, bucket, query)
+	if err != nil {
+		return false, err
+	}
+
+	if len(objects.Results) == 1 {
+		return true, nil
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
Added `force` and `set-retries` flag to both commands. Without `--force` the commands will return success but skip any uploading for files that already exist.

The one piece left of these commands that may not be suitable for scripting is the authentication. Its still interactive when you have a token that doesn't work.