### PR TITLE
adjust etcd health checks

### DIFF
--- a/kola/tests/coretest/etcd.go
+++ b/kola/tests/coretest/etcd.go
@@ -81,8 +81,8 @@ func TestEtcdUpdateValue() error {
 // poll cluster-health until result
 func getClusterHealth(csize int) error {
 	const (
-		retries   = 5
-		retryWait = 3 * time.Second
+		retries   = 15
+		retryWait = 10 * time.Second
 	)
 	var err error
 	var stdout, stderr string

--- a/kola/tests/coretest/etcd.go
+++ b/kola/tests/coretest/etcd.go
@@ -100,9 +100,9 @@ func getClusterHealth(csize int) error {
 	}
 
 	// repsonse should include "healthy" for each machine and for cluster
-	if strings.Count(stderr, "healthy") == csize+1 {
+	if strings.Count(stdout, "healthy") == (csize*2)+1 {
 		return nil
 	} else {
-		return fmt.Errorf("status unhealthy or incomplete: stdout: %s\nstderr: %s", err, stdout, stderr)
+		return fmt.Errorf("status unhealthy or incomplete: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
 	}
 }

--- a/kola/tests/etcd/util.go
+++ b/kola/tests/etcd/util.go
@@ -196,7 +196,7 @@ func getClusterHealth(m platform.Machine, csize int) error {
 		}
 
 		// repsonse should include "healthy" for each machine and for cluster
-		if strings.Count(string(b), "healthy") == csize+1 {
+		if strings.Count(string(b), "healthy") == (csize*2)+1 {
 			plog.Infof("cluster healthy")
 			return nil
 		}

--- a/kola/tests/etcd/util.go
+++ b/kola/tests/etcd/util.go
@@ -150,8 +150,8 @@ func replaceEtcd2Bin(m platform.Machine, newPath string) error {
 
 func checkEtcdVersion(cluster platform.Cluster, m platform.Machine, expected string) error {
 	const (
-		retries   = 5
-		retryWait = 3 * time.Second
+		retries   = 15
+		retryWait = 10 * time.Second
 	)
 	var err error
 	var b []byte
@@ -181,8 +181,8 @@ func checkEtcdVersion(cluster platform.Cluster, m platform.Machine, expected str
 // poll cluster-health until result
 func getClusterHealth(m platform.Machine, csize int) error {
 	const (
-		retries   = 5
-		retryWait = 3 * time.Second
+		retries   = 15
+		retryWait = 10 * time.Second
 	)
 	var err error
 	var b []byte


### PR DESCRIPTION
etcdctl output format has changed recently to include two instances of 'healthy' per member.

etcd also takes a bit more time to come up on aws, so raise the retry count and sleep interval.