### PR TITLE
refactor ssh

### DIFF
--- a/cmd/kola/bootchart.go
+++ b/cmd/kola/bootchart.go
@@ -74,16 +74,11 @@ func runBootchart(cmd *cobra.Command, args []string) {
 	}
 	defer m.Destroy()
 
-	ssh, err := m.SSHSession()
+	out, err := m.SSH("systemd-analyze plot")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "SSH failed: %v\n", err)
 		os.Exit(1)
 	}
 
-	ssh.Stdout = os.Stdout
-	ssh.Stderr = os.Stderr
-	if err = ssh.Run("systemd-analyze plot"); err != nil {
-		fmt.Fprintf(os.Stderr, "SSH failed: %v\n", err)
-		os.Exit(1)
-	}
+	fmt.Printf("%s", out)
 }

--- a/cmd/kola/qemu.go
+++ b/cmd/kola/qemu.go
@@ -67,26 +67,6 @@ func runQemu(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stdout, "SSH: %s\n", out)
 	}
 
-	ssh := cluster.NewCommand("ssh",
-		"-l", "core",
-		"-o", "StrictHostKeyChecking=no",
-		"-o", "UserKnownHostsFile=/dev/null",
-		"-o", "BatchMode=yes",
-		m.IP(),
-		"uptime")
-
-	out, err = ssh.Output()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "SSH command failed: %v\n", err)
-		os.Exit(1)
-	}
-	if len(out) != 0 {
-		fmt.Fprintf(os.Stdout, "SSH command: %s\n", out)
-	} else {
-		fmt.Fprintf(os.Stderr, "SSH command produced no output.\n")
-		os.Exit(1)
-	}
-
 	err = m.Destroy()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Destroy failed: %v\n", err)

--- a/kola/tests/coretest/testgroupglue.go
+++ b/kola/tests/coretest/testgroupglue.go
@@ -30,7 +30,7 @@ func ClusterTests(c platform.TestCluster) error {
 	if plog.LevelAt(capnslog.DEBUG) {
 		// get journalctl -f from all machines before starting
 		for _, m := range c.Machines() {
-			if err := m.StartJournal(); err != nil {
+			if err := platform.StreamJournal(m); err != nil {
 				return fmt.Errorf("failed to start journal: %v", err)
 			}
 		}

--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -60,7 +60,7 @@ func discovery(cluster platform.Cluster, version int) error {
 	if plog.LevelAt(capnslog.DEBUG) {
 		// get journalctl -f from all machines before starting
 		for _, m := range cluster.Machines() {
-			if err := m.StartJournal(); err != nil {
+			if err := platform.StreamJournal(m); err != nil {
 				return fmt.Errorf("failed to start journal: %v", err)
 			}
 		}

--- a/kola/tests/etcd/rolling.go
+++ b/kola/tests/etcd/rolling.go
@@ -40,7 +40,7 @@ func RollingUpgrade(cluster platform.TestCluster) error {
 	if plog.LevelAt(capnslog.DEBUG) {
 		// get journalctl -f from all machines before starting
 		for _, m := range cluster.Machines() {
-			if err := m.StartJournal(); err != nil {
+			if err := platform.StreamJournal(m); err != nil {
 				return fmt.Errorf("failed to start journal: %v", err)
 			}
 		}

--- a/platform/aws.go
+++ b/platform/aws.go
@@ -37,9 +37,8 @@ import (
 )
 
 type awsMachine struct {
-	cluster   *awsCluster
-	mach      *ec2.Instance
-	sshClient *ssh.Client
+	cluster *awsCluster
+	mach    *ec2.Instance
 }
 
 func (am *awsMachine) ID() string {
@@ -54,20 +53,28 @@ func (am *awsMachine) PrivateIP() string {
 	return *am.mach.PrivateIpAddress
 }
 
-func (am *awsMachine) SSHSession() (*ssh.Session, error) {
-	session, err := am.sshClient.NewSession()
+func (am *awsMachine) SSHClient() (*ssh.Client, error) {
+	sshClient, err := am.cluster.agent.NewClient(am.IP())
 	if err != nil {
 		return nil, err
 	}
 
-	return session, nil
+	return sshClient, nil
 }
 
 func (am *awsMachine) SSH(cmd string) ([]byte, error) {
-	session, err := am.SSHSession()
+	client, err := am.SSHClient()
 	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
+
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		return nil, err
+	}
+
 	defer session.Close()
 
 	session.Stderr = os.Stderr
@@ -77,10 +84,6 @@ func (am *awsMachine) SSH(cmd string) ([]byte, error) {
 }
 
 func (am *awsMachine) Destroy() error {
-	if am.sshClient != nil {
-		am.sshClient.Close()
-	}
-
 	id := am.ID()
 
 	input := &ec2.TerminateInstancesInput{
@@ -95,28 +98,13 @@ func (am *awsMachine) Destroy() error {
 	return nil
 }
 
-func (am *awsMachine) StartJournal() error {
-	s, err := am.SSHSession()
-	if err != nil {
-		return fmt.Errorf("SSH session failed: %v", err)
-	}
-
-	s.Stdout = os.Stdout
-	s.Stderr = os.Stderr
-	go func() {
-		s.Run("journalctl -f")
-		s.Close()
-	}()
-
-	return nil
-}
-
 type AWSOptions struct {
 	AMI           string
 	KeyName       string
 	InstanceType  string
 	SecurityGroup string
 }
+
 type awsCluster struct {
 	mu    sync.Mutex
 	api   *ec2.EC2
@@ -213,18 +201,8 @@ func (ac *awsCluster) NewMachine(userdata string) (Machine, error) {
 		mach:    insts.Reservations[0].Instances[0],
 	}
 
-	// Allow a few authentication failures in case setup is slow.
-	sshchecker := func() error {
-		mach.sshClient, err = mach.cluster.agent.NewClient(mach.IP())
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-
-	if err := util.Retry(sshRetries, sshTimeout, sshchecker); err != nil {
-		mach.Destroy()
-		return nil, err
+	if err := commonMachineChecks(mach); err != nil {
+		return nil, fmt.Errorf("machine %q failed basic checks: %v", mach.ID(), err)
 	}
 
 	ac.addMach(mach)

--- a/platform/gce.go
+++ b/platform/gce.go
@@ -477,28 +477,3 @@ func instanceIPs(inst *compute.Instance) (intIP, extIP string) {
 	}
 	return
 }
-
-func sshCheck(gm *gceMachine) error {
-	var err error
-
-	// Allow a few authentication failures in case setup is slow.
-	sshchecker := func() error {
-		return nil
-	}
-
-	if err := util.Retry(sshRetries, sshTimeout, sshchecker); err != nil {
-		return err
-	}
-
-	// sanity check
-	out, err := gm.SSH("grep ^ID= /etc/os-release")
-	if err != nil {
-		return err
-	}
-
-	if !bytes.Equal(out, []byte("ID=coreos")) {
-		return fmt.Errorf("Unexpected SSH output: %s", out)
-	}
-
-	return nil
-}


### PR DESCRIPTION
sort of a heavy-handed approach, but now we establish a new ssh connection for each command executed. this makes it possible to deal with reboots during a test.

added a bit of documentation to Machine and Cluster, and deduplicated the common machine sanity check code.

removed NewCommand from Cluster. not really needed.