### PR TITLE
platform: fix go vet complaints

### DIFF
--- a/platform/conf_test.go
+++ b/platform/conf_test.go
@@ -44,7 +44,7 @@ func TestConfCopyKey(t *testing.T) {
 	for i, tt := range tests {
 		conf, err := NewConf(tt.conf)
 		if err != nil {
-			t.Errorf("failed to parse config %i: %v", i, err)
+			t.Errorf("failed to parse config %d: %v", i, err)
 			continue
 		}
 
@@ -53,7 +53,7 @@ func TestConfCopyKey(t *testing.T) {
 		str := conf.String()
 
 		if !strings.Contains(str, "ssh-rsa ") || !strings.Contains(str, " core@default") {
-			t.Errorf("ssh public key not found in config %i: ", i)
+			t.Errorf("ssh public key not found in config %d: %s", i, str)
 			continue
 		}
 	}

--- a/platform/util.go
+++ b/platform/util.go
@@ -64,7 +64,7 @@ func Manhole(m Machine) error {
 	}
 
 	if err = session.RequestPty(os.Getenv("TERM"), lines, cols, modes); err != nil {
-		fmt.Errorf("failed to request pseudo terminal: %s", err)
+		return fmt.Errorf("failed to request pseudo terminal: %s", err)
 	}
 
 	if err := session.Shell(); err != nil {


### PR DESCRIPTION
```
mischief@delta ~/code/go/src/github.com/coreos/mantle $ go vet ./...
platform/util.go:67: result of fmt.Errorf call not used
platform/conf_test.go:47: unrecognized printf verb 'i'
platform/conf_test.go:56: unrecognized printf verb 'i'
exit status 1
```