### PR TITLE
sdk: reverse wait order of bz2 and tar

### DIFF
--- a/sdk/create.go
+++ b/sdk/create.go
@@ -193,18 +193,16 @@ func extract(tar, dir string) error {
 	}
 
 	if err := untar.Start(); err != nil {
-		unzip.Process.Kill()
-		unzip.Wait()
-		return err
-	}
-
-	if err := unzip.Wait(); err != nil {
-		untar.Process.Kill()
-		untar.Wait()
+		unzip.Kill()
 		return err
 	}
 
 	if err := untar.Wait(); err != nil {
+		unzip.Kill()
+		return err
+	}
+
+	if err := unzip.Wait(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
If sudo or tar fails the bunzip process will happily hang there waiting
for something to read its output. On the flip side if bunzip aborts
early tar itself should also fail and complain about bad input. So this
ordering should be reliable.