### PR TITLE
kola: rename CloudConfig to UserData

### DIFF
--- a/cmd/kola/etcdupgrade.go
+++ b/cmd/kola/etcdupgrade.go
@@ -71,7 +71,7 @@ func runEtcdUpgrade(cmd *cobra.Command, args []string) {
 		Run:         etcd.RollingUpgrade,
 		ClusterSize: 3,
 		Name:        "EtcdUpgrade",
-		CloudConfig: `#cloud-config
+		UserData: `#cloud-config
 
 coreos:
   etcd2:

--- a/kola/coretest.go
+++ b/kola/coretest.go
@@ -42,7 +42,7 @@ func init() {
 			"EtcdUpdateValue":    coretest.TestEtcdUpdateValue,
 			"FleetctlRunService": coretest.TestFleetctlRunService,
 		},
-		CloudConfig: `#cloud-config
+		UserData: `#cloud-config
 
 coreos:
   etcd2:

--- a/kola/etcdregistry.go
+++ b/kola/etcdregistry.go
@@ -24,7 +24,7 @@ func init() {
 		Run:         etcd.DiscoveryV1,
 		ClusterSize: 3,
 		Name:        "Etcd1Discovery",
-		CloudConfig: `#cloud-config
+		UserData: `#cloud-config
 coreos:
   etcd:
     name: $name
@@ -38,7 +38,7 @@ coreos:
 		Run:         etcd.DiscoveryV2,
 		ClusterSize: 3,
 		Name:        "Etcd2Discovery",
-		CloudConfig: `#cloud-config
+		UserData: `#cloud-config
 
 coreos:
   etcd2:

--- a/kola/flannelregistry.go
+++ b/kola/flannelregistry.go
@@ -59,7 +59,7 @@ func init() {
 		ClusterSize: 3,
 		Name:        "FlannelUDP",
 		Platforms:   []string{"aws", "gce"},
-		CloudConfig: udpConf.String(),
+		UserData:    udpConf.String(),
 	})
 
 	vxlanConf := new(bytes.Buffer)
@@ -72,6 +72,6 @@ func init() {
 		ClusterSize: 3,
 		Name:        "FlannelVXLAN",
 		Platforms:   []string{"aws", "gce"},
-		CloudConfig: vxlanConf.String(),
+		UserData:    vxlanConf.String(),
 	})
 }

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -59,7 +59,7 @@ type Test struct {
 	Name        string // should be uppercase and unique
 	Run         func(platform.TestCluster) error
 	NativeFuncs map[string]func() error
-	CloudConfig string
+	UserData    string
 	ClusterSize int
 	Platforms   []string // whitelist of platforms to run test against -- defaults to all
 }
@@ -218,7 +218,7 @@ func RunTest(t *Test, pltfrm string) error {
 		return fmt.Errorf("Failed to create discovery endpoint: %v", err)
 	}
 
-	cfgs := makeConfigs(url, t.CloudConfig, t.ClusterSize)
+	cfgs := makeConfigs(url, t.UserData, t.ClusterSize)
 
 	if t.ClusterSize > 0 {
 		_, err := platform.NewMachines(cluster, cfgs)

--- a/kola/ignitionregistry.go
+++ b/kola/ignitionregistry.go
@@ -22,7 +22,7 @@ func init() {
 		Run:         ignition.SetHostname,
 		ClusterSize: 1,
 		Platforms:   []string{"aws"},
-		CloudConfig: `{
+		UserData: `{
         "ignitionVersion": 1,
         "storage": {
                 "filesystems": [


### PR DESCRIPTION
it no longer makes sense to call this CloudConfig now that we support ignition.