### PR TITLE
version: fix golint complaints

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,18 @@
+// Copyright 2014 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package version
 
+// Version is the current version of mantle.
 const Version = "0"


### PR DESCRIPTION
the following complaints were fixed:

version/version.go:3:7: exported const Version should have comment or be unexported