### PR TITLE
coreos.verity.corruption

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -15,7 +15,6 @@
 package kola
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -52,8 +51,6 @@ var (
 	TestParallelism int //glue var to set test parallelism from main
 
 	testOptions = make(map[string]string, 0)
-
-	Skip = errors.New("test skipped")
 )
 
 // RegisterTestOption registers any options that need visibility inside
@@ -175,7 +172,7 @@ func RunTests(pattern, pltfrm string) error {
 		t := r.test
 		err := r.result
 		seconds := r.duration.Seconds()
-		if err != nil && err == Skip {
+		if err != nil && err == register.Skip {
 			plog.Errorf("--- SKIP: %s on %s (%.3fs)", t.Name, pltfrm, seconds)
 			skipped++
 		} else if err != nil {

--- a/kola/register/register.go
+++ b/kola/register/register.go
@@ -14,7 +14,15 @@
 
 package register
 
-import "github.com/coreos/mantle/platform"
+import (
+	"errors"
+
+	"github.com/coreos/mantle/platform"
+)
+
+// Skip is a sentinel value that can be returned by tests that are skipped
+// rather than passing or failing.
+var Skip = errors.New("test skipped")
 
 // Test provides the main test abstraction for kola. The run function is
 // the actual testing function while the other fields provide ways to

--- a/kola/tests/misc/verity.go
+++ b/kola/tests/misc/verity.go
@@ -17,6 +17,7 @@ package misc
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/platform"
@@ -29,7 +30,16 @@ func init() {
 		Name:        "coreos.verity.verify",
 		Platforms:   []string{"qemu", "aws", "gce"},
 	})
+	register.Register(&register.Test{
+		Run:         VerityCorruption,
+		ClusterSize: 1,
+		Name:        "coreos.verity.corruption",
+		Platforms:   []string{"qemu", "aws", "gce"},
+	})
 }
+
+// Verity verification tests.
+// TODO(mischief): seems like a good candidate for kolet.
 
 // VerityVerify asserts that the filesystem mounted on /usr matches the
 // dm-verity hash that is embedded in the CoreOS kernel.
@@ -48,6 +58,15 @@ func VerityVerify(c platform.TestCluster) error {
 		return fmt.Errorf("failed to find device for /usr: %v: %v", usrdev, err)
 	}
 
+	// XXX: if the /usr dev is /dev/mapper/usr, we're on a verity enabled
+	// image, so use dmsetup to find the real device.
+	if strings.TrimSpace(string(usrdev)) == "/dev/mapper/usr" {
+		usrdev, err = m.SSH("echo -n /dev/$(sudo dmsetup info --noheadings -Co blkdevs_used usr)")
+		if err != nil {
+			return fmt.Errorf("failed to find device for /usr: %v: %v", usrdev, err)
+		}
+	}
+
 	// figure out partition size for hash dev offset
 	offset, err := m.SSH("sudo e2size " + string(usrdev))
 	if err != nil {
@@ -60,6 +79,79 @@ func VerityVerify(c platform.TestCluster) error {
 	verify, err := m.SSH(veritycmd)
 	if err != nil {
 		return fmt.Errorf("verity hash verification on %s failed: %v: %v", usrdev, verify, err)
+	}
+
+	return nil
+}
+
+// VerityCorruption asserts that a machine will fail to read a file from a
+// verify filesystem whose blocks have been modified.
+func VerityCorruption(c platform.TestCluster) error {
+	m := c.Machines()[0]
+	// figure out if we are actually using verity
+	out, err := m.SSH("sudo veritysetup status usr")
+	if err != nil && bytes.Equal(out, []byte("/dev/mapper/usr is inactive.")) {
+		// verity not in use, so skip.
+		return register.Skip
+	} else if err != nil {
+		return fmt.Errorf("failed checking verity status: %s: %v", out, err)
+	}
+
+	// assert that dm shows verity is in use and the device is valid (V)
+	out, err = m.SSH("sudo dmsetup --target verity status usr")
+	if err != nil {
+		return fmt.Errorf("failed checking dmsetup status of usr: %s: %v", out, err)
+	}
+
+	fields := strings.Fields(string(out))
+	if len(fields) != 4 {
+		return fmt.Errorf("failed checking dmsetup status of usr: not enough fields in output (got %d)", len(fields))
+	}
+
+	if fields[3] != "V" {
+		return fmt.Errorf("dmsetup status usr reports verity is not valid!")
+	}
+
+	// corrupt a file on disk and flush disk caches.
+	// try setting NAME=CoreOS to NAME=LulzOS in /usr/lib/os-release
+
+	// get usr device, probably vda3
+	usrdev, err := m.SSH("echo /dev/$(sudo dmsetup info --noheadings -Co blkdevs_used usr)")
+	if err != nil {
+		return fmt.Errorf("failed getting /usr device from dmsetup: %s: %v", out, err)
+	}
+
+	// poke bytes into /usr/lib/os-release
+	out, err = m.SSH(fmt.Sprintf(`echo NAME=LulzOS | sudo dd of=%s seek=$(expr $(sudo debugfs -R "blocks /lib/os-release" %s 2>/dev/null) \* 4096) bs=1 2>/dev/null`, usrdev, usrdev))
+	if err != nil {
+		return fmt.Errorf("failed overwriting disk block: %s: %v", out, err)
+	}
+
+	// make sure we flush everything so cat has to go through to the device backing verity.
+	out, err = m.SSH("sudo /bin/sh -c 'sync; echo -n 3 >/proc/sys/vm/drop_caches'")
+	if err != nil {
+		return fmt.Errorf("failed dropping disk caches: %s: %v", out, err)
+	}
+
+	// read the file back. if we can read it successfully, verity did not do its job.
+	out, err = m.SSH("cat /usr/lib/os-release")
+	if err == nil {
+		return fmt.Errorf("verity did not prevent reading a corrupted file!")
+	}
+
+	// assert that dm shows verity device is now corrupted (C)
+	out, err = m.SSH("sudo dmsetup --target verity status usr")
+	if err != nil {
+		return fmt.Errorf("failed checking dmsetup status of usr: %s: %v", out, err)
+	}
+
+	fields = strings.Fields(string(out))
+	if len(fields) != 4 {
+		return fmt.Errorf("failed checking dmsetup status of usr: not enough fields in output (got %d)", len(fields))
+	}
+
+	if fields[3] != "C" {
+		return fmt.Errorf("dmsetup status usr reports verity is valid after corruption!")
 	}
 
 	return nil


### PR DESCRIPTION
had to move the Skip code to avoid import cycles. sticking it in register seems like a poor choice but it seemed like the best for now.