### PR TITLE
kola/tests/misc: add coreos.selinux.enforce

### DIFF
--- a/kola/tests/misc/selinux.go
+++ b/kola/tests/misc/selinux.go
@@ -1,0 +1,56 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package misc
+
+import (
+	"fmt"
+
+	"github.com/coreos/mantle/kola/register"
+	"github.com/coreos/mantle/platform"
+)
+
+func init() {
+	register.Register(&register.Test{
+		Run:         SelinuxEnforce,
+		ClusterSize: 1,
+		Name:        "coreos.selinux.enforce",
+	})
+}
+
+// SelinuxEnforce checks that some basic things work after `setenforce 1`
+func SelinuxEnforce(c platform.TestCluster) error {
+	m := c.Machines()[0]
+
+	for _, cmd := range []struct {
+		cmdline     string
+		checkoutput bool
+		output      string
+	}{
+		{"sudo setenforce 1", false, ""},
+		{"getenforce", true, "Enforcing"},
+		{"systemctl --no-pager is-active system.slice", true, "active"},
+	} {
+		output, err := m.SSH(cmd.cmdline)
+		if err != nil {
+			return fmt.Errorf("failed to run %q: output: %q status: %q", cmd.cmdline, output, err)
+		}
+
+		if cmd.checkoutput && string(output) != cmd.output {
+			return fmt.Errorf("command %q has unexpected output: want %q got %q", cmd.cmdline, cmd.output, string(output))
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
current output is:

```
$ sudo ./bin/kola --qemu-image /home/mischief/src/coreos/src/build/images/amd64-usr/latest/coreos_production_image.bin run coreos.selinux.enforce
2016-02-19T00:16:24Z kola: === RUN coreos.selinux.enforce on qemu
2016-02-19T00:16:24Z etcdserver: added local member f3620cbbbe7cd162 [http://localhost:0] to cluster 3bd8c6452814d712
2016-02-19T00:16:25Z etcdserver: set the initial cluster version to 2.2
2016-02-19T00:16:45Z network/ntp: NTP server failed: read udp [::]:123: use of closed network connection
2016-02-19T00:16:45Z kola: --- FAIL: coreos.selinux.enforce on qemu (21.497s)
2016-02-19T00:16:45Z kola:         failed to run "systemctl --no-pager is-active system.slice": output: "unknown" status: "Process exited with: 3. Reason was:  ()"
2016-02-19T00:16:45Z kola: 0 passed 1 failed 0 skipped out of 1 total
1 tests failed
```