### PR TITLE
initial implementation of a stand-alone omaha server and delta_generator/update_engine test

### DIFF
--- a/cmd/cork/build.go
+++ b/cmd/cork/build.go
@@ -26,13 +26,16 @@ var (
 	}
 	buildUpdateCmd = &cobra.Command{
 		Use:   "update",
-		Short: "Build a dev image update payload",
+		Short: "Build an image update payload",
 		Run:   runBuildUpdate,
 	}
+
+	doProd = false
 )
 
 func init() {
 	buildCmd.AddCommand(buildUpdateCmd)
+	buildUpdateCmd.Flags().BoolVar(&doProd, "prod", false, "create a production image instead of developer")
 	root.AddCommand(buildCmd)
 }
 
@@ -41,7 +44,7 @@ func runBuildUpdate(cmd *cobra.Command, args []string) {
 		plog.Fatalf("Unrecognized arguments: %v", args)
 	}
 
-	err := omaha.GenerateFullUpdate("latest")
+	err := omaha.GenerateFullUpdate("latest", doProd)
 	if err != nil {
 		plog.Fatalf("Building full update failed: %v", err)
 	}

--- a/cmd/kola/kola.go
+++ b/cmd/kola/kola.go
@@ -20,13 +20,17 @@ import (
 	"sort"
 	"text/tabwriter"
 
-	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/spf13/cobra"
 	"github.com/coreos/mantle/cli"
 	"github.com/coreos/mantle/kola"
 	"github.com/coreos/mantle/kola/register"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/coreos/pkg/capnslog"
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/spf13/cobra"
 )
 
 var (
+	plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "kola")
+
 	root = &cobra.Command{
 		Use:   "kola [command]",
 		Short: "The CoreOS Superdeep Borehole",

--- a/cmd/kola/updatepayload.go
+++ b/cmd/kola/updatepayload.go
@@ -1,0 +1,256 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/coreos/mantle/kola"
+	"github.com/coreos/mantle/network/omaha"
+	"github.com/coreos/mantle/platform"
+	"github.com/coreos/mantle/sdk"
+	sdkomaha "github.com/coreos/mantle/sdk/omaha"
+	"github.com/coreos/mantle/util"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/spf13/cobra"
+)
+
+func init() {
+	root.AddCommand(cmdUpdatePayload)
+}
+
+var cmdUpdatePayload = &cobra.Command{
+	Run:   runUpdatePayload,
+	Use:   "updatepayload",
+	Short: "test serving a update_engine payload",
+	Long: `
+Boot a CoreOS instance and serve an update payload to its update_engine.
+
+This command must run inside of the SDK as root, e.g.
+
+sudo kola updatepayload
+`,
+}
+
+var userdata = `#cloud-config
+
+coreos:
+  update:
+    server: "http://{{.Server}}/v1/update/"
+    # we disable reboot so we have explicit control
+    reboot-strategy: "off"
+`
+
+func runUpdatePayload(cmd *cobra.Command, args []string) {
+	if len(args) != 0 {
+		plog.Fatal("No args accepted")
+	}
+
+	plog.Info("Generating update payload")
+
+	// check for update file, generate if it doesn't exist
+	version := "latest"
+	dir := sdk.BuildImageDir(version)
+	payload := "coreos_production_update.gz"
+
+	_, err := os.Stat(filepath.Join(dir, payload))
+	if err != nil {
+		err = sdkomaha.GenerateFullUpdate("latest", true)
+		if err != nil {
+			plog.Fatalf("Building full update failed: %v", err)
+		}
+	}
+
+	plog.Info("Bringing up test harness cluster")
+
+	cluster, err := platform.NewQemuCluster(kola.QEMUOptions)
+	qc := cluster.(*platform.QEMUCluster)
+	if err != nil {
+		plog.Fatalf("Cluster failed: %v", err)
+	}
+	defer cluster.Destroy()
+
+	svc := &updateServer{
+		updatePath: dir,
+		payload:    payload,
+	}
+
+	qc.OmahaServer.Updater = svc
+
+	// tell omaha server to handle file requests for the images dir
+	qc.OmahaServer.Mux.Handle(dir+"/", http.StripPrefix(dir+"/", http.FileServer(http.Dir(dir))))
+
+	_, port, err := net.SplitHostPort(qc.OmahaServer.Addr().String())
+	if err != nil {
+		plog.Errorf("SplitHostPort failed: %v", err)
+		return
+	}
+
+	tmplVals := map[string]string{
+		"Server": fmt.Sprintf("10.0.0.1:%s", port),
+	}
+
+	tmpl := template.Must(template.New("userdata").Parse(userdata))
+	buf := new(bytes.Buffer)
+
+	err = tmpl.Execute(buf, tmplVals)
+	if err != nil {
+		plog.Errorf("Template execution failed: %v", err)
+		return
+	}
+
+	plog.Infof("Spawning test machine")
+
+	m, err := cluster.NewMachine(buf.String())
+	if err != nil {
+		plog.Errorf("Machine failed: %v", err)
+		return
+	}
+
+	plog.Info("Checking for boot from USR-A partition")
+
+	/* check that we are on USR-A. */
+	if err := checkUsrPartition(m, []string{"PARTUUID=" + sdk.USRAUUID.String(), "PARTLABEL=USR-A"}); err != nil {
+		plog.Errorf("Did not find USR-A partition: %v", err)
+		return
+	}
+
+	plog.Infof("Triggering update_engine")
+
+	/* trigger update, monitor the progress. */
+	out, err := m.SSH("update_engine_client -check_for_update")
+	if err != nil {
+		plog.Errorf("Executing update_engine_client failed: %v: %v", out, err)
+		return
+	}
+
+	checker := func() error {
+		envs, err := m.SSH("update_engine_client -status 2>/dev/null")
+		if err != nil {
+			return err
+		}
+
+		em := splitNewlineEnv(string(envs))
+
+		if em["CURRENT_OP"] != "UPDATE_STATUS_UPDATED_NEED_REBOOT" {
+			return fmt.Errorf("have not arrived in reboot state: currently at %s", em["CURRENT_OP"])
+		}
+
+		return nil
+	}
+
+	if err := util.Retry(12, 10*time.Second, checker); err != nil {
+		plog.Errorf("Applying update payload failed: %v", err)
+		return
+	}
+
+	plog.Info("Rebooting test machine")
+
+	/* reboot it */
+	if err := platform.Reboot(m); err != nil {
+		plog.Errorf("Rebooting machine failed: %v", err)
+		return
+	}
+
+	plog.Info("Checking for boot from USR-B partition")
+
+	/* check that we are on USR-B now. */
+	if err := checkUsrPartition(m, []string{"PARTUUID=" + sdk.USRBUUID.String(), "PARTLABEL=USR-B"}); err != nil {
+		plog.Errorf("Did not find USR-B partition: %v", err)
+		return
+	}
+
+	plog.Info("Update complete!")
+}
+
+// checkUsrPartition inspects /proc/cmdline of the machine, looking for the
+// expected partition mounted at /usr.
+func checkUsrPartition(m platform.Machine, accept []string) error {
+	out, err := m.SSH("cat /proc/cmdline")
+	if err != nil {
+		return fmt.Errorf("cat /proc/cmdline: %v: %v", out, err)
+	}
+
+	vars := splitSpaceEnv(string(out))
+	for _, a := range accept {
+		if vars["mount.usr"] == a {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("mount.usr not one of %q", strings.Join(accept, " "))
+}
+
+// split space-seperated KEY=VAL pairs into a map
+func splitSpaceEnv(envs string) map[string]string {
+	m := make(map[string]string)
+	pairs := strings.Fields(envs)
+	for _, p := range pairs {
+		spl := strings.SplitN(p, "=", 2)
+		m[spl[0]] = spl[1]
+	}
+	return m
+}
+
+// splits newline-delimited KEY=VAL pairs into a map
+func splitNewlineEnv(envs string) map[string]string {
+	m := make(map[string]string)
+	sc := bufio.NewScanner(strings.NewReader(envs))
+	for sc.Scan() {
+		spl := strings.SplitN(sc.Text(), "=", 2)
+		m[spl[0]] = spl[1]
+	}
+	return m
+}
+
+type updateServer struct {
+	omaha.UpdaterStub
+
+	updatePath string
+	payload    string
+}
+
+func (u *updateServer) CheckUpdate(req *omaha.Request, app *omaha.AppRequest) (*omaha.Update, error) {
+	m := omaha.Manifest{}
+
+	pkgpath := filepath.Join(u.updatePath, u.payload)
+	pkg, err := m.AddPackageFromPath(pkgpath)
+	if err != nil {
+		plog.Errorf("Loading package %q failed: %v", pkgpath, err)
+		return nil, omaha.UpdateInternalError
+	}
+
+	act := m.AddAction("postinstall")
+	act.Sha256 = pkg.Sha256
+
+	update := &omaha.Update{
+		Id: sdk.GetDefaultAppId(),
+		URL: omaha.URL{
+			CodeBase: u.updatePath + "/",
+		},
+		Manifest: m,
+	}
+
+	return update, nil
+}

--- a/network/omaha/handler.go
+++ b/network/omaha/handler.go
@@ -99,6 +99,7 @@ func (o *OmahaHandler) ServeHTTP(w http.ResponseWriter, httpReq *http.Request) {
 	}
 
 	encoder := xml.NewEncoder(writer)
+	encoder.Indent("", "\t")
 	if err := encoder.Encode(omahaResp); err != nil {
 		plog.Errorf("Failed encoding response: %v", err)
 	}

--- a/network/omaha/server.go
+++ b/network/omaha/server.go
@@ -17,10 +17,9 @@ package omaha
 import (
 	"net"
 	"net/http"
-	"sync"
 )
 
-func NewServer(addr string) (*Server, error) {
+func NewServer(addr string, updater Updater) (*Server, error) {
 	l, err := net.Listen("tcp", addr)
 	if err != nil {
 		return nil, err
@@ -31,8 +30,9 @@ func NewServer(addr string) (*Server, error) {
 	}
 
 	s := &Server{
-		l:   l,
-		srv: srv,
+		Updater: updater,
+		l:       l,
+		srv:     srv,
 	}
 
 	mux := http.NewServeMux()
@@ -44,13 +44,10 @@ func NewServer(addr string) (*Server, error) {
 }
 
 type Server struct {
-	UpdaterStub
+	Updater
 
 	l   net.Listener
 	srv *http.Server
-
-	reqChanLock sync.Mutex
-	reqChan     chan *Request
 }
 
 func (s *Server) Serve() error {
@@ -71,35 +68,6 @@ func (s *Server) Serve() error {
 
 func (s *Server) Destroy() error {
 	s.l.Close()
-
-	s.reqChanLock.Lock()
-	if s.reqChan != nil {
-		close(s.reqChan)
-		s.reqChan = nil
-	}
-	s.reqChanLock.Unlock()
-	return nil
-}
-
-// RequestChan returns a channel that will receive decoded omaha requests.
-//
-// XXX: if called more than once per Server instance, the receivers will miss
-// requests.
-func (s *Server) RequestChan() <-chan *Request {
-	s.reqChanLock.Lock()
-	if s.reqChan == nil {
-		s.reqChan = make(chan *Request)
-	}
-	s.reqChanLock.Unlock()
-	return s.reqChan
-}
-
-func (s *Server) CheckApp(req *Request, app *AppRequest) error {
-	s.reqChanLock.Lock()
-	if s.reqChan != nil {
-		s.reqChan <- req
-	}
-	s.reqChanLock.Unlock()
 	return nil
 }
 

--- a/network/omaha/server.go
+++ b/network/omaha/server.go
@@ -25,26 +25,29 @@ func NewServer(addr string, updater Updater) (*Server, error) {
 		return nil, err
 	}
 
+	mux := http.NewServeMux()
+
 	srv := &http.Server{
-		Addr: addr,
+		Addr:    addr,
+		Handler: mux,
 	}
 
 	s := &Server{
 		Updater: updater,
+		Mux:     mux,
 		l:       l,
 		srv:     srv,
 	}
 
-	mux := http.NewServeMux()
 	mux.Handle("/v1/update/", &OmahaHandler{s})
-
-	s.srv.Handler = mux
 
 	return s, nil
 }
 
 type Server struct {
 	Updater
+
+	Mux *http.ServeMux
 
 	l   net.Listener
 	srv *http.Server

--- a/platform/local/cluster.go
+++ b/platform/local/cluster.go
@@ -88,7 +88,7 @@ func NewLocalCluster() (*LocalCluster, error) {
 	lc.AddCloser(lc.NTPServer)
 	go lc.NTPServer.Serve()
 
-	lc.OmahaServer, err = omaha.NewServer(":34567")
+	lc.OmahaServer, err = omaha.NewServer(":34567", &omaha.UpdaterStub{})
 	if err != nil {
 		lc.Destroy()
 		return nil, err

--- a/platform/util.go
+++ b/platform/util.go
@@ -100,3 +100,16 @@ func StreamJournal(m Machine) error {
 
 	return nil
 }
+
+// Reboots a machine and blocks until the system to be accessible by SSH again.
+// It will return an error if the machine is not accessible after a timeout.
+func Reboot(m Machine) error {
+	// stop sshd so that commonMachineChecks will only work if the machine
+	// actually rebooted
+	out, err := m.SSH("sudo systemctl stop sshd.socket; sudo systemd-run --no-block systemctl reboot")
+	if err != nil {
+		return fmt.Errorf("issuing reboot command failed: %v", out)
+	}
+
+	return commonMachineChecks(m)
+}

--- a/sdk/const.go
+++ b/sdk/const.go
@@ -1,0 +1,25 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdk
+
+import (
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/satori/go.uuid"
+)
+
+// Partition UUIDs for CoreOS systems.
+var (
+	USRAUUID = uuid.UUID{0x71, 0x30, 0xC9, 0x4A, 0x21, 0x3A, 0x4E, 0x5A, 0x8E, 0x26, 0x6C, 0xCE, 0x96, 0x62, 0xF1, 0x32}
+	USRBUUID = uuid.UUID{0xE0, 0x3D, 0xD3, 0x5C, 0x7C, 0x2D, 0x4A, 0x47, 0xB3, 0xFE, 0x27, 0xF1, 0x57, 0x80, 0xA5, 0x7C}
+)

--- a/sdk/omaha/generate.go
+++ b/sdk/omaha/generate.go
@@ -81,11 +81,17 @@ func checkUpdate(dir, update_xml string) error {
 	return u.Packages[0].Verify(pkgdir)
 }
 
-func GenerateFullUpdate(version string) error {
-	// TODO: support prod images too, for now just match dev_server.
+func GenerateFullUpdate(version string, prod bool) error {
+	var variant string
+	if prod {
+		variant = "production"
+	} else {
+		variant = "developer"
+	}
+
 	var (
 		dir           = sdk.BuildImageDir(version)
-		update_prefix = filepath.Join(dir, "coreos_developer_update")
+		update_prefix = filepath.Join(dir, "coreos_"+variant+"_update")
 		update_bin    = update_prefix + ".bin"
 		update_gz     = update_prefix + ".gz"
 		update_xml    = update_prefix + ".xml"


### PR DESCRIPTION
a successful run looks like so:

```
./build kola && sudo ./bin/kola -v updatepayload
Building kola...
# github.com/coreos/mantle/cmd/kola
/usr/lib/gcc/x86_64-pc-linux-gnu/4.9.3/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/go-link-H7Vk2r/go.o: warning: relocation in readonly section `.gopclntab'.
/usr/lib/gcc/x86_64-pc-linux-gnu/4.9.3/../../../../x86_64-pc-linux-gnu/bin/ld: warning: creating a DT_TEXTREL in object.
2016-01-11T23:27:28Z cli: Started logging at level INFO
2016-01-11T23:27:28Z kola: Generating update payload
2016-01-11T23:27:28Z kola: Bringing up test harness cluster
2016-01-11T23:27:28Z etcdserver: name = simple
2016-01-11T23:27:28Z etcdserver: data dir = /tmp/simple-etcd-410624296
2016-01-11T23:27:28Z etcdserver: member dir = /tmp/simple-etcd-410624296/member
2016-01-11T23:27:28Z etcdserver: heartbeat = 100ms
2016-01-11T23:27:28Z etcdserver: election = 1000ms
2016-01-11T23:27:28Z etcdserver: snapshot count = 0
2016-01-11T23:27:28Z etcdserver: advertise client URLs = http://10.0.0.1:47180,http://10.1.0.1:47180,http://10.2.0.1:47180,http://[fd00::1]:47180,http://[fd01::1]:47180,http://[fd02::1]:47180
2016-01-11T23:27:28Z etcdserver: initial advertise peer URLs = http://localhost:0
2016-01-11T23:27:28Z etcdserver: initial cluster = simple=http://localhost:0
2016-01-11T23:27:28Z util: dnsmasq[20911]: started, version 2.72 cachesize 150
2016-01-11T23:27:28Z util: dnsmasq[20911]: compile time options: IPv6 GNU-getopt no-DBus i18n IDN DHCP DHCPv6 no-scripts no-TFTP no-conntrack ipset no-auth no-DNSSEC loop-detect
2016-01-11T23:27:28Z util: dnsmasq[20911]: warning: no upstream servers configured
2016-01-11T23:27:28Z util: dnsmasq-dhcp[20911]: DHCP, static leases only on 10.2.0.1, lease time 1h
2016-01-11T23:27:28Z util: dnsmasq-dhcp[20911]: DHCP, static leases only on 10.1.0.1, lease time 1h
2016-01-11T23:27:28Z util: dnsmasq-dhcp[20911]: DHCP, static leases only on 10.0.0.1, lease time 1h
2016-01-11T23:27:28Z util: dnsmasq-dhcp[20911]: DHCPv4-derived IPv6 names on fd02::
2016-01-11T23:27:28Z util: dnsmasq-dhcp[20911]: router advertisement on fd02::
2016-01-11T23:27:28Z util: dnsmasq-dhcp[20911]: DHCPv4-derived IPv6 names on fd01::
2016-01-11T23:27:28Z util: dnsmasq-dhcp[20911]: router advertisement on fd01::
2016-01-11T23:27:28Z util: dnsmasq-dhcp[20911]: DHCPv4-derived IPv6 names on fd00::
2016-01-11T23:27:28Z util: dnsmasq-dhcp[20911]: router advertisement on fd00::
2016-01-11T23:27:28Z util: dnsmasq-dhcp[20911]: IPv6 router advertisement enabled
2016-01-11T23:27:28Z util: dnsmasq[20911]: cleared cache
2016-01-11T23:27:28Z etcdserver: starting member f3620cbbbe7cd162 in cluster 3bd8c6452814d712
2016-01-11T23:27:28Z raft: f3620cbbbe7cd162 became follower at term 0
2016-01-11T23:27:28Z raft: newRaft f3620cbbbe7cd162 [peers: [], term: 0, commit: 0, applied: 0, lastindex: 0, lastterm: 0]
2016-01-11T23:27:28Z raft: f3620cbbbe7cd162 became follower at term 1
2016-01-11T23:27:28Z etcdserver: set snapshot count to default 10000
2016-01-11T23:27:28Z etcdserver: starting server... [version: 2.2.1, cluster version: to_be_decided]
2016-01-11T23:27:28Z etcdserver: added local member f3620cbbbe7cd162 [http://localhost:0] to cluster 3bd8c6452814d712
2016-01-11T23:27:28Z network/ntp: Started NTP server on [::]:123
2016-01-11T23:27:29Z kola: Spawning test machine
2016-01-11T23:27:29Z raft: f3620cbbbe7cd162 is starting a new election at term 1
2016-01-11T23:27:29Z raft: f3620cbbbe7cd162 became candidate at term 2
2016-01-11T23:27:29Z raft: f3620cbbbe7cd162 received vote from f3620cbbbe7cd162 at term 2
2016-01-11T23:27:29Z raft: f3620cbbbe7cd162 became leader at term 2
2016-01-11T23:27:29Z raft: raft.node: f3620cbbbe7cd162 elected leader f3620cbbbe7cd162 at term 2
2016-01-11T23:27:29Z etcdserver: setting up the initial cluster version to 2.2
2016-01-11T23:27:29Z etcdserver: set the initial cluster version to 2.2
2016-01-11T23:27:29Z etcdserver: published {Name:simple ClientURLs:[http://10.0.0.1:47180 http://10.1.0.1:47180 http://10.2.0.1:47180 http://[fd00::1]:47180 http://[fd01::1]:47180 http://[fd02::1]:47180]} to cluster 3bd8c6452814d712
2016-01-11T23:27:41Z network/ntp: Recieved NTP request from 10.0.0.2:43507
2016-01-11T23:27:41Z network/ntp: Recieved NTP request from 10.0.0.2:55008
2016-01-11T23:27:42Z kola: Checking for boot from USR-A partition
2016-01-11T23:27:42Z kola: Triggering update_engine
[0111/232742:INFO:update_engine_client.cc(243)] Initiating update check and install.
2016-01-11T23:27:43Z network/ntp: Recieved NTP request from 10.0.0.2:41955
2016-01-11T23:27:45Z network/ntp: Recieved NTP request from 10.0.0.2:42271
2016-01-11T23:27:46Z network/omaha: Update to  via full update payload
2016-01-11T23:29:05Z kola: Rebooting test machine
Running as unit run-905.service.
2016-01-11T23:29:17Z kola: Checking for boot from USR-B partition
2016-01-11T23:29:17Z kola: Update complete!
```