### PR TITLE
kola: improved comments via golint suggestions

### DIFF
--- a/kola/register/register.go
+++ b/kola/register/register.go
@@ -16,6 +16,10 @@ package register
 
 import "github.com/coreos/mantle/platform"
 
+// Test provides the main test abstraction for kola. The run function is
+// the actual testing function while the other fields provide ways to
+// statically declare state of the platform.TestCluster before the test
+// function is run.
 type Test struct {
 	Name        string // should be uppercase and unique
 	Run         func(platform.TestCluster) error
@@ -25,10 +29,12 @@ type Test struct {
 	Platforms   []string // whitelist of platforms to run test against -- defaults to all
 }
 
-// maps names to tests
+// Registered tests live here. Mapping of names to tests.
 var Tests = map[string]*Test{}
 
-// panic if existing name is registered
+// Register is usually called in init() functions and is how kola test
+// harnesses knows which tests it can choose from. Panic if existing
+// name is registered
 func Register(t *Test) {
 	_, ok := Tests[t.Name]
 	if ok {


### PR DESCRIPTION
Ignoring all the golint stuff for anything under kola/tests for now. Mostly just fixing up comments. The Result struct I un-exported rather then add a comment. Used gorename for safe renaming. 

```
harness.go:46:2: exported var QEMUOptions should have comment or be unexported
harness.go:55:1: comment on exported function RegisterTestOption should be of the form "RegisterTestOption ..."
harness.go:71:6: exported type Result should have comment or be unexported
harness.go:123:1: comment on exported function RunTests should be of the form "RunTests ..."
harness.go:183:1: comment on exported function RunTest should be of the form "RunTest ..."
register/register.go:19:6: exported type Test should have comment or be unexported
register/register.go:31:1: comment on exported function Register should be of the form "Register ..."
```

@mischief 