### PR TITLE
repo: start basic repo re-implementation in Go

### DIFF
--- a/sdk/repo/manifest.go
+++ b/sdk/repo/manifest.go
@@ -1,0 +1,451 @@
+// Copyright 2016 CoreOS, Inc.
+// Copyright 2008 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// repo is a limited implementation of the python repo git front end.
+//
+// Manifest Format
+//
+// A repo manifest describes the structure of a repo client; that is
+// the directories that are visible and where they should be obtained
+// from with git.
+//
+// The basic structure of a manifest is a bare Git repository holding
+// a single 'default.xml' XML file in the top level directory.
+//
+// Manifests are inherently version controlled, since they are kept
+// within a Git repository.  Updates to manifests are automatically
+// obtained by clients during `repo sync`.
+//
+// A manifest XML file (e.g. 'default.xml') roughly conforms to the
+// following DTD. The python code is the only authoritative source.
+//
+// Local Manifests
+//
+// Additional remotes and projects may be added through local manifest
+// files stored in `$TOP_DIR/.repo/local_manifests/*.xml`.
+//
+// For example:
+//
+//   $ ls .repo/local_manifests
+//   local_manifest.xml
+//   another_local_manifest.xml
+//
+//   $ cat .repo/local_manifests/local_manifest.xml
+//   <?xml version="1.0" encoding="UTF-8"?>
+//   <manifest>
+//     <project path="manifest"
+//              name="tools/manifest" />
+//     <project path="platform-manifest"
+//              name="platform/manifest" />
+//   </manifest>
+//
+// Users may add projects to the local manifest(s) prior to a `repo sync`
+// invocation, instructing repo to automatically download and manage
+// these extra projects.
+//
+// Manifest files stored in `$TOP_DIR/.repo/local_manifests/*.xml` will
+// be loaded in alphabetical order.
+//
+// Additional remotes and projects may also be added through a local
+// manifest, stored in `$TOP_DIR/.repo/local_manifest.xml`. This method
+// is deprecated in favor of using multiple manifest files as mentioned
+// above.
+//
+// If `$TOP_DIR/.repo/local_manifest.xml` exists, it will be loaded before
+// any manifest files stored in `$TOP_DIR/.repo/local_manifests/*.xml`.
+package repo
+
+import (
+	"encoding/xml"
+)
+
+// Manifest is the root element of the file.
+//
+//    <!ELEMENT manifest (notice?,
+//                        remote*,
+//                        default?,
+//                        manifest-server?,
+//                        project*,
+//                        extend-project*,
+//                        remove-project*,
+//                        repo-hooks?)>
+//
+//    <!ELEMENT notice (#PCDATA)>
+//
+type Manifest struct {
+	XMLName        xml.Name        `xml:"manifest"`
+	Notice         string          `xml:"notice"`
+	Remotes        []Remote        `xml:"remote"`
+	Default        *Default        `xml:"default"`
+	ManifestServer *ManifestServer `xml:"manifest-server"`
+	Projects       []Project       `xml:"project"`
+	ExtendProjects []ExtendProject `xml:"extend-project"`
+	RemoveProjects []RemoveProject `xml:"remove-project"`
+	RepoHooks      *RepoHooks      `xml:"repo-hooks"`
+}
+
+// Remote
+//
+//    <!ELEMENT remote (EMPTY)>
+//    <!ATTLIST remote name         ID    #REQUIRED>
+//    <!ATTLIST remote alias        CDATA #IMPLIED>
+//    <!ATTLIST remote fetch        CDATA #REQUIRED>
+//    <!ATTLIST remote review       CDATA #IMPLIED>
+//    <!ATTLIST remote revision     CDATA #IMPLIED>
+//
+// One or more remote elements may be specified.  Each remote element
+// specifies a Git URL shared by one or more projects and (optionally)
+// the Gerrit review server those projects upload changes through.
+//
+// Attribute `name`: A short name unique to this manifest file.  The
+// name specified here is used as the remote name in each project's
+// .git/config, and is therefore automatically available to commands
+// like `git fetch`, `git remote`, `git pull` and `git push`.
+//
+// Attribute `alias`: The alias, if specified, is used to override
+// `name` to be set as the remote name in each project's .git/config.
+// Its value can be duplicated while attribute `name` has to be unique
+// in the manifest file. This helps each project to be able to have
+// same remote name which actually points to different remote url.
+//
+// Attribute `fetch`: The Git URL prefix for all projects which use
+// this remote.  Each project's name is appended to this prefix to
+// form the actual URL used to clone the project.
+//
+// Attribute `review`: Hostname of the Gerrit server where reviews
+// are uploaded to by `repo upload`.  This attribute is optional;
+// if not specified then `repo upload` will not function.
+//
+// Attribute `revision`: Name of a Git branch (e.g. `master` or
+// `refs/heads/master`). Remotes with their own revision will override
+// the default revision.
+//
+type Remote struct {
+	Name     string `xml:"name,attr"`
+	Alias    string `xml:"alias,attr,omitempty"`
+	Fetch    string `xml:"fetch,attr"`
+	Review   string `xml:"review,attr,omitempty"`
+	Revision string `xml:"revision,attr,omitempty"`
+}
+
+// Default
+//
+//    <!ELEMENT default (EMPTY)>
+//    <!ATTLIST default remote      IDREF #IMPLIED>
+//    <!ATTLIST default revision    CDATA #IMPLIED>
+//    <!ATTLIST default dest-branch CDATA #IMPLIED>
+//    <!ATTLIST default sync-j      CDATA #IMPLIED>
+//    <!ATTLIST default sync-c      CDATA #IMPLIED>
+//    <!ATTLIST default sync-s      CDATA #IMPLIED>
+//
+// At most one default element may be specified.  Its remote and
+// revision attributes are used when a project element does not
+// specify its own remote or revision attribute.
+//
+// Attribute `remote`: Name of a previously defined remote element.
+// Project elements lacking a remote attribute of their own will use
+// this remote.
+//
+// Attribute `revision`: Name of a Git branch (e.g. `master` or
+// `refs/heads/master`).  Project elements lacking their own
+// revision attribute will use this revision.
+//
+// Attribute `dest-branch`: Name of a Git branch (e.g. `master`).
+// Project elements not setting their own `dest-branch` will inherit
+// this value. If this value is not set, projects will use `revision`
+// by default instead.
+//
+// Attribute `sync-j`: Number of parallel jobs to use when synching.
+//
+// Attribute `sync-c`: Set to true to only sync the given Git
+// branch (specified in the `revision` attribute) rather than the
+// whole ref space.  Project elements lacking a sync-c element of
+// their own will use this value.
+//
+// Attribute `sync-s`: Set to true to also sync sub-projects.
+//
+type Default struct {
+	Remote          string `xml:"remote,attr,omitempty"`
+	Revision        string `xml:"revision,attr,omitempty"`
+	DestBranch      string `xml:"dest-branch,attr,omitempty"`
+	SyncJobs        string `xml:"sync-j,attr,omitempty"`
+	SyncBranch      string `xml:"sync-c,attr,omitempty"`
+	SyncSubProjects string `xml:"sync-s,attr,omitempty"`
+}
+
+// ManifestServer
+//
+//    <!ELEMENT manifest-server (EMPTY)>
+//    <!ATTLIST url              CDATA #REQUIRED>
+//
+// At most one manifest-server may be specified. The url attribute
+// is used to specify the URL of a manifest server, which is an
+// XML RPC service.
+//
+// The manifest server should implement the following RPC methods:
+//
+//   GetApprovedManifest(branch, target)
+//
+// Return a manifest in which each project is pegged to a known good revision
+// for the current branch and target.
+//
+// The target to use is defined by environment variables TARGET_PRODUCT
+// and TARGET_BUILD_VARIANT. These variables are used to create a string
+// of the form $TARGET_PRODUCT-$TARGET_BUILD_VARIANT, e.g. passion-userdebug.
+// If one of those variables or both are not present, the program will call
+// GetApprovedManifest without the target parameter and the manifest server
+// should choose a reasonable default target.
+//
+//   GetManifest(tag)
+//
+// Return a manifest in which each project is pegged to the revision at
+// the specified tag.
+//
+type ManifestServer struct {
+	URL string `xml:"url,attr"`
+}
+
+// Project
+//
+//    <!ELEMENT project (annotation*,
+//                       project*,
+//                       copyfile*,
+//                       linkfile*)>
+//    <!ATTLIST project name        CDATA #REQUIRED>
+//    <!ATTLIST project path        CDATA #IMPLIED>
+//    <!ATTLIST project remote      IDREF #IMPLIED>
+//    <!ATTLIST project revision    CDATA #IMPLIED>
+//    <!ATTLIST project dest-branch CDATA #IMPLIED>
+//    <!ATTLIST project groups      CDATA #IMPLIED>
+//    <!ATTLIST project sync-c      CDATA #IMPLIED>
+//    <!ATTLIST project sync-s      CDATA #IMPLIED>
+//    <!ATTLIST project upstream    CDATA #IMPLIED>
+//    <!ATTLIST project clone-depth CDATA #IMPLIED>
+//    <!ATTLIST project force-path  CDATA #IMPLIED>
+//
+// One or more project elements may be specified.  Each element
+// describes a single Git repository to be cloned into the repo
+// client workspace.  You may specify Git-submodules by creating a
+// nested project.  Git-submodules will be automatically
+// recognized and inherit their parent's attributes, but those
+// may be overridden by an explicitly specified project element.
+//
+// Attribute `name`: A unique name for this project.  The project's
+// name is appended onto its remote's fetch URL to generate the actual
+// URL to configure the Git remote with.  The URL gets formed as:
+//
+//   ${remote_fetch}/${project_name}.git
+//
+// where ${remote_fetch} is the remote's fetch attribute and
+// ${project_name} is the project's name attribute.  The suffix ".git"
+// is always appended as repo assumes the upstream is a forest of
+// bare Git repositories.  If the project has a parent element, its
+// name will be prefixed by the parent's.
+//
+// The project name must match the name Gerrit knows, if Gerrit is
+// being used for code reviews.
+//
+// Attribute `path`: An optional path relative to the top directory
+// of the repo client where the Git working directory for this project
+// should be placed.  If not supplied the project name is used.
+// If the project has a parent element, its path will be prefixed
+// by the parent's.
+//
+// Attribute `remote`: Name of a previously defined remote element.
+// If not supplied the remote given by the default element is used.
+//
+// Attribute `revision`: Name of the Git branch the manifest wants
+// to track for this project.  Names can be relative to refs/heads
+// (e.g. just "master") or absolute (e.g. "refs/heads/master").
+// Tags and/or explicit SHA-1s should work in theory, but have not
+// been extensively tested.  If not supplied the revision given by
+// the remote element is used if applicable, else the default
+// element is used.
+//
+// Attribute `dest-branch`: Name of a Git branch (e.g. `master`).
+// When using `repo upload`, changes will be submitted for code
+// review on this branch. If unspecified both here and in the
+// default element, `revision` is used instead.
+//
+// Attribute `groups`: List of groups to which this project belongs,
+// whitespace or comma separated.  All projects belong to the group
+// "all", and each project automatically belongs to a group of
+// its name:`name` and path:`path`.  E.g. for
+// <project name="monkeys" path="barrel-of"/>, that project
+// definition is implicitly in the following manifest groups:
+// default, name:monkeys, and path:barrel-of.  If you place a project in the
+// group "notdefault", it will not be automatically downloaded by repo.
+// If the project has a parent element, the `name` and `path` here
+// are the prefixed ones.
+//
+// Attribute `sync-c`: Set to true to only sync the given Git
+// branch (specified in the `revision` attribute) rather than the
+// whole ref space.
+//
+// Attribute `sync-s`: Set to true to also sync sub-projects.
+//
+// Attribute `upstream`: Name of the Git ref in which a sha1
+// can be found.  Used when syncing a revision locked manifest in
+// -c mode to avoid having to sync the entire ref space.
+//
+// Attribute `clone-depth`: Set the depth to use when fetching this
+// project.  If specified, this value will override any value given
+// to repo init with the --depth option on the command line.
+//
+// Attribute `force-path`: Set to true to force this project to create the
+// local mirror repository according to its `path` attribute (if supplied)
+// rather than the `name` attribute.  This attribute only applies to the
+// local mirrors syncing, it will be ignored when syncing the projects in a
+// client working directory.
+//
+type Project struct {
+	Annotations     []Annotation `xml:"annotation"`
+	SubProjects     []Project    `xml:"project"`
+	CopyFiles       []CopyFile   `xml:"copyfile"`
+	LinkFiles       []LinkFile   `xml:"linkfile"`
+	Name            string       `xml:"name,attr"`
+	Path            string       `xml:"path,attr,omitempty"`
+	Remote          string       `xml:"remote,attr,omitempty"`
+	Revision        string       `xml:"revision,attr,omitempty"`
+	DestBranch      string       `xml:"dest-branch,attr,omitempty"`
+	Groups          string       `xml:"groups,attr,omitempty"`
+	SyncBranch      string       `xml:"sync-c,attr,omitempty"`
+	SyncSubProjects string       `xml:"sync-s,attr,omitempty"`
+	Upstream        string       `xml:"upstream,attr,omitempty"`
+	CloneDepth      string       `xml:"clone-depth,attr,omitempty"`
+	ForcePath       string       `xml:"force-path,attr,omitempty"`
+}
+
+// ExtendProject
+//
+//    <!ELEMENT extend-project>
+//    <!ATTLIST extend-project name   CDATA #REQUIRED>
+//    <!ATTLIST extend-project path   CDATA #IMPLIED>
+//    <!ATTLIST extend-project groups CDATA #IMPLIED>
+//
+// Modify the attributes of the named project.
+//
+// This element is mostly useful in a local manifest file, to modify the
+// attributes of an existing project without completely replacing the
+// existing project definition.  This makes the local manifest more robust
+// against changes to the original manifest.
+//
+// Attribute `path`: If specified, limit the change to projects checked out
+// at the specified path, rather than all projects with the given name.
+//
+// Attribute `groups`: List of additional groups to which this project
+// belongs.  Same syntax as the corresponding element of `project`.
+//
+type ExtendProject struct {
+	Name   string `xml:"name,attr"`
+	Path   string `xml:"path,attr,omitempty"`
+	Groups string `xml:"groups,attr,omitempty"`
+}
+
+// Annotation
+//
+//    <!ELEMENT annotation (EMPTY)>
+//    <!ATTLIST annotation name  CDATA #REQUIRED>
+//    <!ATTLIST annotation value CDATA #REQUIRED>
+//    <!ATTLIST annotation keep  CDATA "true">
+//
+// Zero or more annotation elements may be specified as children of a
+// project element. Each element describes a name-value pair that will be
+// exported into each project's environment during a 'forall' command,
+// prefixed with REPO__.  In addition, there is an optional attribute
+// "keep" which accepts the case insensitive values "true" (default) or
+// "false".  This attribute determines whether or not the annotation will
+// be kept when exported with the manifest subcommand.
+//
+type Annotation struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+	Keep  string `xml:"keep,attr,omitempty"`
+}
+
+// CopyFile
+//
+//    <!ELEMENT copyfile (EMPTY)>
+//    <!ATTLIST src value  CDATA #REQUIRED>
+//    <!ATTLIST dest value CDATA #REQUIRED>
+//
+// Zero or more copyfile elements may be specified as children of a
+// project element. Each element describes a src-dest pair of files;
+// the "src" file will be copied to the "dest" place during 'repo sync'
+// command.
+// "src" is project relative, "dest" is relative to the top of the tree.
+//
+type CopyFile struct {
+	Src  string `xml:"src,attr"`
+	Dest string `xml:"dest,attr"`
+}
+
+// LinkFile
+//
+//    <!ELEMENT linkfile (EMPTY)>
+//    <!ATTLIST src value  CDATA #REQUIRED>
+//    <!ATTLIST dest value CDATA #REQUIRED>
+//
+// It's just like copyfile and runs at the same time as copyfile but
+// instead of copying it creates a symlink.
+//
+type LinkFile struct {
+	Src  string `xml:"src,attr"`
+	Dest string `xml:"dest,attr"`
+}
+
+// RemoveProject
+//
+//    <!ELEMENT remove-project (EMPTY)>
+//    <!ATTLIST remove-project name CDATA #REQUIRED>
+//
+// Deletes the named project from the internal manifest table, possibly
+// allowing a subsequent project element in the same manifest file to
+// replace the project with a different source.
+//
+// This element is mostly useful in a local manifest file, where
+// the user can remove a project, and possibly replace it with their
+// own definition.
+//
+type RemoveProject struct {
+	Name string `xml:"name,attr"`
+}
+
+// RepoHooks
+//
+//    <!ELEMENT repo-hooks (EMPTY)>
+//    <!ATTLIST repo-hooks in-project   CDATA #REQUIRED>
+//    <!ATTLIST repo-hooks enabled-list CDATA #REQUIRED>
+//
+type RepoHooks struct {
+	InProject   string `xml:"in-project,attr"`
+	EnabledList string `xml:"enabled-list,attr"`
+}
+
+// Include
+//
+//    <!ELEMENT include      (EMPTY)>
+//    <!ATTLIST include name CDATA #REQUIRED>
+//
+// This element provides the capability of including another manifest
+// file into the originating manifest.  Normal rules apply for the
+// target manifest to include - it must be a usable manifest on its own.
+//
+// Attribute `name`: the manifest to include, specified relative to
+// the manifest repository's root.
+//
+type Include struct {
+	Name string `xml:"name,attr"`
+}

--- a/sdk/repo/manifest_test.go
+++ b/sdk/repo/manifest_test.go
@@ -1,0 +1,95 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repo
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/kylelemons/godebug/diff"
+)
+
+// Test manifest document, this is mostly identical to the output of
+// `repo manifest -r` except self-closing tags not used (Go doesn't
+// output them) and attribute order is a bit different, Go uses struct
+// order but Python alphabetizes.
+const testManifest = `<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <notice>Your sources have been synced successfully.</notice>
+  <remote name="cros" fetch="https://chromium.googlesource.com/" review="gerrit.chromium.org/gerrit"></remote>
+  <remote name="github" fetch=".."></remote>
+  <remote name="private" fetch="ssh://git@github.com"></remote>
+  <default remote="github" revision="refs/heads/master" sync-j="4"></default>
+  <project name="appc/acbuild" path="src/third_party/appc-acbuild" revision="dd71391585dd0e96e56877d650ff1030cd7d9b01" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="appc/spec" path="src/third_party/appc-spec" revision="62d46939da30111dc3eae51dd36ad5cd146dd964" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="chromiumos/platform/crostestutils" path="src/platform/crostestutils" remote="cros" revision="35331923b30e031a3b3573533bb3b411453d1273" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="chromiumos/platform/factory-utils" path="src/platform/factory-utils" remote="cros" revision="f2e4d8c1e0753c385f34d7be8b3f4ceb3ab17abe" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="chromiumos/repohooks" path="src/repohooks" remote="cros" revision="7a610e823d287f3a1f796100b2a3d11da83de89e" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="chromiumos/third_party/pyelftools" path="chromite/third_party/pyelftools" remote="cros" revision="bdc1d380acd88d4bfaf47265008091483b0d614e" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/baselayout" path="src/third_party/baselayout" revision="fa6fe343b60a6ca694137048278d06aeeba051b6" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/bootengine" path="src/third_party/bootengine" revision="09766b249af4190eef69cccd6609cebab7f6a8b4" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/chromite" path="chromite" revision="f3db21adb76ea48390c5bacc6ae4b70f1037f657" groups="minilayout" upstream="refs/heads/master">
+    <copyfile src="AUTHORS" dest="AUTHORS"></copyfile>
+    <copyfile src="LICENSE" dest="LICENSE"></copyfile>
+  </project>
+  <project name="coreos/coreos-buildbot" path="src/third_party/coreos-buildbot" revision="3e4b20f67839aa541839eca6b4b7274d5ad1932c" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/coreos-cloudinit" path="src/third_party/coreos-cloudinit" revision="b3f805dee6a4aa5ed298a1f370284df470eecf43" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/coreos-metadata" path="src/third_party/coreos-metadata" revision="d976d664051f5b95ab60f7f1770b1b2bcc2877b2" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/coreos-overlay" path="src/third_party/coreos-overlay" revision="c6e011295c7e6c8878f95206c706d53d9294122d" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/coretest" path="src/third_party/coretest" revision="991faaf28eb21f185fed0708b526849a8bc128e6" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/dev-util" path="src/platform/dev" revision="072c33135839b692c6ceb37765e2e0f1a65b416c" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/docker" path="src/third_party/docker" revision="9a9bbacae56d55b45c39751148d967e7d5dfcdfc" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/efunctions" path="src/third_party/efunctions" revision="ecef964cb1eed5c8482ab4c75a23de35fd390584" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/etcd" path="src/third_party/etcd" revision="bfcd39335c6c27d84164c1b1d9e9d65c2e8f39b6" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/etcdctl" path="src/third_party/etcdctl" revision="4c3f5c9fb3441991abf950651be977c3e0eef30e" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/fleet" path="src/third_party/fleet" revision="d605dc00bf2fd4e66f4f79d6ddc56170f53865da" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/grub" path="src/third_party/grub" revision="4ccc609994fe2f5e0911b91a11ad9e4289dc3a04" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/ignition" path="src/third_party/ignition" revision="d4250a015b0d9d9c48338a3644ff3c007dfc7e7d" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/init" path="src/third_party/init" revision="69492d452bc51c4edaa888c69f1fc97fab68c065" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/installer" path="src/platform/installer" revision="95815a7cc15abea574e1b06d9fd403b90b29ba01" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/locksmith" path="src/third_party/locksmith" revision="816e4c4cb05525d43c8aad919eddcc32b4e91619" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/mantle" path="src/third_party/mantle" revision="a6b9288b9078fc02f8ab2f376175abaa20deac5c" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/mayday" path="src/third_party/mayday" revision="85f8b48da25fd6e3c36a9aa1f7d90c19078777ab" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/nss-altfiles" path="src/third_party/nss-altfiles" revision="508d986e38c70bd0636740d287d2fe807822fb57" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/portage-stable" path="src/third_party/portage-stable" revision="b9a47e57b74de596df9bf5da28b85aad105781e3" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/rkt" path="src/third_party/rkt" revision="debc46e5c8b4f1e8519033f5c5ffefe07f7bc3fe" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/scripts" path="src/scripts" revision="b77aa4d24876ed86de834e5dc3c715eaae1ddc92" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/sdnotify-proxy" path="src/third_party/sdnotify-proxy" revision="bfd0269267d91f3bbe89db49ec8ea8903ae8aa3c" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/seismograph" path="src/third_party/seismograph" revision="a96246842fe43d410cb8a69daef0d96c8fd56a21" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/shim" path="src/third_party/shim" revision="03a1513b0985fd682b13a8d29fe3f1314a704c66" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/sysroot-wrappers" path="src/third_party/sysroot-wrappers" revision="437a7a86a482348828423ffd016b379fb70b0445" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/systemd" path="src/third_party/systemd" revision="e859aa9e993453be321450148d45d08fcc55c3f5" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/toolbox" path="src/third_party/toolbox" revision="45f497d12139b6d823a070cfab7724ead0b8bedd" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/update_engine" path="src/third_party/update_engine" revision="fb89e2500e5b1f31d227db5f82b30c1a87113a12" groups="minilayout" upstream="refs/heads/master"></project>
+  <project name="coreos/updateservicectl" path="src/third_party/updateservicectl" revision="0842a025368e7ad9903bc70fcf5aaf06e1f39652" groups="minilayout" upstream="refs/heads/master"></project>
+  <repo-hooks in-project="chromiumos/repohooks" enabled-list="pre-upload"></repo-hooks>
+</manifest>`
+
+func TestMarshal(t *testing.T) {
+	var manifest Manifest
+	if err := xml.Unmarshal([]byte(testManifest), &manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := xml.MarshalIndent(&manifest, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testResult := xml.Header + string(out)
+	if d := diff.Diff(testManifest, testResult); d != "" {
+		t.Fatalf("Unexpected XML:\n%s", d)
+	}
+}


### PR DESCRIPTION
This piece is a bit verbose, creating data structures for the complete
manifest format (at least approximately the documented manifest format,
differences with the python implementation may exist...). This package's
task is just to test that repo is working properly so it will not
implement the vast majority of its features. Just enough to prase a
manifest and check that the right things are checked out.

Based on docs/manifest-format.txt in repo v1.12.32