### PR TITLE
sdk: fix enter

### DIFF
--- a/sdk/enter.go
+++ b/sdk/enter.go
@@ -459,7 +459,7 @@ func Enter(name string, args ...string) error {
 		cmd = append(cmd, args...)
 	}
 	// the directory doesn't matter here, sudo -i will chdir to $HOME
-	return enterChroot(name, "/", args...)
+	return enterChroot(name, "/", cmd...)
 }
 
 func OldEnter(name string, args ...string) error {


### PR DESCRIPTION
Commit f1c32301 was broken, I apparently renamed a variable during a
rebase and didn't retest it. Good grief.