### PR TITLE
platform: set format=raw for disk fds passed to qemu

### DIFF
--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -137,7 +137,7 @@ func (qc *qemuCluster) NewMachine(cfg string) (Machine, error) {
 		"-uuid", qm.id,
 		"-display", "none",
 		"-add-fd", "fd=3,set=1",
-		"-drive", "file=/dev/fdset/1,media=disk,if=virtio",
+		"-drive", "file=/dev/fdset/1,media=disk,if=virtio,format=raw",
 		"-netdev", "tap,id=tap,fd=4",
 		"-device", "virtio-net,netdev=tap,mac="+qmMac,
 		"-fsdev", "local,id=cfg,security_model=none,readonly,path="+qmCfg,


### PR DESCRIPTION
gets rid of an annoying message:

WARNING: Image format was not specified for '/dev/fdset/1' and probing guessed raw.
         Automatically detecting the format is dangerous for raw images, write operations on block 0 will be restricted.
         Specify the 'raw' format explicitly to remove the restrictions.