### PR TITLE
cork: cleanups and fix cloning tags

### DIFF
--- a/cmd/cork/create.go
+++ b/cmd/cork/create.go
@@ -113,8 +113,12 @@ func runCreate(cmd *cobra.Command, args []string) {
 		plog.Fatalf("Create failed: %v", err)
 	}
 
-	if err := sdk.RepoInit(chrootName, manifestURL, manifestName, manifestBranch); err != nil {
-		plog.Fatalf("repo init and sync failed: %v", err)
+	if err := sdk.RepoInit(chrootName, manifestURL, manifestBranch, manifestName); err != nil {
+		plog.Fatalf("repo init failed: %v", err)
+	}
+
+	if err := sdk.RepoSync(chrootName); err != nil {
+		plog.Fatalf("repo sync failed: %v", err)
 	}
 }
 

--- a/sdk/enter.go
+++ b/sdk/enter.go
@@ -462,13 +462,3 @@ func OldEnter(name string, args ...string) error {
 
 	return enterCmd.Run()
 }
-
-func RepoInit(name, manifest, manifestName, branch string) error {
-	if err := Enter(
-		name, "repo", "init", "-u", manifest,
-		"-b", branch, "-m", manifestName); err != nil {
-		return err
-	}
-
-	return Enter(name, "repo", "sync")
-}

--- a/sdk/repo.go
+++ b/sdk/repo.go
@@ -111,3 +111,15 @@ func BuildImageDir(version string) string {
 	dir := defaultGroup + "-" + version
 	return filepath.Join(BuildRoot(), "images", DefaultBoard(), dir)
 }
+
+func RepoInit(chroot, url, branch, name string) error {
+	return Enter(chroot,
+		"repo", "init",
+		"--manifest-url", url,
+		"--manifest-branch", branch,
+		"--manifest-name", name)
+}
+
+func RepoSync(chroot string) error {
+	return Enter(chroot, "repo", "sync", "--no-clone-bundle")
+}

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -70,6 +70,18 @@ func GetSDKVersionFromDir(dir string) (string, error) {
 }
 
 func GetSDKVersionFromRemoteRepo(url, branch string) (string, error) {
+	// git clone cannot be given a full ref path, instead it explicitly checks
+	// under both refs/heads/<name> and refs/tags/<name>, in that order.
+	if strings.HasPrefix(branch, "refs/") {
+		if strings.HasPrefix(branch, "refs/heads/") {
+			branch = strings.TrimPrefix(branch, "refs/heads/")
+		} else if strings.HasPrefix(branch, "refs/tags/") {
+			branch = strings.TrimPrefix(branch, "refs/tags/")
+		} else {
+			return "", fmt.Errorf("SDK version cannot be detected for %q", branch)
+		}
+	}
+
 	tmp, err := ioutil.TempDir("", "")
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This now works:
```
cork create --manifest-name release.xml --manifest-branch refs/tags/v962.0.0
```

Note: although git and cork will handle just the tag name like v962.0.0 the current repo will not and sticks a refs/heads prefix on anything that it feels like. cork could use `git ls-remote` to resolve names given to repo but that a difference in behavior between cork and repo itself may be confusing.