### PR TITLE
util: fix golint complaints

### DIFF
--- a/util/logio.go
+++ b/util/logio.go
@@ -26,6 +26,7 @@ import (
 
 var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "util")
 
+// LogFrom reads lines from reader r and sends them to logger l.
 func LogFrom(l capnslog.LogLevel, r io.Reader) {
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
@@ -36,6 +37,7 @@ func LogFrom(l capnslog.LogLevel, r io.Reader) {
 	}
 }
 
+// CopyProgress copies data from reader into writter, logging progress through level.
 func CopyProgress(level capnslog.LogLevel, prefix string, writer io.Writer, reader io.Reader, total int64) (int64, error) {
 	// TODO(marineam): would be nice to support this natively in
 	// capnslog so the right output stream and formatter are used.

--- a/util/retry.go
+++ b/util/retry.go
@@ -18,6 +18,9 @@ import (
 	"time"
 )
 
+// Retry calls function f until it has been called attemps times, or succeeds.
+// Retry delays for delay between calls of f. If f does not succeed after
+// attempts calls, the error from the last call is returned.
 func Retry(attempts int, delay time.Duration, f func() error) error {
 	var err error
 


### PR DESCRIPTION
the following complaints were fixed:

util/logio.go:29:1: exported function LogFrom should have comment or be unexported
util/logio.go:39:1: exported function CopyProgress should have comment or be unexported
util/retry.go:21:1: exported function Retry should have comment or be unexported