### PR TITLE
cork: create and enter SDK

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/coreos/pkg/capnslog"
 	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/spf13/cobra"
+
+	"github.com/coreos/mantle/system/exec"
 	"github.com/coreos/mantle/version"
 )
 
@@ -42,6 +44,10 @@ var (
 // Execute sets up common features that all mantle commands should share
 // and then executes the command. It does not return.
 func Execute(main *cobra.Command) {
+	// If we were invoked via a multicall entrypoint run it instead.
+	// TODO(marineam): should we figure out a way to initialize logging?
+	exec.MaybeExec()
+
 	main.AddCommand(versionCmd)
 
 	// TODO(marineam): pflags defines the Value interface differently,

--- a/cmd/cork/create.go
+++ b/cmd/cork/create.go
@@ -33,6 +33,11 @@ var (
 		Short: "Download and unpack the SDK",
 		Run:   runCreate,
 	}
+	enterCmd = &cobra.Command{
+		Use:   "enter [-- command]",
+		Short: "Enter the SDK chroot, optionally running a command",
+		Run:   runEnter,
+	}
 	deleteCmd = &cobra.Command{
 		Use:   "delete",
 		Short: "Delete the SDK chroot",
@@ -49,9 +54,12 @@ func init() {
 		"manifest-url", coreosManifestURL, "Manifest git repo location")
 	createCmd.Flags().BoolVar(&allowReplace,
 		"replace", false, "Replace an existing SDK chroot")
+	enterCmd.Flags().StringVar(&chrootName,
+		"chroot", "chroot", "SDK chroot directory name")
 	deleteCmd.Flags().StringVar(&chrootName,
 		"chroot", "chroot", "SDK chroot directory name")
 	root.AddCommand(createCmd)
+	root.AddCommand(enterCmd)
 	root.AddCommand(deleteCmd)
 }
 
@@ -85,6 +93,12 @@ func runCreate(cmd *cobra.Command, args []string) {
 
 	if err := sdk.RepoInit(chrootName, manifestURL); err != nil {
 		plog.Fatalf("repo init and sync failed: %v", err)
+	}
+}
+
+func runEnter(cmd *cobra.Command, args []string) {
+	if err := sdk.Enter(chrootName, args...); err != nil && len(args) != 0 {
+		plog.Fatalf("Running %v failed: %v", args, err)
 	}
 }
 

--- a/platform/aws.go
+++ b/platform/aws.go
@@ -31,7 +31,7 @@ import (
 	"github.com/coreos/mantle/Godeps/_workspace/src/golang.org/x/crypto/ssh"
 
 	"github.com/coreos/mantle/network"
-	"github.com/coreos/mantle/util"
+	"github.com/coreos/mantle/system/exec"
 )
 
 type awsMachine struct {
@@ -141,8 +141,8 @@ func (ac *awsCluster) delMach(m *awsMachine) {
 	delete(ac.machs, *m.mach.InstanceId)
 }
 
-func (ac *awsCluster) NewCommand(name string, arg ...string) util.Cmd {
-	return util.NewCommand(name, arg...)
+func (ac *awsCluster) NewCommand(name string, arg ...string) exec.Cmd {
+	return exec.Command(name, arg...)
 }
 
 func (ac *awsCluster) NewMachine(userdata string) (Machine, error) {

--- a/platform/local/cluster.go
+++ b/platform/local/cluster.go
@@ -26,7 +26,7 @@ import (
 	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/vishvananda/netns"
 	"github.com/coreos/mantle/network"
 	"github.com/coreos/mantle/network/ntp"
-	"github.com/coreos/mantle/util"
+	"github.com/coreos/mantle/system/exec"
 )
 
 type LocalCluster struct {
@@ -85,7 +85,7 @@ func NewLocalCluster() (*LocalCluster, error) {
 	return lc, nil
 }
 
-func (lc *LocalCluster) NewCommand(name string, arg ...string) util.Cmd {
+func (lc *LocalCluster) NewCommand(name string, arg ...string) exec.Cmd {
 	cmd := NewNsCommand(lc.nshandle, name, arg...)
 	sshEnv := fmt.Sprintf("SSH_AUTH_SOCK=%s", lc.SSHAgent.Socket)
 	cmd.Env = append(cmd.Env, sshEnv)

--- a/platform/local/dnsmasq.go
+++ b/platform/local/dnsmasq.go
@@ -17,11 +17,11 @@ package local
 import (
 	"fmt"
 	"net"
-	"os/exec"
 	"text/template"
 
 	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/coreos/pkg/capnslog"
 	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/vishvananda/netlink"
+	"github.com/coreos/mantle/system/exec"
 	"github.com/coreos/mantle/util"
 )
 
@@ -41,7 +41,7 @@ type Segment struct {
 
 type Dnsmasq struct {
 	Segments []*Segment
-	dnsmasq  *exec.Cmd
+	dnsmasq  *exec.ExecCmd
 }
 
 var configTemplate = template.Must(template.New("dnsmasq").Parse(`
@@ -201,7 +201,5 @@ func (dm *Dnsmasq) GetInterface(bridge string) (in *Interface) {
 }
 
 func (dm *Dnsmasq) Destroy() error {
-	dm.dnsmasq.Process.Kill()
-	dm.dnsmasq.Wait()
-	return nil
+	return dm.dnsmasq.Kill()
 }

--- a/platform/local/nsexec.go
+++ b/platform/local/nsexec.go
@@ -15,20 +15,19 @@
 package local
 
 import (
-	"os/exec"
-
 	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/vishvananda/netns"
-	"github.com/coreos/mantle/util"
+
+	"github.com/coreos/mantle/system/exec"
 )
 
 type NsCmd struct {
-	util.ExecCmd
+	*exec.ExecCmd
 	NsHandle netns.NsHandle
 }
 
 func NewNsCommand(ns netns.NsHandle, name string, arg ...string) *NsCmd {
 	return &NsCmd{
-		ExecCmd:  util.ExecCmd{exec.Command(name, arg...)},
+		ExecCmd:  exec.Command(name, arg...),
 		NsHandle: ns,
 	}
 }

--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -18,14 +18,14 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"strings"
 	"sync"
 
 	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/satori/go.uuid"
 	"github.com/coreos/mantle/Godeps/_workspace/src/golang.org/x/crypto/ssh"
+
 	"github.com/coreos/mantle/platform/local"
-	"github.com/coreos/mantle/util"
+	"github.com/coreos/mantle/system/exec"
 )
 
 type QEMUOptions struct {
@@ -42,7 +42,7 @@ type qemuCluster struct {
 type qemuMachine struct {
 	qc          *qemuCluster
 	id          string
-	qemu        util.Cmd
+	qemu        exec.Cmd
 	configDrive *local.ConfigDrive
 	netif       *local.Interface
 }

--- a/sdk/enter.go
+++ b/sdk/enter.go
@@ -15,37 +15,73 @@
 package sdk
 
 import (
-	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
-	"text/template"
+	"syscall"
 
 	"github.com/coreos/mantle/system"
+	"github.com/coreos/mantle/system/exec"
 	"github.com/coreos/mantle/system/user"
 )
 
-const (
-	// This command is the absolute bare minimum to enter the SDK
-	// and run repo. It *must* be run in a new mount namespace.
-	repoScript = "mkdir -p {{.Chroot}}/mnt/host/source && " +
-		"mount --make-rslave / && " +
-		"mount --bind {{.RepoRoot}} {{.Chroot}}/mnt/host/source && " +
-		"exec chroot {{.Chroot}} " +
-		"/usr/bin/sudo -u {{.Username}} sh -c " +
-		"'cd /mnt/host/source && repo {{.RepoArgs}}'"
-	enterChroot = "src/scripts/sdk_lib/enter_chroot.sh"
-)
+const enterChroot = "src/scripts/sdk_lib/enter_chroot.sh"
 
-var repoTemplate = template.Must(template.New("script").Parse(repoScript))
+var simpleChroot exec.Entrypoint
 
-type repoParams struct {
-	*user.User
-	Chroot   string
-	RepoRoot string
-	RepoArgs string
+func init() {
+	simpleChroot = exec.NewEntrypoint("simpleChroot", simpleChrootHelper)
+}
+
+// bind mount the repo source tree into the chroot and run a command
+func simpleChrootHelper(args []string) error {
+	if len(args) < 3 {
+		return fmt.Errorf("got %d args, need at least 3", len(args))
+	}
+	hostRepoRoot := args[0]
+	chroot := args[1]
+	chrootCmd := args[2:]
+	username := os.Getenv("SUDO_USER")
+	if username == "" {
+		return fmt.Errorf("SUDO_USER environment variable is not set.")
+	}
+
+	newRepoRoot := filepath.Join(chroot, chrootRepoRoot)
+	if err := os.MkdirAll(newRepoRoot, 0755); err != nil {
+		return err
+	}
+
+	// namespaces are per-thread attributes
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	if err := syscall.Unshare(syscall.CLONE_NEWNS); err != nil {
+		return fmt.Errorf("Unsharing mount namespace failed: %v", err)
+	}
+
+	if err := syscall.Mount(
+		"none", "/", "none", syscall.MS_REC|syscall.MS_SLAVE, ""); err != nil {
+		return fmt.Errorf("Unsharing mount points failed: %v", err)
+	}
+
+	if err := syscall.Mount(
+		hostRepoRoot, newRepoRoot, "none", syscall.MS_BIND, ""); err != nil {
+		return fmt.Errorf("Mounting %q failed: %v", newRepoRoot, err)
+	}
+
+	if err := syscall.Chroot(chroot); err != nil {
+		return fmt.Errorf("Chrooting to %q failed: %v", chroot, err)
+	}
+
+	if err := os.Chdir(chrootRepoRoot); err != nil {
+		return err
+	}
+
+	sudo := "/usr/bin/sudo"
+	sudoArgs := append([]string{sudo, "-u", username, "--"}, chrootCmd...)
+	return syscall.Exec(sudo, sudoArgs, os.Environ())
 }
 
 // Set an environment variable if it isn't already defined.
@@ -70,34 +106,18 @@ func setDefaultEmail(environ []string) []string {
 	return setDefault(environ, "EMAIL", email)
 }
 
-func repo(name, args string) error {
-	chroot := filepath.Join(RepoRoot(), name)
-	u, err := user.Current()
-	if err != nil {
-		return err
-	}
+func SimpleEnter(name string, args ...string) error {
+	reroot := RepoRoot()
+	chroot := filepath.Join(reroot, name)
+	args = append([]string{reroot, chroot}, args...)
 
-	params := repoParams{
-		User:     u,
-		Chroot:   chroot,
-		RepoRoot: RepoRoot(),
-		RepoArgs: args,
-	}
+	sudo := simpleChroot.Sudo(args...)
+	sudo.Env = setDefaultEmail(os.Environ())
+	sudo.Stdin = os.Stdin
+	sudo.Stdout = os.Stdout
+	sudo.Stderr = os.Stderr
 
-	var sc bytes.Buffer
-	if err := repoTemplate.Execute(&sc, &params); err != nil {
-		return err
-	}
-
-	sh := exec.Command("sudo", sudoPrompt, "-E",
-		"unshare", "--mount",
-		"sh", "-e", "-c", sc.String())
-	sh.Env = setDefaultEmail(os.Environ())
-	sh.Stdin = os.Stdin
-	sh.Stdout = os.Stdout
-	sh.Stderr = os.Stderr
-
-	return sh.Run()
+	return sudo.Run()
 }
 
 func Enter(name string, args ...string) error {
@@ -121,9 +141,9 @@ func Enter(name string, args ...string) error {
 }
 
 func RepoInit(name, manifest string) error {
-	if err := repo(name, "init -u "+manifest); err != nil {
+	if err := SimpleEnter(name, "repo", "init", "-u", manifest); err != nil {
 		return err
 	}
 
-	return repo(name, "sync")
+	return SimpleEnter(name, "repo", "sync")
 }

--- a/system/exec/exec.go
+++ b/system/exec/exec.go
@@ -12,12 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+// exec is extension of the standard os.exec package.
+// Adds a handy dandy interface and assorted other features.
+package exec
 
 import (
 	"io"
 	"os/exec"
 	"syscall"
+)
+
+var (
+	// for equivalence with os/exec
+	ErrNotFound = exec.ErrNotFound
+	LookPath    = exec.LookPath
 )
 
 // An exec.Cmd compatible interface.
@@ -41,7 +49,7 @@ type ExecCmd struct {
 	*exec.Cmd
 }
 
-func NewCommand(name string, arg ...string) *ExecCmd {
+func Command(name string, arg ...string) *ExecCmd {
 	return &ExecCmd{exec.Command(name, arg...)}
 }
 

--- a/system/exec/exec_test.go
+++ b/system/exec/exec_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package exec
 
 import (
 	"syscall"
@@ -20,7 +20,7 @@ import (
 )
 
 func TestExecCmdKill(t *testing.T) {
-	cmd := NewCommand("sleep", "3600")
+	cmd := Command("sleep", "3600")
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("Start failed: %v", err)
 	}

--- a/system/exec/multicall.go
+++ b/system/exec/multicall.go
@@ -1,0 +1,97 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// inspired by github.com/docker/docker/pkg/reexec
+
+package exec
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+)
+
+// prefix of first argument if it is defining an entrypoint to be called.
+const entryArgPrefix = "_MULTICALL_ENTRYPOINT_"
+
+var exePath string
+
+func init() {
+	// save the program path
+	var err error
+	exePath, err = os.Readlink("/proc/self/exe")
+	if err != nil {
+		panic("cannot get current executable")
+	}
+}
+
+type entrypointFn func(args []string) error
+
+var entrypoints = make(map[string]entrypointFn)
+
+// Entrypoint provides the access to a multicall command.
+type Entrypoint string
+
+// NewEntrypoint adds a new multicall command. name is the command name
+// and fn is the function that will be executed for the specified
+// command. It returns the related Entrypoint. Packages adding new
+// multicall commands should call Add in their init function.
+func NewEntrypoint(name string, fn entrypointFn) Entrypoint {
+	if _, ok := entrypoints[name]; ok {
+		panic(fmt.Errorf("command with name %q already exists", name))
+	}
+	entrypoints[name] = fn
+	return Entrypoint(name)
+}
+
+// MaybeExec should be called at the start of the program, if the process argv[0] is
+// a name registered with multicall, the related function will be executed.
+// If the functions returns an error, it will be printed to stderr and will
+// exit with an exit status of 1, otherwise it will exit with a 0 exit status.
+func MaybeExec() {
+	if len(os.Args) < 2 || !strings.HasPrefix(os.Args[1], entryArgPrefix) {
+		return
+	}
+	name := os.Args[1][len(entryArgPrefix):]
+	if err := entrypoints[name](os.Args[2:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+// Command will prepare the *ExecCmd for the given entrypoint, configured with
+// the provided args.
+func (e Entrypoint) Command(args ...string) *ExecCmd {
+	args = append([]string{entryArgPrefix + string(e)}, args...)
+	cmd := Command(exePath, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGTERM,
+	}
+	return cmd
+}
+
+// Sudo will prepare the *ExecCmd for the given entrypoint to be run as root
+// via sudo with the provided args.
+func (e Entrypoint) Sudo(args ...string) *ExecCmd {
+	args = append([]string{"--preserve-env",
+		"--prompt=sudo password for %p: ", "--",
+		exePath, entryArgPrefix + string(e)}, args...)
+	cmd := Command("sudo", args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGTERM,
+	}
+	return cmd
+}

--- a/system/exec/multicall_test.go
+++ b/system/exec/multicall_test.go
@@ -1,0 +1,59 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+var testMulticall Entrypoint
+
+func init() {
+	testMulticall = NewEntrypoint("testMulticall", testMulticallHelper)
+}
+
+func testMulticallHelper(args []string) error {
+	fmt.Println(args)
+	return nil
+}
+
+func TestMain(m *testing.M) {
+	MaybeExec()
+	os.Exit(m.Run())
+}
+
+func TestMulticallNoArgs(t *testing.T) {
+	cmd := testMulticall.Command()
+	out, err := cmd.Output()
+	if err != nil {
+		t.Error(err)
+	}
+	if string(out) != "[]\n" {
+		t.Errorf("Unexpected output: %q", string(out))
+	}
+}
+
+func TestMulticallWithArgs(t *testing.T) {
+	cmd := testMulticall.Command("arg1", "020")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Error(err)
+	}
+	if string(out) != "[arg1 020]\n" {
+		t.Errorf("Unexpected output: %q", string(out))
+	}
+}


### PR DESCRIPTION
The create and enter commands should be fully functional now. The main issue I can think of that may be an issue for developers is the initial repo sync doesn't support passing an ssh agent into the chroot so git ssh urls cannot be used but the user could re-run repo init after the initial sync to switch. That shouldn't be a problem for automated builds though.