### PR TITLE
Add support for generating update payloads

### DIFF
--- a/build
+++ b/build
@@ -14,7 +14,10 @@ export GOPATH=${PWD}/gopath
 
 eval $(go env)
 
-for cmd in "$(dirname "$0")"/cmd/*; do
+if [[ $# -eq 0 ]]; then
+    set -- "$(dirname "$0")"/cmd/*
+fi
+for cmd in "$@"; do
     cmd=$(basename "${cmd}")
     echo "Building ${cmd}..."
     go build -o "bin/${cmd}" "${REPO_PATH}/cmd/${cmd}"

--- a/cmd/cork/build.go
+++ b/cmd/cork/build.go
@@ -1,0 +1,48 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/spf13/cobra"
+	"github.com/coreos/mantle/sdk/omaha"
+)
+
+var (
+	buildCmd = &cobra.Command{
+		Use:   "build [object]",
+		Short: "Build something",
+	}
+	buildUpdateCmd = &cobra.Command{
+		Use:   "update",
+		Short: "Build a dev image update payload",
+		Run:   runBuildUpdate,
+	}
+)
+
+func init() {
+	buildCmd.AddCommand(buildUpdateCmd)
+	root.AddCommand(buildCmd)
+}
+
+func runBuildUpdate(cmd *cobra.Command, args []string) {
+	if len(args) != 0 {
+		plog.Fatalf("Unrecognized arguments: %v", args)
+	}
+
+	err := omaha.GenerateFullUpdate("latest")
+	if err != nil {
+		plog.Fatalf("Building full update failed: %v", err)
+	}
+}

--- a/network/omaha/update.go
+++ b/network/omaha/update.go
@@ -1,0 +1,50 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package omaha
+
+import (
+	"encoding/xml"
+)
+
+// Update is a manifest for a single omaha update response. It extends
+// the standard Manifest protocol element with the application id and
+// previous version which are used to match against the update request.
+// A blank previous version indicates this update can be applied to any
+// existing install. The application id may not be blank.
+type Update struct {
+	XMLName         xml.Name `xml:"update" json:"-"`
+	Id              string   `xml:"appid,attr"`
+	PreviousVersion string   `xml:"previousversion,attr,omitempty"`
+	URL             URL      `xml:"urls>url"`
+	Manifest
+
+	// The delta_okay request attribute is an update_engine extension.
+	RespectDeltaOK bool `xml:"respect_delta_okay,attr,omitempty"`
+}
+
+// The URL attribute in Update is currently assumed to be a relative
+// path which may be found on multiple mirrors. A server using this is
+// expected to know the mirror prefix(s) it can give the client.
+func (u *Update) URLs(prefixes []string) []*URL {
+	urls := make([]*URL, len(prefixes))
+	for i, prefix := range prefixes {
+		urls[i] = &URL{CodeBase: prefix + u.URL.CodeBase}
+	}
+	return urls
+}
+
+type Updater interface {
+	Update(os *OS, app *AppRequest) (*Update, error)
+}

--- a/network/omaha/update_test.go
+++ b/network/omaha/update_test.go
@@ -1,0 +1,42 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package omaha
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+const SampleUpdate = `<?xml version="1.0" encoding="UTF-8"?>
+<update appid="{87efface-864d-49a5-9bb3-4b050a7c227a}" version="9999.0.0">
+ <urls>
+  <url codebase="packages/9999.0.0"></url>
+ </urls>
+ <manifest version="9999.0.0">
+  <packages>
+   <package name="update.gz" hash="+LXvjiaPkeYDLHoNKlf9qbJwvnk=" size="67546213" required="true"></package>
+  </packages>
+</update>
+`
+
+func TestUpdateURLs(t *testing.T) {
+	u := Update{}
+	xml.Unmarshal([]byte(SampleUpdate), &u)
+
+	urls := u.URLs([]string{"http://localhost/updates/"})
+	if urls[0].CodeBase != "http://localhost/updates/packages/9999.0.0" {
+		t.Error("Unexpected URL", urls[0].CodeBase)
+	}
+}

--- a/sdk/omaha/generate.go
+++ b/sdk/omaha/generate.go
@@ -1,0 +1,121 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package omaha
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/coreos/pkg/capnslog"
+	"github.com/coreos/mantle/network/omaha"
+	"github.com/coreos/mantle/sdk"
+)
+
+const (
+	privateKey = "/usr/share/update_engine/update-payload-key.key.pem"
+	publicKey  = "/usr/share/update_engine/update-payload-key.pub.pem"
+)
+
+var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "sdk/omaha")
+
+func run(name string, arg ...string) error {
+	cmd := exec.Command(name, arg...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func xmlMarshalFile(path string, v interface{}) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(xml.Header); err != nil {
+		return err
+	}
+
+	enc := xml.NewEncoder(f)
+	enc.Indent("", "  ")
+	return enc.Encode(v)
+}
+
+func xmlUnmarshalFile(path string, v interface{}) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return xml.NewDecoder(f).Decode(v)
+}
+
+func checkUpdate(dir, update_xml string) error {
+	u := omaha.Update{}
+	if err := xmlUnmarshalFile(update_xml, &u); err != nil {
+		return err
+	}
+
+	if len(u.Packages) != 1 {
+		return fmt.Errorf("%s contains %s packages, expected 1",
+			update_xml, len(u.Packages))
+	}
+
+	pkgdir := filepath.Join(dir, u.URL.CodeBase)
+	return u.Packages[0].Verify(pkgdir)
+}
+
+func GenerateFullUpdate(version string) error {
+	// TODO: support prod images too, for now just match dev_server.
+	var (
+		dir           = sdk.BuildImageDir(version)
+		update_prefix = filepath.Join(dir, "coreos_developer_update")
+		update_bin    = update_prefix + ".bin"
+		update_gz     = update_prefix + ".gz"
+		update_xml    = update_prefix + ".xml"
+	)
+
+	if err := checkUpdate(dir, update_xml); err == nil {
+		plog.Infof("Using update manifest: %s", update_xml)
+		return nil
+	}
+
+	plog.Noticef("Generating update payload: %s", update_gz)
+	if err := run("delta_generator",
+		"-new_image", update_bin,
+		"-out_file", update_gz,
+		"-private_key", privateKey); err != nil {
+		return err
+	}
+
+	plog.Infof("Writing update manifest: %s", update_xml)
+	update := omaha.Update{Id: sdk.GetDefaultAppId()}
+	pkg, err := update.AddPackageFromPath(update_gz)
+
+	// update engine needs the payload hash here in the action element
+	postinstall := update.AddAction("postinstall")
+	postinstall.Sha256 = pkg.Sha256
+
+	update.Version, err = sdk.GetVersion(dir)
+	if err != nil {
+		return err
+	}
+
+	return xmlMarshalFile(update_xml, &update)
+}


### PR DESCRIPTION
This will be useful in the future for a dev server replacement and automated update testing.