### PR TITLE
sdk: create debian_chroot flag file

### DIFF
--- a/sdk/create.go
+++ b/sdk/create.go
@@ -124,6 +124,9 @@ source ~/trunk/src/scripts/bash_completion
 EOF
 
 chown -R {{.Uid}}:{{.Gid}} "$HOME"
+
+# Checked in src/scripts/common.sh
+touch /etc/debian_chroot
 `
 )
 


### PR DESCRIPTION
The build scripts check this file to determine if they are inside the
chroot or not, optionally entering the chroot if needed. The optional
entering part uses cros_sdk but the inside chroot check needs to work.