### PR TITLE
kola: increase fleet etcd request timeout

### DIFF
--- a/kola/coretest.go
+++ b/kola/coretest.go
@@ -53,6 +53,8 @@ coreos:
     initial-advertise-peer-urls: http://$private_ipv4:2380
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
     listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+  fleet:
+    etcd-request-timeout: 5.0
   units:
     - name: etcd2.service
       command: start


### PR DESCRIPTION
this should help the tests pass on a system with slow io.