### PR TITLE
kola/tests/ignition: fix xfsroot mkfs options

### DIFF
--- a/kola/tests/ignition/root.go
+++ b/kola/tests/ignition/root.go
@@ -63,7 +63,7 @@ func init() {
 		                           "create": {
 		                               "force": true,
 		                               "options": [
-		                                   "-L ROOT"
+		                                   "-L", "ROOT"
 		                               ]
 		                           }
 		                       }


### PR DESCRIPTION
"-L ROOT" must be supplied in two separate arguments, mkfs.xfs
erroneously accepts this form but will result in the label " ROOT"
in my tests.