### PR TITLE
kola/tests/coretest: etcd cluster-health now writes to stderr

### DIFF
--- a/kola/tests/coretest/etcd.go
+++ b/kola/tests/coretest/etcd.go
@@ -100,7 +100,7 @@ func getClusterHealth(csize int) error {
 	}
 
 	// repsonse should include "healthy" for each machine and for cluster
-	if strings.Count(stdout, "healthy") == csize+1 {
+	if strings.Count(stderr, "healthy") == csize+1 {
 		return nil
 	} else {
 		return fmt.Errorf("status unhealthy or incomplete: stdout: %s\nstderr: %s", err, stdout, stderr)


### PR DESCRIPTION
fixes:
2015-09-01T21:57:23Z kola/tests/coretest: running EtcdUpdateValue...
2015-09-01T21:57:26Z kola: --- FAIL: coretestsCluster on aws (286.267s)
2015-09-01T21:57:26Z kola:         kolet: on native test EtcdUpdateValue: status unhealthy or incomplete: stdout: %!s(<nil>)
stderr: member 50b86a96d459d7ba is healthy: got healthy result from http://172.31.0.225:2379
member 863ba4b74514ea78 is healthy: got healthy result from http://172.31.5.24:2379
member f0b790eb87110478 is healthy: got healthy result from http://172.31.6.199:2379
cluster is healthy