### PR TITLE
(WIP) kubernetes conformance tests

### DIFF
--- a/kola/tests/kubernetes/basic.go
+++ b/kola/tests/kubernetes/basic.go
@@ -20,9 +20,57 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/util"
 )
+
+// register a separate test for each version tag
+var basicTags = []string{
+	"v1.1.7_coreos.2",
+	"v1.1.8_coreos.0",
+}
+
+func init() {
+	for i := range basicTags {
+		// use closure to store a version tag in a Test
+		t := basicTags[i]
+		f := func(c platform.TestCluster) error {
+			return CoreOSBasic(c, t)
+		}
+
+		register.Register(&register.Test{
+			Name:        "google.kubernetes.basic." + t,
+			Run:         f,
+			ClusterSize: 0,
+			Platforms:   []string{"gce", "aws"},
+		})
+	}
+}
+
+// Run basic smoke tests on cluster. Assumes master is machine index 1,
+// workers make up the rest.
+func CoreOSBasic(c platform.TestCluster, version string) error {
+	if err := setupCluster(c, 2, version); err != nil {
+		return err
+	}
+
+	master := c.Machines()[1]
+	workers := c.Machines()[2:]
+
+	// start nginx pod and curl endpoint
+	if err := nginxCheck(master, workers); err != nil {
+		return err
+	}
+
+	// http://kubernetes.io/v1.0/docs/user-guide/secrets/ Also, ensures
+	// https://github.com/coreos/bugs/issues/447 does not re-occur.
+	if err := secretCheck(master, workers); err != nil {
+		return err
+	}
+
+	return nil
+}
 
 func nodeCheck(master platform.Machine, nodes []platform.Machine) error {
 	b, err := master.SSH("./kubectl get nodes")

--- a/kola/tests/kubernetes/conformance.go
+++ b/kola/tests/kubernetes/conformance.go
@@ -1,0 +1,85 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"fmt"
+
+	"github.com/coreos/mantle/kola/register"
+	"github.com/coreos/mantle/platform"
+)
+
+// register a separate test for each version tag
+var confTags = []string{
+	"v1.1.7_coreos.2",
+	"v1.1.8_coreos.0",
+}
+
+func init() {
+	for i := range confTags {
+		// use closure to store a version tag in a Test
+		t := confTags[i]
+		f := func(c platform.TestCluster) error {
+			return CoreOSConformance(c, t)
+		}
+
+		register.Register(&register.Test{
+			Name:        "google.kubernetes.conformance." + t,
+			Run:         f,
+			ClusterSize: 0,
+			Platforms:   []string{"gce", "aws"},
+		})
+	}
+}
+
+// Run kubernetes conformance tests. Assumes there is a container with
+// all the upstream test binaries for each version tag.
+func CoreOSConformance(c platform.TestCluster, version string) error {
+	if err := setupCluster(c, 4, version); err != nil {
+		return err
+	}
+	master := c.Machines()[1]
+
+	version, err := stripSemverSuffix(version)
+	if err != nil {
+		return err
+	}
+
+	runTests := `sudo rkt  run \
+		--volume kube,kind=host,source=/home/core \
+		--mount volume=kube,target=/home/core \
+		--net=host \
+		--trust-keys-from-https \
+		quay.io/peanutbutter/kubeconformance:%v \
+		--exec=/bin/bash -- -c \
+		"cd /kubernetes/ && KUBECONFIG=/home/core/.kube/config hack/conformance-test.sh 2>&1"`
+	runTests = fmt.Sprintf(runTests, version)
+	plog.Errorf("%v", runTests)
+
+	b, err := master.SSH(runTests)
+
+	// The exceptional case: all conformance tests pass
+	if err == nil {
+		plog.Noticef("All conformance tests passed!")
+		plog.Noticef("%s", b)
+		return nil
+	}
+	plog.Noticef("%s", b)
+
+	// Check failures against our whitelist and report those.
+
+	// If any failures remain report and fail test
+	return nil
+}

--- a/kola/tests/kubernetes/setup.go
+++ b/kola/tests/kubernetes/setup.go
@@ -22,7 +22,6 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/kola/tests/etcd"
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/util"
@@ -32,33 +31,10 @@ import (
 
 var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "kola/tests/kubernetes")
 
-// register a separate test for each version tag
-var tags = []string{
-	"v1.1.7_coreos.2",
-	"v1.1.8_coreos.0",
-}
-
-func init() {
-	for i := range tags {
-		// use closure to store a version tag in a Test
-		t := tags[i]
-		f := func(c platform.TestCluster) error {
-			return CoreOSBasic(c, t)
-		}
-
-		register.Register(&register.Test{
-			Name:        "google.kubernetes.coreosbasic." + tags[i],
-			Run:         f,
-			ClusterSize: 0,
-			Platforms:   []string{"gce", "aws"},
-		})
-	}
-}
-
-// Start a multi-node cluster from offcial coreos guides on manual
-// installation. Once up, do a couple basic smoke checks. See:
+// Setup a multi-node cluster based on official coreos guides for manual
+// installation.
 // https://coreos.com/kubernetes/docs/latest/getting-started.html
-func CoreOSBasic(c platform.TestCluster, version string) error {
+func setupCluster(c platform.TestCluster, nodes int, version string) error {
 	// start single-node etcd
 	etcdNode, err := c.NewMachine(etcdConfig)
 	if err != nil {
@@ -89,8 +65,8 @@ func CoreOSBasic(c platform.TestCluster, version string) error {
 		return err
 	}
 
-	// create 3 worker nodes
-	workerConfigs := []string{"", "", ""}
+	// create worker nodes
+	workerConfigs := make([]string, nodes)
 	workers, err := platform.NewMachines(c, workerConfigs)
 	if err != nil {
 		return err
@@ -122,17 +98,6 @@ func CoreOSBasic(c platform.TestCluster, version string) error {
 		return nodeCheck(master, workers)
 	}
 	if err := util.Retry(15, 10*time.Second, f); err != nil {
-		return err
-	}
-
-	// start nginx pod and curl endpoint
-	if err = nginxCheck(master, workers); err != nil {
-		return err
-	}
-
-	// http://kubernetes.io/v1.0/docs/user-guide/secrets/ Also, ensures
-	// https://github.com/coreos/bugs/issues/447 does not re-occur.
-	if err = secretCheck(master, workers); err != nil {
 		return err
 	}
 
@@ -232,11 +197,10 @@ func generateWorkerTLSAssets(master platform.Machine, workers []platform.Machine
 
 // https://coreos.com/kubernetes/docs/latest/configure-kubectl.html
 func configureKubectl(m platform.Machine, server string, version string) error {
-	// ignore suffix like '-coreos.1' on version to grab upstream
-	semverPrefix := regexp.MustCompile(`^v[\d]+\.[\d]+\.[\d]+`)
-	version = semverPrefix.FindString(version)
-	if version == "" {
-		return fmt.Errorf("Failure to parse kubectl version")
+	// ignore suffix like '-coreos.1' to grab upstream kubelet
+	version, err := stripSemverSuffix(version)
+	if err != nil {
+		return err
 	}
 
 	var (
@@ -267,6 +231,19 @@ func configureKubectl(m platform.Machine, server string, version string) error {
 		}
 	}
 	return nil
+}
+
+var semverPrefix = regexp.MustCompile(`^v[\d]+\.[\d]+\.[\d]+`)
+
+// Strip semver suffix -- e.g., v1.1.8_coreos.1 --> v1.1.8. If no match
+// found, return error.
+func stripSemverSuffix(v string) (string, error) {
+	v = semverPrefix.FindString(v)
+	if v == "" {
+		return "", fmt.Errorf("error stripping semver suffix")
+	}
+
+	return v, nil
 }
 
 // Run and configure the coreos-kubernetes generic install scripts.


### PR DESCRIPTION
This will run the kubernetes conformance tests on a cluster setup by kola using test binaries pre-built in containers.

Conformance tests are basically a subset of the e2e tests that allow you to pass in an existing cluster. Provider specific tests are not run.

I'll consider this PR ready to submit once I deal with expected errors from the conformance test output. Right now i'm just trying to create a whitelist of errors for each version we test. Any errors outside the whitelist will cause the test to report the errors and fail.
