### PR TITLE
Downloadimage

### DIFF
--- a/cmd/cork/downloadimage.go
+++ b/cmd/cork/downloadimage.go
@@ -1,0 +1,116 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/spf13/cobra"
+	"github.com/coreos/mantle/sdk"
+)
+
+var (
+	downloadImageCmd = &cobra.Command{
+		Use:   "download-image",
+		Short: "Download and verify CoreOS images",
+		Long:  "Download and verify current CoreOS images to a local cache.",
+		Run:   runDownloadImage,
+	}
+	downloadImageRoot         string
+	downloadImageCacheDir     string
+	downloadImagePrefix       string
+	downloadImageVerify       bool
+	downloadImagePlatformList platformList
+)
+
+func init() {
+	downloadImageCmd.Flags().StringVar(&downloadImageRoot,
+		"root", "http://storage.core-os.net/coreos/amd64-usr/master/", "base URL of images")
+	downloadImageCmd.Flags().StringVar(&downloadImageCacheDir,
+		"cache-dir", "", "local dir for image cache")
+	downloadImageCmd.Flags().StringVar(&downloadImagePrefix,
+		"image-prefix", "coreos_production", "image filename prefix")
+	downloadImageCmd.Flags().BoolVar(&downloadImageVerify,
+		"verify", true, "verify")
+	downloadImageCmd.Flags().Var(&downloadImagePlatformList,
+		"platform", "Choose qemu, gce, or aws. Multiple platforms can be specified by repeating the flag")
+
+	root.AddCommand(downloadImageCmd)
+}
+
+type platformList []string // satisfies pflag.Value interface
+
+func (platforms *platformList) String() string {
+	return fmt.Sprintf("%v", *platforms)
+}
+
+// not sure what this is for, but won't compile without it
+func (platforms *platformList) Type() string {
+	return "platformList"
+}
+
+// Set will append additional platform for each flag set. Comma
+// separated flags without spaces will also be parsed correctly.
+func (platforms *platformList) Set(value string) error {
+
+	// maps names of platforms to filename prefix
+	platformMap := map[string]string{
+		"qemu": "_image.bin.bz2",
+		"gce":  "_gce.tar.gz",
+		"aws":  "_ami_image.bin.bz2",
+	}
+
+	values := strings.Split(value, ",")
+
+	for _, platform := range values {
+		prefix, ok := platformMap[platform]
+		if !ok {
+			plog.Fatalf("platform not supported: %v", platform)
+		}
+		*platforms = append(*platforms, prefix)
+	}
+	return nil
+}
+
+func runDownloadImage(cmd *cobra.Command, args []string) {
+	if len(args) != 0 {
+		plog.Fatalf("Unrecognized arguements: %v", args)
+	}
+
+	if downloadImageCacheDir == "" {
+		plog.Fatal("Missing --cache-dir=FILEPATH")
+	}
+	if len(downloadImagePlatformList) == 0 {
+		plog.Fatal("Must specify 1 or more platforms to download")
+	}
+	if downloadImageVerify == false {
+		plog.Notice("Warning: image verification turned off")
+	}
+
+	// download signed digest
+	for _, suffix := range downloadImagePlatformList {
+		file := downloadImagePrefix + suffix
+		url := downloadImageRoot + file
+
+		if downloadImageVerify {
+			plog.Noticef("Verifying and updating to latest image %v", file)
+			sdk.DownloadSignedFile(file, url)
+		} else {
+			plog.Noticef("Forcing non-verified download of image %v", file)
+			sdk.DownloadFile(file, downloadImageRoot)
+		}
+	}
+}

--- a/sdk/download.go
+++ b/sdk/download.go
@@ -15,8 +15,11 @@
 package sdk
 
 import (
+	"bytes"
+	"crypto/sha512"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -150,4 +153,97 @@ func DownloadSDK(version string) error {
 	tarFile := filepath.Join(RepoCache(), "sdk", TarballName(version))
 	tarURL := TarballURL(version)
 	return DownloadSignedFile(tarFile, tarURL)
+}
+
+func fileSum(file string) ([]byte, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	hash := sha512.New()
+	if _, err := io.Copy(hash, f); err != nil {
+		return nil, err
+	}
+
+	return hash.Sum(nil), nil
+}
+
+func compareFileBytes(fileName1, fileName2 string) (bool, error) {
+	sum1, err := fileSum(fileName1)
+	if err != nil {
+		return false, err
+	}
+	sum2, err := fileSum(fileName2)
+	if err != nil {
+		return false, err
+	}
+	return bytes.Equal(sum1, sum2), nil
+}
+
+// UpdateFile downloads a file to temp dir and replaces the file only if
+// contents have changed. If tempDir is "" default will be os.TempDir().
+func UpdateFile(file, url string) error {
+	t, err := ioutil.TempFile(filepath.Dir(file), "sdkUpdateCheck")
+	if err != nil {
+		return nil
+	}
+	t.Close()
+	tempFile := t.Name()
+	defer os.Remove(tempFile)
+
+	// NOTE: It'd be nice to have a Download(dst io.Writer, url) error
+	// function so you can just io.Multiwriter() the hasher and file
+	// before passing it to Download().
+	if err := DownloadFile(tempFile, url); err != nil {
+		return err
+	}
+
+	equal, err := compareFileBytes(file, tempFile)
+	if os.IsExist(err) { // file may not exist, that is ok
+		return err
+	}
+	if equal {
+		plog.Infof("%v is up to date", file)
+		return nil
+	}
+
+	// not equal so delete any existing file and rename tempFile to file
+	if err := os.MkdirAll(filepath.Dir(file), 0777); err != nil {
+		return err
+	}
+	if err := os.Rename(tempFile, file); err != nil {
+		return err
+	}
+	return nil
+}
+
+// UpdateSignedFile will download and replace the local file if the
+// published signature doesn't match the local copy
+func UpdateSignedFile(file, url string) error {
+	sigFile := file + ".sig"
+	sigURL := url + ".sig"
+
+	// update local sig to latest
+	if err := UpdateFile(sigFile, sigURL); err != nil {
+		return err
+	}
+
+	// try to verify with latest sig
+	if e := VerifyFile(file); e == nil {
+		plog.Infof("Verified existing file: %s", file)
+		return nil
+	}
+
+	// download image and try to verify again
+	if err := UpdateFile(file, url); err != nil {
+		return err
+	}
+	if err := VerifyFile(file); err != nil {
+		return err
+	}
+
+	plog.Infof("Verified file: %s", file)
+	return nil
 }


### PR DESCRIPTION
Adds a download image command to cork. This is intended to replace curling the image down each time kola runs. Now the image is verified and only updated if its different form the local copy.