### PR TITLE
kola/tests/kubernetes: bump nginx timeout

### DIFF
--- a/kola/tests/kubernetes/smokechecks.go
+++ b/kola/tests/kubernetes/smokechecks.go
@@ -57,7 +57,7 @@ func nginxCheck(master platform.Machine, nodes []platform.Machine) error {
 	}
 	// wait for pod status to be 'Running'
 	podIsRunning := func() error {
-		b, err := master.SSH("./kubectl get pod nginx -o=template -t={{.status.phase}}")
+		b, err := master.SSH("./kubectl get pod nginx --template={{.status.phase}}")
 		if err != nil {
 			return err
 		}
@@ -66,7 +66,7 @@ func nginxCheck(master platform.Machine, nodes []platform.Machine) error {
 		}
 		return nil
 	}
-	if err := util.Retry(10, 5*time.Second, podIsRunning); err != nil {
+	if err := util.Retry(10, 10*time.Second, podIsRunning); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
While we are here, fix kubectl flags to avoid deprecation warnings.