### PR TITLE
lang: create a new package for language utilities

### DIFF
--- a/lang/destructor/destructor.go
+++ b/lang/destructor/destructor.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package destructor
 
 import (
 	"io"

--- a/lang/doc.go
+++ b/lang/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// lang provides an assortment of Go language utilities
+package lang

--- a/platform/local/cluster.go
+++ b/platform/local/cluster.go
@@ -24,15 +24,15 @@ import (
 
 	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/vishvananda/netlink"
 	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/vishvananda/netns"
+	"github.com/coreos/mantle/lang/destructor"
 	"github.com/coreos/mantle/network"
 	"github.com/coreos/mantle/network/ntp"
 	"github.com/coreos/mantle/network/omaha"
 	"github.com/coreos/mantle/system/exec"
-	"github.com/coreos/mantle/util"
 )
 
 type LocalCluster struct {
-	util.MultiDestructor
+	destructor.MultiDestructor
 	Dnsmasq     *Dnsmasq
 	NTPServer   *ntp.Server
 	OmahaServer *omaha.Server


### PR DESCRIPTION
More specific package names than `util` help keep things organized. This
new package is basically for things Go could have been nice enough to do
for us but doesn't, giving us sads.

First obvious candidate for this is our destructor implementation.

I'll have more stuff for this soon. ;-)