### PR TITLE
index: use a hash to trigger index updates instead of time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 language: go
 sudo: false
-matrix:
-  include:
-    - go: 1.4.3
-      install:
-        - go get golang.org/x/tools/cmd/cover
-        - go get golang.org/x/tools/cmd/vet
-    - go: 1.5.3
-    - go: 1.6
+
+go:
+ - 1.5.3
+ - 1.6
 
 # Gracefully handle developer forks
 install: |
@@ -22,4 +18,3 @@ install: |
 script:
   - ./build
   - ./test
-

--- a/index/update.go
+++ b/index/update.go
@@ -49,10 +49,7 @@ func Update(client *http.Client, url string) error {
 					errc <- nil
 					return
 				}
-				if !d.NeedsIndex() {
-					continue
-				}
-				if err := d.WriteIndex(client); err != nil {
+				if err := d.UpdateIndex(client); err != nil {
 					errc <- err
 					return
 				}

--- a/index/write.go
+++ b/index/write.go
@@ -16,7 +16,9 @@ package index
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
+	"hash/crc32"
 	"html/template"
 	"net/http"
 
@@ -28,9 +30,7 @@ var (
 )
 
 const (
-	// TODO: The version will be used to regenerate existing indexes.
-	INDEX_VERSION = `2014-08-12`
-	INDEX_TEXT    = `<html>
+	INDEX_TEXT = `<html>
     <head>
 	<title>{{.Bucket}}/{{.Prefix}}</title>
 	<meta http-equiv="X-Clacks-Overhead" content="GNU Terry Pratchett" />
@@ -54,10 +54,26 @@ func init() {
 	indexTemplate = template.Must(template.New("index").Parse(INDEX_TEXT))
 }
 
-func (d *Directory) WriteIndex(client *http.Client) error {
+// crcSum returns the base64 encoded CRC32c sum of the given data
+func crcSum(b []byte) string {
+	c := crc32.New(crc32.MakeTable(crc32.Castagnoli))
+	c.Write(b)
+	return base64.StdEncoding.EncodeToString(c.Sum(nil))
+}
+
+// Judges whether two Objects are equal based on size and CRC
+func crcEq(a, b *storage.Object) bool {
+	return a.Size == b.Size && a.Crc32c == b.Crc32c
+}
+
+func (d *Directory) UpdateIndex(client *http.Client) error {
 	service, err := storage.New(client)
 	if err != nil {
 		return err
+	}
+
+	if len(d.SubDirs) == 0 && len(d.Objects) == 0 {
+		return nil
 	}
 
 	buf := bytes.Buffer{}
@@ -66,15 +82,22 @@ func (d *Directory) WriteIndex(client *http.Client) error {
 		return err
 	}
 
-	writeObj := storage.Object{
+	obj := &storage.Object{
 		Name:         d.Prefix + "index.html",
 		ContentType:  "text/html",
 		CacheControl: "public, max-age=60",
+		Crc32c:       crcSum(buf.Bytes()),
+		Size:         uint64(buf.Len()), // used by crcEq but not API
 	}
-	writeReq := service.Objects.Insert(d.Bucket, &writeObj)
+
+	if old, ok := d.Objects["index.html"]; ok && crcEq(old, obj) {
+		return nil // up to date!
+	}
+
+	writeReq := service.Objects.Insert(d.Bucket, obj)
 	writeReq.Media(&buf)
 
-	fmt.Printf("Writing gs://%s/%s\n", d.Bucket, writeObj.Name)
+	fmt.Printf("Writing gs://%s/%s\n", d.Bucket, obj.Name)
 	_, err = writeReq.Do()
 	return err
 }

--- a/index/write_test.go
+++ b/index/write_test.go
@@ -1,0 +1,144 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"bytes"
+	"fmt"
+	"html"
+	"io"
+	"net/url"
+	"testing"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/google.golang.org/api/storage/v1"
+)
+
+func TestBuildIndex(t *testing.T) {
+	root, err := NewDirectory("gs://bucket/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := root.AddObject(&storage.Object{Name: "foo"}); err != nil {
+		t.Fatal(err)
+	}
+
+	ix1, _, err := root.buildIndex()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := root.AddObject(&storage.Object{Name: "bar"}); err != nil {
+		t.Fatal(err)
+	}
+
+	ix2, _, err := root.buildIndex()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ix1.Size >= ix2.Size || ix1.Crc32c == ix2.Crc32c {
+		t.Errorf("index didn't change after adding bar")
+	}
+}
+
+func newTestDirectory() (root *Directory, err error) {
+	if root, err = NewDirectory("gs://bucket/"); err != nil {
+		return
+	}
+
+	for i := 0; i < 20; i++ {
+		obj := storage.Object{Name: fmt.Sprintf("object%d", i)}
+		if err = root.AddObject(&obj); err != nil {
+			return
+		}
+	}
+
+	for i := 0; i < 5; i++ {
+		obj := storage.Object{Name: fmt.Sprintf("dir%d/object", i)}
+		if err = root.AddObject(&obj); err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+func BenchmarkBuildIndex(b *testing.B) {
+	root, err := newTestDirectory()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, err = root.buildIndex(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// For the sake of comparison, see how much faster building the page by
+// hand is over the existing implementation using text/template.
+// As a bonus this one does escape properly, the existing code doesn't.
+func BenchmarkRawBuildIndex(b *testing.B) {
+	root, err := newTestDirectory()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rawBuildIndex(root)
+	}
+}
+
+func rawBuildIndex(d *Directory) (*storage.Object, io.Reader) {
+	title := html.EscapeString(d.Bucket + "/" + d.Prefix)
+	buf := bytes.NewBuffer(make([]byte, 0, 4096))
+	buf.WriteString("<html><head><title>")
+	buf.WriteString(title)
+	buf.WriteString("</title></head><body><h1>")
+	buf.WriteString(title)
+	buf.WriteString("</h1>")
+	for name := range d.SubDirs {
+		buf.WriteString("\n[dir] <a href=\"")
+		buf.WriteString(escapePath(name))
+		buf.WriteString("\">")
+		buf.WriteString(html.EscapeString(name))
+		buf.WriteString("</a></br>")
+	}
+	for name := range d.Objects {
+		buf.WriteString("\n[file] <a href=\"")
+		buf.WriteString(escapePath(name))
+		buf.WriteString("\">")
+		buf.WriteString(html.EscapeString(name))
+		buf.WriteString("</a></br>")
+	}
+	buf.WriteString("\n</body></html>\n")
+
+	return &storage.Object{
+		Name:         d.Prefix + "index.html",
+		ContentType:  "text/html",
+		CacheControl: "public, max-age=60",
+		Crc32c:       crcSum(buf.Bytes()),
+		Size:         uint64(buf.Len()), // used by crcEq but not API
+	}, buf
+}
+
+func escapePath(path string) string {
+	u := url.URL{Path: path}
+	return u.EscapedPath()
+}


### PR DESCRIPTION
This is more robust since it can detect deletion of child nodes and
changes to the html template. For now CRC32c is used, if that is
insufficient we can switch to MD5 in the future. As an added bonus,
the storage server validates the upload using the provided hash.

Depends on https://github.com/coreos/mantle/pull/270
Replaces https://github.com/coreos/mantle/pull/265