### PR TITLE
util: add targen, a package that can generate tarballs of binaries

### DIFF
--- a/system/targen/ldd.go
+++ b/system/targen/ldd.go
@@ -1,0 +1,57 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package targen
+
+import (
+	"bufio"
+	"bytes"
+	"path/filepath"
+	"strings"
+
+	"github.com/coreos/mantle/system/exec"
+)
+
+// return a slice of strings that are the library dependencies of binary.
+// returns a nil slice if the binary is static
+func ldd(binary string) ([]string, error) {
+	c := exec.Command("ldd", binary)
+
+	// let's not get LD_PRELOAD invovled.
+	c.Env = []string{}
+
+	out, err := c.CombinedOutput()
+	if err != nil {
+		// static binaries have no libs (barring dlopened ones, which we can't find)
+		if strings.Contains(string(out), "not a dynamic executable") {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	buf := bytes.NewBuffer(out)
+	sc := bufio.NewScanner(buf)
+	sc.Split(bufio.ScanWords)
+
+	var libs []string
+	for sc.Scan() {
+		w := sc.Text()
+		if filepath.IsAbs(w) {
+			libs = append(libs, w)
+		}
+	}
+
+	return libs, nil
+}

--- a/system/targen/ldd_test.go
+++ b/system/targen/ldd_test.go
@@ -1,0 +1,33 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package targen
+
+import (
+	"testing"
+)
+
+func TestLdd(t *testing.T) {
+	bin := "/bin/sh"
+	deps, err := ldd(bin)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(deps) == 0 {
+		t.Fatalf("no deps of %q", bin)
+	}
+
+	t.Logf("%+v", deps)
+}

--- a/system/targen/tar.go
+++ b/system/targen/tar.go
@@ -1,0 +1,145 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// exec is extension of the standard os.exec package.
+// Adds a handy dandy interface and assorted other features.
+
+package targen
+
+import (
+	"archive/tar"
+	"io"
+	"os"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/coreos/pkg/capnslog"
+)
+
+var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "targen")
+
+type TarGen struct {
+	files    []string
+	binaries []string
+}
+
+func New() *TarGen {
+	return &TarGen{}
+}
+
+func (t *TarGen) AddFile(path string) *TarGen {
+	plog.Tracef("adding file %q", path)
+	t.files = append(t.files, path)
+	return t
+}
+
+func (t *TarGen) AddBinary(path string) *TarGen {
+	plog.Tracef("adding binary %q", path)
+	t.binaries = append(t.binaries, path)
+	return t
+}
+
+func tarWriteFile(tw *tar.Writer, file string) error {
+	plog.Tracef("writing file %q", file)
+
+	st, err := os.Stat(file)
+	if err != nil {
+		return err
+	}
+	hdr := &tar.Header{
+		Name:    file,
+		Size:    st.Size(),
+		Mode:    int64(st.Mode()),
+		ModTime: st.ModTime(),
+	}
+
+	if err = tw.WriteHeader(hdr); err != nil {
+		return err
+	}
+
+	f, err := os.Open(file)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	if _, err := io.Copy(tw, f); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *TarGen) Generate(w io.Writer) error {
+	tw := tar.NewWriter(w)
+
+	// store processed files here so we skip duplicates.
+	copied := make(map[string]struct{})
+
+	for _, file := range t.files {
+		if _, ok := copied[file]; ok {
+			plog.Tracef("skipping duplicate file %q", file)
+			continue
+		}
+
+		plog.Tracef("copying file %q", file)
+
+		if err := tarWriteFile(tw, file); err != nil {
+			return err
+		}
+
+		copied[file] = struct{}{}
+	}
+
+	for _, binary := range t.binaries {
+		libs, err := ldd(binary)
+		if err != nil {
+			return err
+		}
+
+		for _, lib := range libs {
+			if _, ok := copied[lib]; ok {
+				plog.Tracef("skipping duplicate library %q", lib)
+
+				continue
+			}
+
+			plog.Tracef("copying library %q", lib)
+
+			if err := tarWriteFile(tw, lib); err != nil {
+				return err
+			}
+
+			copied[lib] = struct{}{}
+		}
+
+		if _, ok := copied[binary]; ok {
+			plog.Tracef("skipping duplicate binary %q", binary)
+			continue
+		}
+
+		plog.Tracef("copying binary %q", binary)
+
+		if err := tarWriteFile(tw, binary); err != nil {
+			return err
+		}
+
+		copied[binary] = struct{}{}
+	}
+
+	if err := tw.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/system/targen/tar_test.go
+++ b/system/targen/tar_test.go
@@ -1,0 +1,87 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// exec is extension of the standard os.exec package.
+// Adds a handy dandy interface and assorted other features.
+
+package targen
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/coreos/pkg/capnslog"
+)
+
+func TestTarGenBinary(t *testing.T) {
+	if testing.Verbose() {
+		capnslog.SetGlobalLogLevel(capnslog.TRACE)
+	}
+
+	bins := []string{"/bin/sh", "/bin/ls"}
+	buf := new(bytes.Buffer)
+
+	tg := New()
+
+	for _, bin := range bins {
+		tg.AddBinary(bin)
+	}
+
+	err := tg.Generate(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := bytes.NewReader(buf.Bytes())
+	tr := tar.NewReader(r)
+
+	tarfiles := make(map[string]struct{})
+
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			// end of tar archive
+			break
+		}
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Logf("tar file %q", hdr.Name)
+
+		// check dups
+		if _, ok := tarfiles[hdr.Name]; ok {
+			t.Fatalf("found duplicate file %q", hdr.Name)
+		}
+
+		tarfiles[hdr.Name] = struct{}{}
+	}
+
+	for _, bin := range bins {
+		libs, err := ldd(bin)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		libs = append(libs, bin)
+		for _, file := range libs {
+			if _, ok := tarfiles[file]; !ok {
+				t.Fatalf("file %q is missing from the tarball", file)
+			}
+		}
+	}
+}

--- a/test
+++ b/test
@@ -15,8 +15,12 @@ COVER=${COVER:-"-cover"}
 source ./env
 
 TESTABLE="auth cli index kola kola/register network network/ntp network/omaha
-	platform platform/local sdk sdk/omaha system system/exec system/user
-	util version"
+	platform platform/local
+	sdk sdk/omaha
+	system system/exec system/targen system/user
+	util
+	version"
+
 FORMATTABLE="$TESTABLE cmd/cork cmd/kola cmd/kolet cmd/ore cmd/plume"
 
 # user has not provided PKG override


### PR DESCRIPTION
test output:

```
$ go test -v
=== RUN   TestLdd
--- PASS: TestLdd (0.01s)
        ldd_test.go:32: [/lib64/libreadline.so.6 /lib64/libncurses.so.5 /lib64/libc.so.6 /lib64/ld-linux-x86-64.so.2]
=== RUN   TestTarGenBinary
2016-02-26 13:29:36.353377 T | targen: adding binary "/bin/sh"
2016-02-26 13:29:36.353482 T | targen: adding binary "/bin/ls"
2016-02-26 13:29:36.359849 T | targen: copying library "/lib64/libreadline.so.6"
2016-02-26 13:29:36.359871 T | targen: writing file "/lib64/libreadline.so.6"
2016-02-26 13:29:36.360441 T | targen: copying library "/lib64/libncurses.so.5"
2016-02-26 13:29:36.360466 T | targen: writing file "/lib64/libncurses.so.5"
2016-02-26 13:29:36.362728 T | targen: copying library "/lib64/libc.so.6"
2016-02-26 13:29:36.362799 T | targen: writing file "/lib64/libc.so.6"
2016-02-26 13:29:36.369105 T | targen: copying library "/lib64/ld-linux-x86-64.so.2"
2016-02-26 13:29:36.369123 T | targen: writing file "/lib64/ld-linux-x86-64.so.2"
2016-02-26 13:29:36.369299 T | targen: copying binary "/bin/sh"
2016-02-26 13:29:36.369312 T | targen: writing file "/bin/sh"
2016-02-26 13:29:36.378514 T | targen: copying library "/lib64/libcap.so.2"
2016-02-26 13:29:36.378577 T | targen: writing file "/lib64/libcap.so.2"
2016-02-26 13:29:36.378878 T | targen: copying library "/lib64/libacl.so.1"
2016-02-26 13:29:36.378911 T | targen: writing file "/lib64/libacl.so.1"
2016-02-26 13:29:36.379162 T | targen: skipping duplicate library "/lib64/libc.so.6"
2016-02-26 13:29:36.379242 T | targen: copying library "/lib64/libattr.so.1"
2016-02-26 13:29:36.379268 T | targen: writing file "/lib64/libattr.so.1"
2016-02-26 13:29:36.379455 T | targen: skipping duplicate library "/lib64/ld-linux-x86-64.so.2"
2016-02-26 13:29:36.379480 T | targen: copying binary "/bin/ls"
2016-02-26 13:29:36.379494 T | targen: writing file "/bin/ls"
--- PASS: TestTarGenBinary (0.04s)
        tar_test.go:64: tar file "/lib64/libreadline.so.6"
        tar_test.go:64: tar file "/lib64/libncurses.so.5"
        tar_test.go:64: tar file "/lib64/libc.so.6"
        tar_test.go:64: tar file "/lib64/ld-linux-x86-64.so.2"
        tar_test.go:64: tar file "/bin/sh"
        tar_test.go:64: tar file "/lib64/libcap.so.2"
        tar_test.go:64: tar file "/lib64/libacl.so.1"
        tar_test.go:64: tar file "/lib64/libattr.so.1"
        tar_test.go:64: tar file "/bin/ls"
PASS
ok      github.com/coreos/mantle/util/targen    0.055s
```