### PR TITLE
Implement Martin Pool's Natural Order sorting

### DIFF
--- a/lang/maps/sorted.go
+++ b/lang/maps/sorted.go
@@ -17,9 +17,12 @@ package maps
 import (
 	"reflect"
 	"sort"
+
+	"github.com/coreos/mantle/lang/natsort"
 )
 
-func SortedKeys(m interface{}) []string {
+// Keys returns a map's keys as an unordered slice of strings.
+func Keys(m interface{}) []string {
 	mapValue := reflect.ValueOf(m)
 
 	// Value.String() isn't sufficient to assert the keys are strings.
@@ -33,6 +36,20 @@ func SortedKeys(m interface{}) []string {
 		keys[i] = k.String()
 	}
 
+	return keys
+}
+
+// SortedKeys returns a map's keys as a sorted slice of strings.
+func SortedKeys(m interface{}) []string {
+	keys := Keys(m)
 	sort.Strings(keys)
+	return keys
+}
+
+// NaturalKeys returns a map's keys as a natural sorted slice of strings.
+// See github.com/coreos/mantle/lang/natsort
+func NaturalKeys(m interface{}) []string {
+	keys := Keys(m)
+	natsort.Strings(keys)
 	return keys
 }

--- a/lang/maps/sorted_test.go
+++ b/lang/maps/sorted_test.go
@@ -17,14 +17,16 @@ package maps
 import (
 	"sort"
 	"testing"
+
+	"github.com/coreos/mantle/lang/natsort"
 )
 
 var (
 	// some random goo
 	testKeys = []string{
-		"aicuquie",
-		"loocheiv",
-		"phiexieh",
+		"100uquie",
+		"10ocheiv",
+		"1hiexieh",
 		"cheuzash",
 		"ohbohmop",
 		"oobeecoh",
@@ -40,6 +42,18 @@ var (
 		"kaibahgh",
 	}
 )
+
+func TestBadKeys(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Errorf("Keys did not panic")
+		} else if r != "maps: keys must be strings" {
+			panic(r)
+		}
+	}()
+	Keys(map[int]int{})
+}
 
 func TestSortedKeys(t *testing.T) {
 	testMap := make(map[string]bool)
@@ -58,6 +72,32 @@ func TestSortedKeys(t *testing.T) {
 
 	sortedKeys := SortedKeys(testMap)
 	if !sort.StringsAreSorted(sortedKeys) {
+		t.Error("SortedKeys did not sort the keys!")
+	}
+
+	if len(sortedKeys) != len(testKeys) {
+		t.Errorf("SortedKeys returned %d keys, not %d",
+			len(sortedKeys), len(testKeys))
+	}
+}
+
+func TestNaturalKeys(t *testing.T) {
+	testMap := make(map[string]bool)
+	for _, k := range testKeys {
+		testMap[k] = true
+	}
+
+	// test is pointless if map iterates in-order by random chance
+	mapKeys := make([]string, 0, len(testMap))
+	for k, _ := range testMap {
+		mapKeys = append(mapKeys, k)
+	}
+	if natsort.StringsAreSorted(mapKeys) {
+		t.Skip("map is already iterating in order!")
+	}
+
+	sortedKeys := NaturalKeys(testMap)
+	if !natsort.StringsAreSorted(sortedKeys) {
 		t.Error("SortedKeys did not sort the keys!")
 	}
 

--- a/lang/natsort/cmp.go
+++ b/lang/natsort/cmp.go
@@ -1,0 +1,129 @@
+// Copyright 2016 CoreOS, Inc.
+// Copyright 2000 Martin Pool <mbp@humbug.org.au>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// natsort implements Martin Pool's Natural Order String Comparison
+// Original implementation: https://github.com/sourcefrog/natsort
+//
+// Strings are sorted as usual, except that decimal integer substrings
+// are compared on their numeric value. For example:
+//
+//     a < a0 < a1 < a1a < a1b < a2 < a10 < a20
+//
+// All white space and control characters are ignored.
+//
+// Leading zeros are *not* ignored, which tends to give more
+// reasonable results on decimal fractions:
+//
+//     1.001 < 1.002 < 1.010 < 1.02 < 1.1 < 1.3
+//
+package natsort
+
+func isDigit(s string, i int) bool {
+	return i < len(s) && s[i] >= '0' && s[i] <= '9'
+}
+
+// Compare unpadded numbers, such as a plain ol' integer.
+func cmpInteger(a, b string, ai, bi *int) int {
+	// The longest run of digits wins. That aside, the greatest
+	// value wins, but we can't know that it will until we've
+	// scanned both numbers to know that they have the same
+	// magnitude, so we remember it in bias.
+	var bias int
+	for {
+		aIsDigit := isDigit(a, *ai)
+		bIsDigit := isDigit(b, *bi)
+		switch {
+		case !aIsDigit && !bIsDigit:
+			return bias
+		case !aIsDigit:
+			return -1
+		case !bIsDigit:
+			return +1
+		case bias == 0 && a[*ai] < b[*bi]:
+			bias = -1
+		case bias == 0 && a[*ai] > b[*bi]:
+			bias = +1
+		}
+		*ai++
+		*bi++
+	}
+}
+
+// Compare zero padded numbers, such as the fractional part of a decimal.
+func cmpFraction(a, b string, ai, bi *int) int {
+	for {
+		aIsDigit := isDigit(a, *ai)
+		bIsDigit := isDigit(b, *bi)
+		switch {
+		case !aIsDigit && !bIsDigit:
+			return 0
+		case !aIsDigit:
+			return -1
+		case !bIsDigit:
+			return +1
+		case a[*ai] < b[*bi]:
+			return -1
+		case a[*ai] > b[*bi]:
+			return +1
+		}
+		*ai++
+		*bi++
+	}
+}
+
+// Compare tests if a is less than, equal to, or greater than b according
+// to the natural sorting algorithm, returning -1, 0, or +1 respectively.
+func Compare(a, b string) int {
+	var ai, bi int
+	for {
+		// Skip ASCII space and control characters. Keeping it simple
+		// for the sake of speed. Checking specific chars and UTF-8
+		// more than doubles the runtime for non-numeric strings.
+		for ai < len(a) && a[ai] <= 32 {
+			ai++
+		}
+		for bi < len(b) && b[bi] <= 32 {
+			bi++
+		}
+
+		if isDigit(a, ai) && isDigit(b, bi) {
+			if a[ai] == '0' || b[bi] == '0' {
+				if r := cmpFraction(a, b, &ai, &bi); r != 0 {
+					return r
+				}
+			} else {
+				if r := cmpInteger(a, b, &ai, &bi); r != 0 {
+					return r
+				}
+			}
+		}
+
+		switch {
+		case ai >= len(a) && bi >= len(b):
+			return 0
+		case ai >= len(a):
+			return -1
+		case bi >= len(b):
+			return +1
+		case a[ai] < b[bi]:
+			return -1
+		case a[ai] > b[bi]:
+			return +1
+		}
+
+		ai++
+		bi++
+	}
+}

--- a/lang/natsort/cmp_test.go
+++ b/lang/natsort/cmp_test.go
@@ -1,0 +1,95 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package natsort
+
+import (
+	"strings"
+	"testing"
+)
+
+func testCompare(t *testing.T, a, b string) {
+	if result := Compare(a, b); result != -1 {
+		t.Errorf("Compare(%q, %q) = %+d, expected -1", a, b, result)
+	}
+	if result := Compare(b, a); result != +1 {
+		t.Errorf("Compare(%q, %q) = %+d, expected +1", a, b, result)
+	}
+}
+
+func testCompareEq(t *testing.T, a, b string) {
+	if result := Compare(a, b); result != 0 {
+		t.Errorf("Compare(%q, %q) = %+d, expected 0", a, b, result)
+	}
+}
+
+func testList(t *testing.T, l []string) {
+	for i := 0; i < len(l)-1; i++ {
+		testCompare(t, l[i], l[i+1])
+	}
+}
+
+func TestCompare01(t *testing.T) {
+	testCompare(t, "01", "02")
+}
+
+func TestCompare02(t *testing.T) {
+	testCompare(t, "02", "2")
+}
+
+func TestCompare10(t *testing.T) {
+	testCompare(t, "2", "10")
+}
+
+func TestCompare100a(t *testing.T) {
+	testCompare(t, "100a", "120")
+}
+
+func TestCompare001a(t *testing.T) {
+	testCompare(t, "001a", "0012")
+}
+
+func TestCompareSpace(t *testing.T) {
+	testCompare(t, "a 1", "a2")
+	testCompare(t, "a1", "a 2")
+	testCompare(t, " 1", "2")
+	testCompare(t, "1", " 2")
+	testCompareEq(t, "a a", "aa")
+}
+
+func TestExample1(t *testing.T) {
+	testList(t, strings.Split("a a0 a1 a1a a1b a2 a10 a20", " "))
+}
+
+func TestExample2(t *testing.T) {
+	testList(t, strings.Split("1.001 1.002 1.010 1.02 1.1 1.3", " "))
+}
+
+func BenchmarkCompareFraction(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Compare("0000005", "0000006")
+	}
+}
+
+func BenchmarkCompareInteger(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Compare("5000000", "6000000")
+	}
+}
+
+func BenchmarkCompareWords(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Compare("notnum.", "notnum!")
+	}
+}

--- a/lang/natsort/sort.go
+++ b/lang/natsort/sort.go
@@ -1,0 +1,50 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package natsort
+
+import (
+	"sort"
+)
+
+// Strings natural sorts a slice of strings.
+func Strings(s []string) {
+	sort.Sort(StringSlice(s))
+}
+
+// StringsAreSorted tests whether a slice of strings is natural sorted.
+func StringsAreSorted(s []string) bool {
+	return sort.IsSorted(StringSlice(s))
+}
+
+// StringSlice provides sort.Interface for natural sorting []string.
+type StringSlice []string
+
+func (ss StringSlice) Len() int {
+	return len(ss)
+}
+
+func (ss StringSlice) Less(i, j int) bool {
+	if r := Compare(ss[i], ss[j]); r == 0 {
+		// If the strings compare the same ignoring spaces try again
+		// with a full comparison to help ensure stable sorts.
+		return ss[i] < ss[j]
+	} else {
+		return r < 0
+	}
+}
+
+func (ss StringSlice) Swap(i, j int) {
+	ss[i], ss[j] = ss[j], ss[i]
+}

--- a/lang/natsort/sort_test.go
+++ b/lang/natsort/sort_test.go
@@ -1,0 +1,165 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package natsort
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/kylelemons/godebug/pretty"
+)
+
+const (
+	testDates = `2000-1-10
+2000-1-2
+1999-12-25
+2000-3-23
+1999-3-3`
+	sortedDates = `1999-3-3
+1999-12-25
+2000-1-2
+2000-1-10
+2000-3-23`
+	testFractions = `Fractional release numbers
+1.011.02
+1.010.12
+1.009.02
+1.009.20
+1.009.10
+1.002.08
+1.002.03
+1.002.01`
+	sortedFractions = `1.002.01
+1.002.03
+1.002.08
+1.009.02
+1.009.10
+1.009.20
+1.010.12
+1.011.02
+Fractional release numbers`
+	testWords = `fred
+pic2
+pic100a
+pic120
+pic121
+jane
+tom
+pic02a
+pic3
+pic4
+1-20
+pic100
+pic02000
+10-20
+1-02
+1-2
+x2-y7
+x8-y8
+x2-y08
+x2-g8
+pic01
+pic02
+pic 6
+pic   7
+pic 5
+pic05
+pic 5 
+pic 5 something
+pic 4 else`
+	sortedWords = `1-02
+1-2
+1-20
+10-20
+fred
+jane
+pic01
+pic02
+pic02a
+pic02000
+pic05
+pic2
+pic3
+pic4
+pic 4 else
+pic 5
+pic 5 
+pic 5 something
+pic 6
+pic   7
+pic100
+pic100a
+pic120
+pic121
+tom
+x2-g8
+x2-y08
+x2-y7
+x8-y8`
+	testEq = `a     a
+a  a
+aa
+a   a
+a a
+a    a`
+	sortedEq = `a     a
+a    a
+a   a
+a  a
+a a
+aa`
+)
+
+func randomize(ss []string) {
+	for i := range ss {
+		j := rand.Intn(i + 1)
+		ss[i], ss[j] = ss[j], ss[i]
+	}
+}
+
+func doTestSlice(t *testing.T, testSlice, sortedSlice []string) {
+	Strings(testSlice)
+	if diff := pretty.Compare(sortedSlice, testSlice); diff != "" {
+		t.Errorf("Unexpected order: %s", diff)
+	}
+}
+
+func doTest(t *testing.T, testData, sortedData string) {
+	testSlice := strings.Split(testData, "\n")
+	sortedSlice := strings.Split(sortedData, "\n")
+	if !StringsAreSorted(sortedSlice) {
+		t.Errorf("StringsAreSorted claims unsorted: %#v", sortedSlice)
+	}
+	doTestSlice(t, testSlice, sortedSlice)
+	randomize(testSlice)
+	doTestSlice(t, testSlice, sortedSlice)
+}
+
+func TestDates(t *testing.T) {
+	doTest(t, testDates, sortedDates)
+}
+
+func TestFractions(t *testing.T) {
+	doTest(t, testFractions, sortedFractions)
+}
+
+func TestWords(t *testing.T) {
+	doTest(t, testWords, sortedWords)
+}
+
+func TestEqual(t *testing.T) {
+	doTest(t, testEq, sortedEq)
+}


### PR DESCRIPTION
This is the same sort algorithm as used by Apache httpd's index module with `VersionSort` enabled. Considering that is exactly what all my indexing go is mimicking in the first place that seems fitting. Original version available here: https://github.com/sourcefrog/natsort

Interesting trivia for related software, GNU's `sort --version-sort` implements the full [Debian package version format](https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version) which I find quite silly complicated and specific for such a generic thing. ;-)