### PR TITLE
kola: re-enable fleet tests ported from coretest

### DIFF
--- a/kola/coretest.go
+++ b/kola/coretest.go
@@ -38,10 +38,9 @@ func init() {
 		Run:         coretest.ClusterTests,
 		ClusterSize: 3,
 		NativeFuncs: map[string]func() error{
-			"EtcdUpdateValue": coretest.TestEtcdUpdateValue,
-			// until stability improves comment out fleet tests
-			//"FleetctlListMachines": coretest.TestFleetctlListMachines,
-			//"FleetctlRunService":   coretest.TestFleetctlRunService,
+			"EtcdUpdateValue":      coretest.TestEtcdUpdateValue,
+			"FleetctlListMachines": coretest.TestFleetctlListMachines,
+			"FleetctlRunService":   coretest.TestFleetctlRunService,
 		},
 		CloudConfig: `#cloud-config
 


### PR DESCRIPTION
fixes #6 