### PR TITLE
Private repo support

### DIFF
--- a/cmd/cork/create.go
+++ b/cmd/cork/create.go
@@ -24,11 +24,13 @@ const (
 )
 
 var (
-	chrootVersion string
-	chrootName    string
-	manifestURL   string
-	allowReplace  bool
-	createCmd     = &cobra.Command{
+	chrootVersion  string
+	chrootName     string
+	manifestURL    string
+	manifestName   string
+	manifestBranch string
+	allowReplace   bool
+	createCmd      = &cobra.Command{
 		Use:   "create",
 		Short: "Download and unpack the SDK",
 		Run:   runCreate,
@@ -52,6 +54,10 @@ func init() {
 		"chroot", "chroot", "SDK chroot directory name")
 	createCmd.Flags().StringVar(&manifestURL,
 		"manifest-url", coreosManifestURL, "Manifest git repo location")
+	createCmd.Flags().StringVar(&manifestBranch,
+		"manifest-branch", "master", "Manifest git repo branch")
+	createCmd.Flags().StringVar(&manifestName,
+		"manifest-name", "default.xml", "Manifest file name")
 	createCmd.Flags().BoolVar(&allowReplace,
 		"replace", false, "Replace an existing SDK chroot")
 	enterCmd.Flags().StringVar(&chrootName,
@@ -91,7 +97,7 @@ func runCreate(cmd *cobra.Command, args []string) {
 		plog.Fatalf("Create failed: %v", err)
 	}
 
-	if err := sdk.RepoInit(chrootName, manifestURL); err != nil {
+	if err := sdk.RepoInit(chrootName, manifestURL, manifestName, manifestBranch); err != nil {
 		plog.Fatalf("repo init and sync failed: %v", err)
 	}
 }

--- a/sdk/enter.go
+++ b/sdk/enter.go
@@ -256,8 +256,10 @@ func Enter(name string, args ...string) error {
 	return enterCmd.Run()
 }
 
-func RepoInit(name, manifest string) error {
-	if err := SimpleEnter(name, "repo", "init", "-u", manifest); err != nil {
+func RepoInit(name, manifest, manifestName, branch string) error {
+	if err := SimpleEnter(
+		name, "repo", "init", "-u", manifest,
+		"-b", branch, "-m", manifestName); err != nil {
 		return err
 	}
 

--- a/sdk/enter.go
+++ b/sdk/enter.go
@@ -16,9 +16,11 @@ package sdk
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -80,6 +82,61 @@ func simpleChrootHelper(args []string) error {
 		return fmt.Errorf("Mounting %q failed: %v", newRepoRoot, err)
 	}
 
+	// mount the /run directory and setup the permissions
+	runMountDir := filepath.Join(chroot, "run")
+	if err := syscall.Mount(
+		"tmpfs", runMountDir, "tmpfs", syscall.MS_NOSUID|syscall.MS_NODEV, "mode=755"); err != nil {
+		return fmt.Errorf("Mounting %q failed: %v", runMountDir, err)
+	}
+
+	userInfo, err := user.Lookup(username)
+	if err != nil {
+		return err
+	}
+
+	rundir := filepath.Join(runMountDir, "user", userInfo.Uid)
+
+	err = os.MkdirAll(rundir, 0755)
+	if err != nil {
+		return err
+	}
+
+	uid, err := strconv.Atoi(userInfo.Uid)
+	if err != nil {
+		return err
+	}
+
+	gid, err := strconv.Atoi(userInfo.Gid)
+	if err != nil {
+		return err
+	}
+
+	err = os.Chown(rundir, uid, gid)
+	if err != nil {
+		return err
+	}
+
+	// mount the directory containing the ssh-agent socket in order
+	// to support a private repos during repo sync
+	sshAuthSock := os.Getenv("SSH_AUTH_SOCK")
+	if sshAuthSock != "" {
+		sshSourceDir, sshSocketFile := filepath.Split(sshAuthSock)
+		if _, err := os.Stat(sshSourceDir); err == nil {
+			sshTargetdir, err := ioutil.TempDir(rundir, "ssh-")
+			if err != nil {
+				return err
+			}
+
+			if err := syscall.Mount(
+				sshSourceDir, sshTargetdir, "none", syscall.MS_BIND, ""); err != nil {
+				return fmt.Errorf("Mounting %q failed: %v", sshSourceDir, err)
+			}
+
+			os.Setenv("SSH_AUTH_SOCK",
+				filepath.Join(strings.TrimPrefix(sshTargetdir, chroot), sshSocketFile))
+		}
+	}
+
 	if err := syscall.Chroot(chroot); err != nil {
 		return fmt.Errorf("Chrooting to %q failed: %v", chroot, err)
 	}
@@ -104,6 +161,52 @@ func setDefault(environ []string, key, value string) []string {
 	return append(environ, prefix+value)
 }
 
+// copies a user's config file from user's home directory to the equivalent
+// location in the chroot
+func copyUserConfigFile(source, chroot string) error {
+	userInfo, err := user.Current()
+	if err != nil {
+		return err
+	}
+
+	sourcepath := filepath.Join(userInfo.HomeDir, source)
+	if _, err := os.Stat(sourcepath); err != nil {
+		return nil
+	}
+
+	chrootHome := filepath.Join(chroot, "home", userInfo.Username)
+	sourceDir := filepath.Dir(source)
+	if sourceDir != "." {
+		if err := os.MkdirAll(
+			filepath.Join(chrootHome, sourceDir), 0700); err != nil {
+			return err
+		}
+	}
+
+	tartgetpath := filepath.Join(chrootHome, source)
+	if err := system.CopyRegularFile(sourcepath, tartgetpath); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func copyUserConfig(chroot string) error {
+	if err := copyUserConfigFile(".ssh/config", chroot); err != nil {
+		return err
+	}
+
+	if err := copyUserConfigFile(".ssh/known_hosts", chroot); err != nil {
+		return err
+	}
+
+	if err := copyUserConfigFile(".gitconfig", chroot); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Set a default email address so repo doesn't explode on 'u@h.(none)'
 func setDefaultEmail(environ []string) []string {
 	username := "nobody"
@@ -125,6 +228,10 @@ func SimpleEnter(name string, args ...string) error {
 	sudo.Stdin = os.Stdin
 	sudo.Stdout = os.Stdout
 	sudo.Stderr = os.Stderr
+
+	if err := copyUserConfig(chroot); err != nil {
+		return err
+	}
 
 	return sudo.Run()
 }


### PR DESCRIPTION
This PR adds support for private repositories in the manifest repo, and reduces the prompting done by repo init. 

When an ssh-agent is being used we mount the directory holding the ssh-agent socket in the chroot and copy ~/.ssh/config and ~/.ssh/known_hosts. 

Also ~/.gitconfig is copied into the chroot to avoid repo init prompts and support automated build environments.

Lastly, I added support for specifying a manifest branch to "cork create".