### PR TITLE
add rolling upgrade test to kola

### DIFF
--- a/cmd/kola/kola.go
+++ b/cmd/kola/kola.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/coreos/mantle/cli"
 	"github.com/coreos/mantle/kola"
+	"github.com/coreos/mantle/kola/options"
 )
 
 const (
@@ -37,7 +38,14 @@ var cmdRun = &cli.Command{
 	Run:         runRun,
 }
 
-var kolaPlatform = flag.String("platform", "qemu", "VM platform: qemu or gce")
+var (
+	kolaPlatform           = flag.String("platform", "qemu", "VM platform: qemu or gce")
+	EtcdRollingVersion     = flag.String("EtcdRollingVersion", "", "")
+	EtcdRollingVersion2    = flag.String("EtcdRollingVersion2", "", "")
+	EtcdRollingBin         = flag.String("EtcdRollingBin", "", "")
+	EtcdRollingBin2        = flag.String("EtcdRollingBin2", "", "")
+	EtcdRollingSkipVersion = flag.Bool("EtcdRollingSkipVersion", false, "")
+)
 
 func init() {
 	cli.Register(cmdRun)
@@ -48,6 +56,14 @@ func main() {
 }
 
 func runRun(args []string) int {
+	options.Opts = options.TestOptions{
+		EtcdRollingVersion:     *EtcdRollingVersion,
+		EtcdRollingVersion2:    *EtcdRollingVersion2,
+		EtcdRollingBin:         *EtcdRollingBin,
+		EtcdRollingBin2:        *EtcdRollingBin2,
+		EtcdRollingSkipVersion: *EtcdRollingSkipVersion,
+	}
+
 	if len(args) > 1 {
 		fmt.Fprintf(os.Stderr, "Extra arguements specified. Usage: 'kola run [glob pattern]'\n")
 		return 2

--- a/kola/etcdregistry.go
+++ b/kola/etcdregistry.go
@@ -49,4 +49,23 @@ coreos:
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
     listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001`,
 	})
+
+	// Test rolling upgrade of etcd 2.0.10 to 2.1.0-alpha.1.  3 node
+	// cluster, 4th node tests availability during upgrade processs.
+	Register(&Test{
+		Run:         etcd.RollingUpgrade,
+		ClusterSize: 3,
+		Name:        "EtcdRollingUpgrade",
+		CloudConfig: `#cloud-config
+
+coreos:
+  etcd2:
+    name: $name
+    discovery: $discovery
+    advertise-client-urls: http://$public_ipv4:2379
+    initial-advertise-peer-urls: http://$private_ipv4:2380
+    listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
+    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001`,
+	})
+
 }

--- a/kola/options/options.go
+++ b/kola/options/options.go
@@ -1,0 +1,16 @@
+package options
+
+//TODO(pb): get rid of this hack and look into implementing subcommand
+//flags per kola test
+
+// Misc options that kola tests can access without a cyclic
+// dependency. Set in kola main cmd.
+type TestOptions struct {
+	EtcdRollingVersion     string
+	EtcdRollingVersion2    string
+	EtcdRollingBin         string
+	EtcdRollingBin2        string
+	EtcdRollingSkipVersion bool
+}
+
+var Opts TestOptions

--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -16,8 +16,6 @@ package etcd
 
 import (
 	"fmt"
-	"strings"
-	"time"
 
 	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/coreos/pkg/capnslog"
 	"github.com/coreos/mantle/platform"
@@ -70,35 +68,4 @@ func discovery(cluster platform.Cluster, version int) error {
 	}
 
 	return nil
-}
-
-// poll cluster-health until result
-func getClusterHealth(m platform.Machine, csize int) error {
-	const (
-		retries   = 5
-		retryWait = 3 * time.Second
-	)
-	var err error
-	var b []byte
-
-	for i := 0; i < retries; i++ {
-		plog.Info("polling cluster health...")
-		b, err = m.SSH("etcdctl cluster-health")
-		if err != nil {
-			time.Sleep(retryWait)
-			continue
-		}
-
-		// repsonse should include "healthy" for each machine and for cluster
-		if strings.Count(string(b), "healthy") == csize+1 {
-			plog.Debug(string(b))
-			return nil
-		}
-	}
-
-	if err != nil {
-		return fmt.Errorf("health polling failed: %v: %s", err, b)
-	} else {
-		return fmt.Errorf("status unhealthy or incomplete: %s", b)
-	}
 }

--- a/kola/tests/etcd/rolling.go
+++ b/kola/tests/etcd/rolling.go
@@ -1,0 +1,157 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/coreos/pkg/capnslog"
+	"github.com/coreos/mantle/platform"
+)
+
+const (
+	etcdVersion  = "etcd 2.0.12"
+	etcdVersion2 = `{"etcdserver":"2.1.0-alpha.1","etcdcluster":"2.1.0"}`
+	etcdBin      = "./etcd"
+	etcdBin2     = "./etcd2"
+	dropPath     = "/home/core"
+	settingSize  = 20 // number of random keys set and checked per node multiple times
+)
+
+func RollingUpgrade(cluster platform.TestCluster) error {
+	csize := len(cluster.Machines())
+
+	if plog.LevelAt(capnslog.DEBUG) {
+		// get journalctl -f from all machines before starting
+		for _, m := range cluster.Machines() {
+			if err := m.StartJournal(); err != nil {
+				return fmt.Errorf("failed to start journal: %v", err)
+			}
+		}
+	}
+
+	// drop in starting etcd binary
+	plog.Debug("adding files to cluster")
+	if err := cluster.DropFile(etcdBin); err != nil {
+		return err
+	}
+	// TODO(pb): skip this test if binaries aren't available once we
+	// have meaninful way to do so.
+
+	// drop in etcd binary to upgrade to
+	if err := cluster.DropFile(etcdBin2); err != nil {
+		return err
+	}
+
+	// replace existing etcd2 binary with 2.0.12
+	plog.Info("replacing etcd with 2.0.12")
+	etcdPath := filepath.Join(dropPath, filepath.Base(etcdBin))
+	for _, m := range cluster.Machines() {
+		if err := replaceEtcd2Bin(m, etcdPath); err != nil {
+			return err
+		}
+	}
+
+	// start 2.0 cluster
+	plog.Info("starting 2.0 cluster")
+	for _, m := range cluster.Machines() {
+		if err := startEtcd2(m); err != nil {
+			return err
+		}
+	}
+	for _, m := range cluster.Machines() {
+		if err := getClusterHealth(m, csize); err != nil {
+			return err
+		}
+	}
+	for _, m := range cluster.Machines() {
+		if err := checkEtcdVersion(cluster, m, etcdVersion); err != nil {
+			return err
+		}
+	}
+
+	// set some values on all nodes
+	mapSet, err := setKeys(cluster, settingSize)
+	if err != nil {
+		return err
+	}
+
+	// rolling replacement checking cluster health, and
+	// version after each replaced binary. Also test
+	plog.Info("rolling upgrade to 2.1")
+	etcdPath2 := filepath.Join(dropPath, filepath.Base(etcdBin2))
+	for i, m := range cluster.Machines() {
+
+		// check current value set
+		if err := checkKeys(cluster, mapSet); err != nil {
+			return err
+		}
+
+		plog.Infof("stopping instance %v", i)
+		if err := stopEtcd2(m); err != nil {
+			return err
+		}
+		if err := replaceEtcd2Bin(m, etcdPath2); err != nil {
+			return err
+		}
+
+		// set some values while running down a node and update set
+		tempSet, err := setKeys(cluster, settingSize)
+		if err != nil {
+			return err
+		}
+		mapCopy(mapSet, tempSet)
+
+		plog.Infof("starting instance %v with upgraded binary", i)
+		if err := startEtcd2(m); err != nil {
+			return err
+		}
+
+		for _, m := range cluster.Machines() {
+			if err := getClusterHealth(m, csize); err != nil {
+				return err
+			}
+		}
+
+	}
+	// set some more values
+	tempSet, err := setKeys(cluster, settingSize)
+	if err != nil {
+		return err
+	}
+	mapCopy(mapSet, tempSet)
+
+	// final check all values written correctly
+	if err := checkKeys(cluster, mapSet); err != nil {
+		return err
+	}
+
+	// check version is now 2.1
+	for _, m := range cluster.Machines() {
+		if err := checkEtcdVersion(cluster, m, etcdVersion2); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// copies m2 into m1 overwriting any overlapping keys
+func mapCopy(m1, m2 map[string]string) {
+	for k, v := range m2 {
+		m1[k] = v
+	}
+}

--- a/kola/tests/etcd/util.go
+++ b/kola/tests/etcd/util.go
@@ -1,0 +1,210 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/coreos/mantle/platform"
+)
+
+// run etcd on each cluster machine
+func startEtcd2(m platform.Machine) error {
+	etcdStart := "sudo systemctl start etcd2.service"
+	_, err := m.SSH(etcdStart)
+	if err != nil {
+		return fmt.Errorf("start etcd2.service on %v failed: %s", m.IP(), err)
+	}
+	return nil
+}
+
+// stop etcd on each cluster machine
+func stopEtcd2(m platform.Machine) error {
+	// start etcd instance
+	etcdStop := "sudo systemctl stop etcd2.service"
+	_, err := m.SSH(etcdStop)
+	if err != nil {
+		return fmt.Errorf("stop etcd.2service on failed: %s", err)
+	}
+	return nil
+}
+
+// setKeys sets n random keys and values across each machine in a
+// cluster and returns these values to later be checked with checkKeys.
+// If all the values don't get set due to a machine that is down and
+// error is NOT returned. An error is returned if no keys are able to be
+// set.
+func setKeys(cluster platform.Cluster, n int) (map[string]string, error) {
+	var written = map[string]string{}
+	for _, m := range cluster.Machines() {
+		for i := 0; i < n; i++ {
+			// random key and value, may overwrwite previous sets if
+			// collision which is fine
+			key := strconv.Itoa(rand.Int())[0:3]
+			value := strconv.Itoa(rand.Int())[0:3]
+
+			cmd := cluster.NewCommand("curl", "-w", "%{http_code}", "-s", fmt.Sprintf("http://%v:2379/v2/keys/%v", m.IP(), key), "-XPUT", "-d", "value="+value)
+			b, err := cmd.Output()
+			if err != nil {
+				continue
+			}
+
+			// check for 201 or 200 resp header
+			if !bytes.HasSuffix(b, []byte("200")) && !bytes.HasSuffix(b, []byte("201")) {
+				continue
+			}
+
+			written[key] = value
+		}
+	}
+	if len(written) == 0 {
+		return nil, fmt.Errorf("failed to write any keys")
+	}
+
+	plog.Infof("wrote %v keys", len(written))
+	return written, nil
+}
+
+// checkKeys tests that each node in the cluster has the full provided
+// key set in keyMap. Quorum get must be used.
+func checkKeys(cluster platform.Cluster, keyMap map[string]string) error {
+	for i, m := range cluster.Machines() {
+		for k, v := range keyMap {
+			cmd := cluster.NewCommand("curl", fmt.Sprintf("http://%v:2379/v2/keys/%v?quorum=true", m.IP(), k))
+			b, err := cmd.Output()
+			if err != nil {
+				return fmt.Errorf("error curling key: %v", err)
+			}
+
+			var jsonMap map[string]interface{}
+			err = json.Unmarshal(b, &jsonMap)
+			if err != nil {
+				return err
+			}
+
+			// error code?
+			errorCode, ok := jsonMap["errorCode"]
+			if ok {
+				msg := jsonMap["message"]
+				return fmt.Errorf("machine %v errorCode %v: %v: %s", i, errorCode, msg, b)
+			}
+
+			node, ok := jsonMap["node"]
+			if !ok {
+				return fmt.Errorf("retrieving key in CheckKeys, no node in resp")
+			}
+
+			n := node.(map[string]interface{})
+			value, ok := n["value"]
+			if !ok {
+				return fmt.Errorf("retrieving key in CheckKeys, no value in resp")
+			}
+
+			if value != v {
+				return fmt.Errorf("checkKeys got incorrect value! expected:%v got: %v", v, value)
+			}
+		}
+	}
+	plog.Infof("checked %v keys", len(keyMap))
+	return nil
+}
+
+// replace default binary for etcd2.service with given binary
+func replaceEtcd2Bin(m platform.Machine, newPath string) error {
+	if !filepath.IsAbs(newPath) {
+		return fmt.Errorf("newPath must be an absolute filepath")
+	}
+
+	override := "\"[Service]\nExecStart=\nExecStart=" + newPath
+	override += "\nEnvironment=ETCD_SNAPSHOT_COUNT=10" + "\"" // make it easy to trigger snapshots
+
+	_, err := m.SSH(fmt.Sprintf("echo %v | sudo tee /run/systemd/system/etcd2.service.d/99-exec.conf", override))
+	if err != nil {
+		return err
+	}
+	_, err = m.SSH("sudo systemctl daemon-reload")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func checkEtcdVersion(cluster platform.Cluster, m platform.Machine, expected string) error {
+	const (
+		retries   = 5
+		retryWait = 3 * time.Second
+	)
+	var err error
+	var b []byte
+
+	for i := 0; i < retries; i++ {
+		cmd := cluster.NewCommand("curl", "-L", fmt.Sprintf("http://%v:2379/version", m.IP()))
+		b, err = cmd.Output()
+		if err != nil {
+			plog.Infof("retrying version check, hit failure %v", err)
+			time.Sleep(retryWait)
+			continue
+		}
+		break
+	}
+	if err != nil {
+		return fmt.Errorf("curling version: %v", err)
+	}
+
+	plog.Infof("got version: %s", b)
+
+	if string(b) != expected {
+		return fmt.Errorf("expected %v, got %s", expected, b)
+	}
+	return nil
+}
+
+// poll cluster-health until result
+func getClusterHealth(m platform.Machine, csize int) error {
+	const (
+		retries   = 5
+		retryWait = 3 * time.Second
+	)
+	var err error
+	var b []byte
+
+	for i := 0; i < retries; i++ {
+		b, err = m.SSH("etcdctl cluster-health")
+		if err != nil {
+			plog.Debugf("retrying health check, hit failure %v", err)
+			time.Sleep(retryWait)
+			continue
+		}
+
+		// repsonse should include "healthy" for each machine and for cluster
+		if strings.Count(string(b), "healthy") == csize+1 {
+			plog.Infof("cluster healthy")
+			return nil
+		}
+	}
+
+	if err != nil {
+		return fmt.Errorf("health polling failed: %v: %s", err, b)
+	} else {
+		return fmt.Errorf("status unhealthy or incomplete: %s", b)
+	}
+}


### PR DESCRIPTION
/cc @marineam @yichengq 

The test works by starting a 2.0.12 etcd cluster. Then a rolling upgrade is started by bringing down and replacing the binary of one node at a time. During this , random writes are being made and checked to try and ensure the cluster remains available the entire time. The specific versions are configurable, but right now it tests 2.0.12 -> 2.1.0-alpha.1 using precompiled binaries. As far as this test can tell, the reliable works and the final cluster version is updated.

@marineam I added a bit of a hack to get some flags into the rolling upgrade test itself.