### PR TITLE
New package for managing cloud storage

### DIFF
--- a/cmd/ore/sync.go
+++ b/cmd/ore/sync.go
@@ -1,0 +1,86 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/spf13/cobra"
+	"github.com/coreos/mantle/Godeps/_workspace/src/golang.org/x/net/context"
+
+	"github.com/coreos/mantle/auth"
+	"github.com/coreos/mantle/storage"
+)
+
+var (
+	syncDryRun bool
+	syncForce  bool
+	cmdSync    = &cobra.Command{
+		Use:   "sync gs://src/foo gs://dst/bar",
+		Short: "Copy objects in the cloud!",
+		Run:   runSync,
+	}
+)
+
+func init() {
+	cmdSync.Flags().BoolVarP(&syncDryRun, "dry-run", "n", false,
+		"perform a trial run, do not make changes")
+	cmdSync.Flags().BoolVarP(&syncForce, "force", "f", false,
+		"write everything, even when already up-to-date")
+	root.AddCommand(cmdSync)
+}
+
+func runSync(cmd *cobra.Command, args []string) {
+	if len(args) != 2 {
+		fmt.Fprintf(os.Stderr, "Expected exactly two gs:// URLs. Got: %v\n", args)
+		os.Exit(2)
+	}
+
+	ctx := context.Background()
+	client, err := auth.GoogleClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Authentication failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	src, err := storage.NewBucket(client, args[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	src.WriteDryRun(true) // do not write to src
+
+	dst, err := storage.NewBucket(client, args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	dst.WriteDryRun(syncDryRun)
+	dst.WriteAlways(syncForce)
+
+	if err := src.Fetch(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	if err := dst.Fetch(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	if err := storage.Sync(ctx, src, dst); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/ore/sync.go
+++ b/cmd/ore/sync.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/coreos/mantle/auth"
 	"github.com/coreos/mantle/storage"
+	"github.com/coreos/mantle/storage/index"
 )
 
 var (
@@ -79,7 +80,7 @@ func runSync(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-	if err := storage.Sync(ctx, src, dst); err != nil {
+	if err := index.Sync(ctx, src, dst); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}

--- a/lang/worker/group.go
+++ b/lang/worker/group.go
@@ -1,0 +1,94 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"sync"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/coreos/pkg/multierror"
+	"github.com/coreos/mantle/Godeps/_workspace/src/golang.org/x/net/context"
+)
+
+// Worker is a function that WorkerGroup will run in a new goroutine.
+type Worker func(context.Context) error
+
+// WorkerGroup is similar in principle to sync.WaitGroup but manages the
+// Workers itself. This allows it to provide a few helpful features:
+//  - Integration with the context library.
+//  - Limit the number of concurrent Workers.
+//  - Capture the errors returned by each Worker.
+//  - Abort everything after a single Worker reports an error.
+type WorkerGroup struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	limit  chan struct{}
+
+	mu     sync.Mutex
+	errors multierror.Error
+}
+
+// NewWorkerGroup creates a new group.
+func NewWorkerGroup(ctx context.Context, workerLimit int) *WorkerGroup {
+	wg := WorkerGroup{limit: make(chan struct{}, workerLimit)}
+	wg.ctx, wg.cancel = context.WithCancel(ctx)
+	return &wg
+}
+
+func (wg *WorkerGroup) addErr(err error) {
+	wg.mu.Lock()
+	defer wg.mu.Unlock()
+	wg.errors = append(wg.errors, err)
+	wg.cancel()
+}
+
+func (wg *WorkerGroup) getErr() error {
+	wg.mu.Lock()
+	defer wg.mu.Unlock()
+	return wg.errors.AsError()
+}
+
+// Start launches a new worker, blocking if too many workers are
+// already running. An error indicates the group's context is closed.
+func (wg *WorkerGroup) Start(worker Worker) error {
+	// check for cancellation before waiting on a worker slot
+	select {
+	default:
+	case <-wg.ctx.Done():
+		return wg.ctx.Err()
+	}
+	select {
+	case wg.limit <- struct{}{}:
+		go func() {
+			if err := worker(wg.ctx); err != nil {
+				wg.addErr(err)
+			}
+			<-wg.limit
+		}()
+		return nil
+	case <-wg.ctx.Done():
+		return wg.ctx.Err()
+	}
+}
+
+// Wait blocks until all running workers have finished. An error
+// indicates if at least one worker returned an error or was canceled.
+func (wg *WorkerGroup) Wait() error {
+	// make sure cancel is called at least once, after all work is done.
+	defer wg.cancel()
+	for i := 0; i < cap(wg.limit); i++ {
+		wg.limit <- struct{}{}
+	}
+	return wg.getErr()
+}

--- a/storage/bucket.go
+++ b/storage/bucket.go
@@ -97,6 +97,19 @@ func (b *Bucket) WriteDryRun(dryrun bool) {
 	b.writeDryRun = dryrun
 }
 
+// TrimPrefix removes the Bucket's path prefix from an Object name.
+func (b *Bucket) TrimPrefix(objName string) string {
+	if !strings.HasPrefix(objName, b.prefix) {
+		panic(fmt.Errorf("%q missing prefix %q", objName, b.prefix))
+	}
+	return objName[len(b.prefix):]
+}
+
+// AddPrefix joins the Bucket's path prefix with a relative Object name.
+func (b *Bucket) AddPrefix(objName string) string {
+	return b.prefix + objName
+}
+
 func (b *Bucket) Object(objName string) *storage.Object {
 	b.mu.RLock()
 	defer b.mu.RUnlock()

--- a/storage/bucket.go
+++ b/storage/bucket.go
@@ -1,0 +1,336 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/golang.org/x/net/context"
+	"github.com/coreos/mantle/Godeps/_workspace/src/google.golang.org/api/googleapi"
+	"github.com/coreos/mantle/Godeps/_workspace/src/google.golang.org/api/storage/v1"
+)
+
+var (
+	UnknownScheme = errors.New("storage: URL missing gs:// scheme")
+	UnknownBucket = errors.New("storage: URL missing bucket name")
+)
+
+type Bucket struct {
+	service *storage.Service
+	name    string
+	prefix  string
+
+	mu      sync.RWMutex
+	objects map[string]*storage.Object
+
+	// writeAlways enables overwriting of objects that appear up-to-date
+	writeAlways bool
+	// writeDryRun blocks any changes, merely logging them instead
+	writeDryRun bool
+}
+
+func NewBucket(client *http.Client, bucketURL string) (*Bucket, error) {
+	service, err := storage.New(client)
+	if err != nil {
+		return nil, err
+	}
+
+	parsedURL, err := url.Parse(bucketURL)
+	if err != nil {
+		return nil, err
+	}
+	if parsedURL.Scheme != "gs" {
+		return nil, UnknownScheme
+	}
+	if parsedURL.Host == "" {
+		return nil, UnknownBucket
+	}
+
+	// unsure if this is behavior is what we want or not
+	if parsedURL.Path != "" && !strings.HasSuffix(parsedURL.Path, "/") {
+		parsedURL.Path += "/"
+	}
+
+	return &Bucket{
+		service: service,
+		name:    parsedURL.Host,
+		prefix:  strings.TrimPrefix(parsedURL.Path, "/"),
+		objects: make(map[string]*storage.Object),
+	}, nil
+}
+
+func (b *Bucket) Name() string {
+	return b.name
+}
+
+func (b *Bucket) Prefix() string {
+	return b.prefix
+}
+
+func (b *Bucket) URL() *url.URL {
+	return &url.URL{Scheme: "gs", Host: b.name, Path: b.prefix}
+}
+
+func (b *Bucket) WriteAlways(always bool) {
+	b.writeAlways = always
+}
+
+func (b *Bucket) WriteDryRun(dryrun bool) {
+	b.writeDryRun = dryrun
+}
+
+func (b *Bucket) Object(objName string) *storage.Object {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.objects[objName]
+}
+
+func (b *Bucket) Objects() []*storage.Object {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	objs := make([]*storage.Object, 0, len(b.objects))
+	for _, obj := range b.objects {
+		objs = append(objs, obj)
+	}
+	return objs
+}
+
+func (b *Bucket) Prefixes() []string {
+	prefixmap := make(map[string]struct{})
+	prefixlist := make([]string, 0)
+
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for path := range b.objects {
+		for strings.HasPrefix(path, b.prefix) {
+			i := strings.LastIndexByte(path, '/')
+			if i < 0 {
+				break
+			}
+			path = path[:i+1]
+			if _, ok := prefixmap[path]; ok {
+				break
+			}
+			prefixmap[path] = struct{}{}
+			prefixlist = append(prefixlist, path)
+		}
+	}
+	return prefixlist
+}
+
+func (b *Bucket) Len() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.objects)
+}
+
+func (b *Bucket) addObject(obj *storage.Object) {
+	if obj.Bucket != b.name {
+		panic(fmt.Errorf("adding gs://%s/%s to bucket %s", obj.Bucket, obj.Name, b.name))
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.objects[obj.Name] = obj
+}
+
+func (b *Bucket) addObjects(objs *storage.Objects) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, obj := range objs.Items {
+		if obj.Bucket != b.name {
+			panic(fmt.Errorf("adding gs://%s/%s to bucket %s", obj.Bucket, obj.Name, b.name))
+		}
+		b.objects[obj.Name] = obj
+	}
+}
+
+func (b *Bucket) delObject(objName string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.objects, objName)
+}
+
+func (b *Bucket) mkURL(obj interface{}) *url.URL {
+	switch v := obj.(type) {
+	case string:
+		u := b.URL()
+		u.Path = v
+		return u
+	case *storage.Object:
+		u := b.URL()
+		u.Path = v.Name
+		if v.Bucket != "" {
+			u.Host = v.Bucket
+		}
+		return u
+	case *url.URL:
+		return v
+	case nil:
+		return b.URL()
+	default:
+		panic(fmt.Errorf("unknown type %T", obj))
+	}
+}
+
+func (b *Bucket) apiErr(op string, obj interface{}, e error) error {
+	if _, ok := e.(*googleapi.Error); ok {
+		return &Error{Op: op, URL: b.mkURL(obj).String(), Err: e}
+	}
+	return e
+}
+
+func (b *Bucket) Fetch(ctx context.Context) error {
+	req := b.service.Objects.List(b.name)
+	if b.prefix != "" {
+		req.Prefix(b.prefix)
+	}
+
+	add := func(objs *storage.Objects) error {
+		b.addObjects(objs)
+		plog.Infof("Found %d objects under %s", b.Len(), b.URL())
+		return nil
+	}
+
+	startRequest()
+	defer stopRequest()
+	plog.Noticef("Fetching %s", b.URL())
+
+	return b.apiErr("storage.objects.list", nil, req.Pages(nil, add))
+}
+
+func (b *Bucket) Upload(ctx context.Context, obj *storage.Object, media io.ReadSeeker) error {
+	// Calculate the checksum to enable upload integrity checking.
+	if obj.Crc32c == "" {
+		obj = dupObj(obj) // avoid editing the original
+		if err := crcSum(obj, media); err != nil {
+			return err
+		}
+	}
+
+	old := b.Object(obj.Name)
+	if !b.writeAlways && crcEq(old, obj) {
+		return nil // up to date!
+	}
+	if b.writeDryRun {
+		plog.Noticef("Would write %s", b.mkURL(obj))
+		return nil
+	}
+
+	req := b.service.Objects.Insert(b.name, obj)
+	req.Context(ctx)
+	req.Media(media)
+
+	// Watch out for unexpected conflicting updates.
+	if old != nil {
+		req.IfGenerationMatch(old.Generation)
+	}
+
+	startRequest()
+	defer stopRequest()
+	plog.Noticef("Writing %s", b.mkURL(obj))
+
+	inserted, err := req.Do()
+	if err != nil {
+		return b.apiErr("storage.objects.insert", obj, err)
+	}
+
+	b.addObject(inserted)
+	return nil
+}
+
+func (b *Bucket) Copy(ctx context.Context, src *storage.Object, dstName string) error {
+	if src.Bucket == "" {
+		panic(fmt.Errorf("src.Bucket is blank: %#v", src))
+	}
+
+	old := b.Object(dstName)
+	if !b.writeAlways && crcEq(old, src) {
+		return nil // up to date!
+	}
+
+	// It does work to pass src directly to the Rewrite API call, the
+	// name and bucket values don't really matter, they just cannot be
+	// blank for whatever reason. We make a copy just to get consistent
+	// results, e.g. always use the destination bucket's default ACL.
+	dst := dupObj(src)
+	dst.Name = dstName
+	dst.Bucket = b.name
+
+	if b.writeDryRun {
+		plog.Noticef("Would copy %s to %s", b.mkURL(src), b.mkURL(dst))
+		return nil
+	}
+
+	req := b.service.Objects.Rewrite(
+		src.Bucket, src.Name, dst.Bucket, dst.Name, src)
+	req.Context(ctx)
+
+	// Watch out for unexpected conflicting updates.
+	if old != nil {
+		req.IfGenerationMatch(old.Generation)
+	}
+	if src.Generation != 0 {
+		req.IfSourceGenerationMatch(src.Generation)
+	}
+
+	startRequest()
+	defer stopRequest()
+	plog.Noticef("Copying %s to %s", b.mkURL(src), b.mkURL(dst))
+
+	for {
+		resp, err := req.Do()
+		if err != nil {
+			return b.apiErr("storage.objects.rewrite", dst, err)
+		}
+		if resp.Done {
+			b.addObject(resp.Resource)
+			return nil
+		}
+		req.RewriteToken(resp.RewriteToken)
+	}
+}
+
+func (b *Bucket) Delete(ctx context.Context, objName string) error {
+	if b.writeDryRun {
+		plog.Noticef("Would delete %s", b.mkURL(objName))
+		return nil
+	}
+
+	req := b.service.Objects.Delete(b.name, objName)
+	req.Context(ctx)
+
+	// Watch out for unexpected conflicting updates.
+	if old := b.Object(objName); old != nil {
+		req.IfGenerationMatch(old.Generation)
+		req.IfMetagenerationMatch(old.Metageneration)
+	}
+
+	startRequest()
+	defer stopRequest()
+	plog.Noticef("Deleting %s", b.mkURL(objName))
+
+	if err := req.Do(); err != nil {
+		return b.apiErr("storage.objects.delete", objName, err)
+	}
+
+	b.delObject(objName)
+	return nil
+}

--- a/storage/bucket_test.go
+++ b/storage/bucket_test.go
@@ -1,0 +1,81 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/google.golang.org/api/storage/v1"
+)
+
+type fakeTransport struct{}
+
+func (f fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("FAKE! %s %s", req.Method, req.URL)
+}
+
+func FakeBucket(bucketURL string) (*Bucket, error) {
+	return NewBucket(&http.Client{Transport: fakeTransport{}}, bucketURL)
+}
+
+func (b *Bucket) AddObject(obj *storage.Object) {
+	b.addObject(obj)
+}
+
+func TestBucketURL(t *testing.T) {
+	if _, err := FakeBucket("http://bucket/"); err != UnknownScheme {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if _, err := FakeBucket("gs:///"); err != UnknownBucket {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	for _, test := range []struct {
+		url    string
+		name   string
+		prefix string
+	}{
+		{"gs://bucket", "bucket", ""},
+		{"gs://bucket/", "bucket", ""},
+		{"gs://bucket/prefix", "bucket", "prefix/"},
+		{"gs://bucket/prefix/", "bucket", "prefix/"},
+		{"gs://bucket/prefix/foo", "bucket", "prefix/foo/"},
+		{"gs://bucket/prefix/foo/", "bucket", "prefix/foo/"},
+	} {
+
+		bkt, err := FakeBucket(test.url)
+		if err != nil {
+			t.Errorf("Unexpected error for url %q: %v", test.url, err)
+			continue
+		}
+
+		if bkt.Name() != test.name {
+			t.Errorf("Unexpected name for url %q: %q", test.url, bkt.Name())
+		}
+		if bkt.Prefix() != test.prefix {
+			t.Errorf("Unexpected name for url %q: %q", test.url, bkt.Prefix())
+		}
+	}
+
+}
+
+func BenchmarkMatchPrefix(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		matchPrefix("some/path/prefix/objectname.foo", "some/path/prefix/")
+	}
+}

--- a/storage/error.go
+++ b/storage/error.go
@@ -1,0 +1,25 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+type Error struct {
+	Op  string
+	URL string
+	Err error
+}
+
+func (e *Error) Error() string {
+	return e.Op + " " + e.URL + ": " + e.Err.Error()
+}

--- a/storage/index/indexer.go
+++ b/storage/index/indexer.go
@@ -1,0 +1,147 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"bytes"
+	"html/template"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/golang.org/x/net/context"
+	gs "github.com/coreos/mantle/Godeps/_workspace/src/google.golang.org/api/storage/v1"
+
+	"github.com/coreos/mantle/storage"
+)
+
+var (
+	indexTemplate *template.Template
+)
+
+const (
+	indexText = `<html>
+    <head>
+	<title>{{.Title}}</title>
+	<meta http-equiv="X-Clacks-Overhead" content="GNU Terry Pratchett" />
+    </head>
+    <body>
+    <h1>{{.Title}}</h1>
+    {{range $shortname, $longname := .SubDirs}}
+	[dir] <a href="{{$shortname}}/">{{$shortname}}</a> </br>
+    {{end}}
+    {{range $name, $obj := .Objects}}
+	[file] <a href="{{$name}}">{{$name}}</a> </br>
+    {{end}}
+    </body>
+</html>
+`
+)
+
+func init() {
+	indexTemplate = template.Must(template.New("index").Parse(indexText))
+}
+
+type Indexer struct {
+	bucket  *storage.Bucket
+	prefix  string
+	Title   string
+	SubDirs map[string]string
+	Objects map[string]*gs.Object
+}
+
+func (t *IndexTree) Indexer(dir string) *Indexer {
+	return &Indexer{
+		bucket:  t.bucket,
+		prefix:  dir,
+		Title:   t.bucket.Name() + "/" + dir,
+		SubDirs: t.SubDirs(dir),
+		Objects: t.Objects(dir),
+	}
+}
+
+func (i *Indexer) DeleteRedirect(ctx context.Context) error {
+	if i.prefix == "" {
+		return nil
+	}
+	return i.bucket.Delete(ctx, strings.TrimSuffix(i.prefix, "/"))
+}
+
+func (i *Indexer) DeleteDirectory(ctx context.Context) error {
+	if i.prefix == "" {
+		return nil
+	}
+	return i.bucket.Delete(ctx, i.prefix)
+}
+
+func (i *Indexer) DeleteIndexHTML(ctx context.Context) error {
+	return i.bucket.Delete(ctx, i.prefix+"index.html")
+}
+
+func (i *Indexer) UpdateRedirect(ctx context.Context) error {
+	if i.prefix == "" {
+		return nil
+	}
+
+	name := strings.TrimSuffix(i.prefix, "/")
+	obj := gs.Object{
+		Name:         name,
+		ContentType:  "text/html",
+		CacheControl: "public, max-age=60",
+	}
+
+	link := escapePath(path.Base(name))
+	buf := bytes.NewBuffer(make([]byte, 0, 256))
+	buf.WriteString("<html><head>\n")
+	// TODO: include <link rel="canonical" href="d.Prefix"/>
+	// I suspect that's only meaningful if we switch to absolute paths
+	buf.WriteString(`<meta http-equiv="refresh" content="0;url=`)
+	buf.WriteString(link)
+	buf.WriteString("/\">\n</head></html>\n")
+
+	return i.bucket.Upload(ctx, &obj, bytes.NewReader(buf.Bytes()))
+}
+
+func (i *Indexer) updateHTML(ctx context.Context, suffix string) error {
+	obj := gs.Object{
+		Name:         i.prefix + suffix,
+		ContentType:  "text/html",
+		CacheControl: "public, max-age=60",
+	}
+
+	buf := bytes.Buffer{}
+	if err := indexTemplate.Execute(&buf, i); err != nil {
+		return err
+	}
+
+	return i.bucket.Upload(ctx, &obj, bytes.NewReader(buf.Bytes()))
+}
+
+func (i *Indexer) UpdateDirectoryHTML(ctx context.Context) error {
+	if i.prefix == "" {
+		return nil
+	}
+
+	return i.updateHTML(ctx, "")
+}
+
+func (i *Indexer) UpdateIndexHTML(ctx context.Context) error {
+	return i.updateHTML(ctx, "index.html")
+}
+
+func escapePath(path string) string {
+	u := url.URL{Path: path}
+	return u.EscapedPath()
+}

--- a/storage/index/sync.go
+++ b/storage/index/sync.go
@@ -1,0 +1,80 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"github.com/coreos/mantle/Godeps/_workspace/src/golang.org/x/net/context"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/coreos/pkg/capnslog"
+
+	"github.com/coreos/mantle/lang/worker"
+	"github.com/coreos/mantle/storage"
+)
+
+// Arbitrary limit on the number of concurrent jobs
+const maxWorkers = 12
+
+var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "storage/index")
+
+func Sync(ctx context.Context, src, dst *storage.Bucket) (err error) {
+	wg := worker.NewWorkerGroup(ctx, maxWorkers)
+	for _, srcObj := range FilteredObjects(src) {
+		obj := srcObj // for the sake of the closure
+		worker := func(c context.Context) error {
+			name := dst.AddPrefix(src.TrimPrefix(obj.Name))
+			return dst.Copy(c, obj, name)
+		}
+		if err = wg.Start(worker); err != nil {
+			break
+		}
+	}
+
+	if werr := wg.Wait(); werr != nil {
+		return werr
+	}
+	if err != nil {
+		// Start failed but Wait did not, only likely to happen
+		// if the context was dead before we even started.
+		return err
+	}
+
+	wg = worker.NewWorkerGroup(ctx, maxWorkers)
+	tree := NewIndexTree(dst)
+	var doDir func(string) error
+	doDir = func(dir string) error {
+		ix := tree.Indexer(dir)
+		if err := wg.Start(ix.UpdateRedirect); err != nil {
+			return err
+		}
+		if err := wg.Start(ix.UpdateDirectoryHTML); err != nil {
+			return err
+		}
+		if err := wg.Start(ix.UpdateIndexHTML); err != nil {
+			return err
+		}
+		for _, subdir := range ix.SubDirs {
+			if err := doDir(subdir); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	err = doDir(dst.Prefix())
+	if werr := wg.Wait(); werr != nil {
+		return werr
+	}
+	return err
+}

--- a/storage/index/tree.go
+++ b/storage/index/tree.go
@@ -1,0 +1,87 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"strings"
+
+	gs "github.com/coreos/mantle/Godeps/_workspace/src/google.golang.org/api/storage/v1"
+
+	"github.com/coreos/mantle/storage"
+)
+
+type IndexTree struct {
+	bucket  *storage.Bucket
+	objects map[string][]*gs.Object
+}
+
+func NewIndexTree(bucket *storage.Bucket) *IndexTree {
+	t := &IndexTree{
+		bucket:  bucket,
+		objects: make(map[string][]*gs.Object),
+	}
+
+	for _, obj := range FilteredObjects(bucket) {
+		i := strings.LastIndexByte(obj.Name, '/')
+		dir := obj.Name[:i+1]
+		t.objects[dir] = append(t.objects[dir], obj)
+	}
+
+	return t
+}
+
+func (t *IndexTree) Objects(dir string) map[string]*gs.Object {
+	files := make(map[string]*gs.Object)
+	for _, obj := range t.objects[dir] {
+		files[strings.TrimPrefix(obj.Name, dir)] = obj
+	}
+	return files
+}
+
+func (t *IndexTree) SubDirs(dir string) map[string]string {
+	subdirs := make(map[string]string)
+	for prefix := range t.objects {
+		if strings.HasPrefix(prefix, dir) {
+			name := prefix[len(dir):]
+			if name == "" {
+				continue
+			}
+			if i := strings.IndexByte(name, '/'); i >= 0 {
+				name = name[:i]
+				prefix = prefix[:len(dir)+i+1]
+			}
+			subdirs[name] = prefix
+		}
+	}
+	return subdirs
+}
+
+func FilteredObjects(bucket *storage.Bucket) []*gs.Object {
+	indexes := make(map[string]struct{})
+	for _, prefix := range bucket.Prefixes() {
+		indexes[prefix] = struct{}{}
+		indexes[strings.TrimSuffix(prefix, "/")] = struct{}{}
+		indexes[prefix+"index.html"] = struct{}{}
+	}
+
+	allobjs := bucket.Objects()
+	filtered := make([]*gs.Object, 0, len(allobjs))
+	for _, obj := range allobjs {
+		if _, ok := indexes[obj.Name]; !ok {
+			filtered = append(filtered, obj)
+		}
+	}
+	return filtered
+}

--- a/storage/object.go
+++ b/storage/object.go
@@ -1,0 +1,72 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"encoding/base64"
+	"hash/crc32"
+	"io"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/google.golang.org/api/storage/v1"
+)
+
+// Update CRC32c and Size in the given Object
+// Assumes media is at offset 0, seeks back to offset 0 after reading.
+func crcSum(obj *storage.Object, media io.ReadSeeker) error {
+	c := crc32.New(crc32.MakeTable(crc32.Castagnoli))
+	n, err := io.Copy(c, media)
+	if err != nil {
+		return err
+	}
+	obj.Size = uint64(n)
+	obj.Crc32c = base64.StdEncoding.EncodeToString(c.Sum(nil))
+	_, err = media.Seek(0, 0)
+	return err
+}
+
+// Judges whether two Objects are equal based on size and CRC. To guard against
+// uninitialized fields, nil objects and empty CRC values are never equal.
+func crcEq(a, b *storage.Object) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	if a.Crc32c == "" || b.Crc32c == "" {
+		return false
+	}
+	return a.Size == b.Size && a.Crc32c == b.Crc32c
+}
+
+// Duplicate basic Object metadata, useful for preparing a copy operation.
+func dupObj(src *storage.Object) *storage.Object {
+	dst := &storage.Object{
+		Bucket:             src.Bucket,
+		CacheControl:       src.CacheControl,
+		ContentDisposition: src.ContentDisposition,
+		ContentEncoding:    src.ContentEncoding,
+		ContentLanguage:    src.ContentLanguage,
+		ContentType:        src.ContentType,
+		Crc32c:             src.Crc32c,
+		Md5Hash:            src.Md5Hash,
+		Name:               src.Name,
+		Size:               src.Size,
+	}
+	if len(src.Metadata) > 0 {
+		dst.Metadata = make(map[string]string)
+		for k, v := range src.Metadata {
+			dst.Metadata[k] = v
+		}
+	}
+	return dst
+}

--- a/storage/object_test.go
+++ b/storage/object_test.go
@@ -1,0 +1,85 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/google.golang.org/api/storage/v1"
+)
+
+const (
+	testPage = `<html><head>
+<meta http-equiv="refresh" content="0;url=amd64-usr/">
+</head></html>
+`
+	testPageCRC  = "xH9jaw=="
+	testPageMD5  = "2a6rirkVBEsl0bzTOzNtzA=="
+	testPageSize = 83
+)
+
+func TestCRCSum(t *testing.T) {
+	obj := storage.Object{}
+	if err := crcSum(&obj, strings.NewReader(testPage)); err != nil {
+		t.Fatal(err)
+	}
+	if obj.Crc32c != testPageCRC {
+		t.Errorf("Bad CRC32c: %q != %q", obj.Crc32c, testPageCRC)
+	}
+	if obj.Size != testPageSize {
+		t.Errorf("Bad Size: %d != %d", obj.Size, testPageSize)
+	}
+}
+
+func TestCRCEq(t *testing.T) {
+	obj := storage.Object{Crc32c: testPageCRC, Size: testPageSize}
+	if crcEq(&obj, nil) {
+		t.Errorf("%#v equal to nil", obj)
+	}
+	if crcEq(nil, &obj) {
+		t.Errorf("nil equal to %#v", obj)
+	}
+	if crcEq(nil, nil) {
+		t.Error("nil not equal to nil")
+	}
+	if crcEq(&obj, &storage.Object{Crc32c: testPageCRC}) {
+		t.Errorf("%#v equal ignored size", obj)
+	}
+	if crcEq(&obj, &storage.Object{Size: testPageSize}) {
+		t.Errorf("%#v equal ignored blank CRC", obj)
+	}
+	if !crcEq(&obj, &obj) {
+		t.Errorf("%#v not equal to itself", obj)
+	}
+}
+
+func TestCRCSumAndEq(t *testing.T) {
+	var a, b storage.Object
+	r := strings.NewReader(testPage) // reading twice should work
+	if err := crcSum(&a, r); err != nil {
+		t.Fatal(err)
+	}
+	if err := crcSum(&b, r); err != nil {
+		t.Fatal(err)
+	}
+	if !crcEq(&a, &b) {
+		t.Errorf("%#v not equal to %#v", a, b)
+	}
+	c := storage.Object{Crc32c: testPageCRC, Size: testPageSize}
+	if !crcEq(&a, &c) {
+		t.Errorf("%#v not equal to %#v", a, c)
+	}
+}

--- a/storage/ratelimit.go
+++ b/storage/ratelimit.go
@@ -1,0 +1,32 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+// Arbitrary limit on the number of concurrent remote storage API calls
+const maxConcurrentRequests = 12
+
+var concurrentRequests chan struct{}
+
+func init() {
+	concurrentRequests = make(chan struct{}, maxConcurrentRequests)
+}
+
+func startRequest() {
+	concurrentRequests <- struct{}{}
+}
+
+func stopRequest() {
+	<-concurrentRequests
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,0 +1,22 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// storage provides a high level interface for Google Cloud Storage
+package storage
+
+import (
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/coreos/pkg/capnslog"
+)
+
+var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "storage")

--- a/storage/sync.go
+++ b/storage/sync.go
@@ -1,0 +1,40 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"github.com/coreos/mantle/Godeps/_workspace/src/golang.org/x/net/context"
+
+	"github.com/coreos/mantle/lang/worker"
+)
+
+// Arbitrary limit on the number of concurrent jobs
+const maxWorkers = 12
+
+func Sync(ctx context.Context, src, dst *Bucket) error {
+	wg := worker.NewWorkerGroup(ctx, maxWorkers)
+	for _, srcObj := range src.Objects() {
+		obj := srcObj // for the sake of the closure
+		worker := func(c context.Context) error {
+			name := dst.AddPrefix(src.TrimPrefix(obj.Name))
+			return dst.Copy(c, obj, name)
+		}
+		if err := wg.Start(worker); err != nil {
+			plog.Error(err)
+			break
+		}
+	}
+	return wg.Wait()
+}


### PR DESCRIPTION
This is the core chunk of code for replacing "gsutil rsync && plume index" with a single command that will keeps a local cache of bucket state, avoiding issues caused by the eventual consistency of bucket object listings.

Integrating all this into a new plume command will come in a follow-up commit.