### PR TITLE
Make cork's --sdk-version optional

### DIFF
--- a/cmd/cork/create.go
+++ b/cmd/cork/create.go
@@ -50,7 +50,7 @@ var (
 
 func init() {
 	createCmd.Flags().StringVar(&chrootVersion,
-		"sdk-version", "", "SDK version")
+		"sdk-version", "", "SDK version. Defaults to the SDK version in version.txt")
 	createCmd.Flags().StringVar(&chrootName,
 		"chroot", "chroot", "SDK chroot directory name")
 	createCmd.Flags().StringVar(&manifestURL,
@@ -78,7 +78,20 @@ func runCreate(cmd *cobra.Command, args []string) {
 	}
 
 	if chrootVersion == "" {
-		plog.Fatal("Missing --sdk-version=VERSION")
+		plog.Noticef("Detecting SDK version")
+
+		var err error
+		chrootVersion, err = sdk.GetSDKVersion()
+		if err != nil {
+			chrootVersion, err = sdk.GetSDKVersionFromRemoteRepo(manifestURL, manifestBranch)
+			if err != nil {
+				plog.Fatalf("GetSDKVersionFromRemoteRepo failed: %v", err)
+			} else {
+				plog.Noticef("Found SDK version %s from remote repo", chrootVersion)
+			}
+		} else {
+			plog.Noticef("Found SDK version %s from local repo", chrootVersion)
+		}
 	}
 
 	plog.Noticef("Downloading SDK version %s", chrootVersion)

--- a/cmd/ore/upload.go
+++ b/cmd/ore/upload.go
@@ -71,7 +71,7 @@ func runUpload(cmd *cobra.Command, args []string) {
 	// if an image name is unspecified try to use version.txt
 	if uploadImageName == "" {
 		var err error
-		uploadImageName, err = sdk.GetVersion(filepath.Dir(uploadFile))
+		uploadImageName, err = sdk.GetVersionFromDir(filepath.Dir(uploadFile))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Unable to get version from image directory, provide a -name flag or include a version.txt in the image directory: %v\n", err)
 			os.Exit(1)

--- a/sdk/create.go
+++ b/sdk/create.go
@@ -227,7 +227,7 @@ func Unpack(version, name string) error {
 		return err
 	}
 
-	tar := filepath.Join(RepoCache(), "sdk", TarballName(version))
+	tar := filepath.Join(RepoCache(), "sdks", TarballName(version))
 	plog.Infof("Using %s", tar)
 	if err := extract(tar, chroot); err != nil {
 		plog.Errorf("Extracting %s to %s failed: %v", tar, chroot, err)

--- a/sdk/download.go
+++ b/sdk/download.go
@@ -190,7 +190,7 @@ func DownloadSignedFile(file, url string, client *http.Client) error {
 }
 
 func DownloadSDK(version string) error {
-	tarFile := filepath.Join(RepoCache(), "sdk", TarballName(version))
+	tarFile := filepath.Join(RepoCache(), "sdks", TarballName(version))
 	tarURL := TarballURL(version)
 	return DownloadSignedFile(tarFile, tarURL, nil)
 }

--- a/sdk/omaha/generate.go
+++ b/sdk/omaha/generate.go
@@ -112,7 +112,7 @@ func GenerateFullUpdate(version string) error {
 	postinstall := update.AddAction("postinstall")
 	postinstall.Sha256 = pkg.Sha256
 
-	update.Version, err = sdk.GetVersion(dir)
+	update.Version, err = sdk.GetVersionFromDir(dir)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
cork create --sdk-version is now optional. If not specified we will read COREOS_SDK_VERSION from version.txt in the manifest repo. 

I'm shelling out to "git clone" instead of using the git golang lib, hope thats OK. 