### PR TITLE
kola/tests/misc: use private ip in nfs tests

### DIFF
--- a/kola/tests/misc/nfs.go
+++ b/kola/tests/misc/nfs.go
@@ -94,7 +94,7 @@ func testNFS(c platform.TestCluster, nfsversion int) error {
 				config.Unit{
 					Name:    "mnt.mount",
 					Command: "start",
-					Content: fmt.Sprintf(mounttmpl, m1.IP(), nfsversion),
+					Content: fmt.Sprintf(mounttmpl, m1.PrivateIP(), nfsversion),
 				},
 			},
 		},


### PR DESCRIPTION
this will hopefully make the nfs tests pass on aws, where the security group disallows nfs connections to the public ip.