### PR TITLE
New plume release command, supporting storage and GCE

### DIFF
--- a/cmd/plume/plume.go
+++ b/cmd/plume/plume.go
@@ -15,14 +15,18 @@
 package main
 
 import (
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/coreos/pkg/capnslog"
 	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/spf13/cobra"
 	"github.com/coreos/mantle/cli"
 )
 
-var root = &cobra.Command{
-	Use:   "plume [command]",
-	Short: "The CoreOS release utility",
-}
+var (
+	plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "plume")
+	root = &cobra.Command{
+		Use:   "plume [command]",
+		Short: "The CoreOS release utility",
+	}
+)
 
 func main() {
 	cli.Execute(root)

--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -1,0 +1,114 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/spf13/cobra"
+	"github.com/coreos/mantle/Godeps/_workspace/src/golang.org/x/net/context"
+
+	"github.com/coreos/mantle/auth"
+	"github.com/coreos/mantle/storage"
+	"github.com/coreos/mantle/storage/index"
+)
+
+var (
+	releaseBatch  bool
+	releaseDryRun bool
+	cmdRelease    = &cobra.Command{
+		Use:   "release [options]",
+		Short: "Publish a new CoreOS release.",
+		Run:   runRelease,
+		Long: `Publish a new CoreOS release.
+
+TODO`,
+	}
+)
+
+func init() {
+	cmdRelease.Flags().BoolVarP(&releaseDryRun, "dry-run", "n", false,
+		"perform a trial run, do not make changes")
+	AddSpecFlags(cmdRelease.Flags())
+	root.AddCommand(cmdRelease)
+}
+
+func runRelease(cmd *cobra.Command, args []string) {
+	if len(args) > 0 {
+		plog.Fatal("No args accepted")
+	}
+
+	spec := ChannelSpec()
+	ctx := context.Background()
+	client, err := auth.GoogleClient()
+	if err != nil {
+		plog.Fatalf("Authentication failed: %v", err)
+	}
+
+	src, err := storage.NewBucket(client, spec.SourceURL())
+	if err != nil {
+		plog.Fatal(err)
+	}
+	src.WriteDryRun(releaseDryRun)
+
+	if err := src.Fetch(ctx); err != nil {
+		plog.Fatal(err)
+	}
+
+	// Sanity check!
+	if vertxt := src.Object(src.Prefix() + "version.txt"); vertxt == nil {
+		verurl := src.URL().String() + "version.txt"
+		plog.Fatalf("File not found: %s", verurl)
+	}
+
+	// GCE
+
+	for _, dSpec := range spec.Destinations {
+		dst, err := storage.NewBucket(client, dSpec.ParentURL())
+		if err != nil {
+			plog.Fatal(err)
+		}
+		dst.WriteDryRun(releaseDryRun)
+
+		// Fetch parent directory non-recursively to re-index it later.
+		if err := dst.FetchPrefix(ctx, dst.Prefix(), false); err != nil {
+			plog.Fatal(err)
+		}
+
+		// Fetch and sync each destination directory.
+		for _, prefix := range dSpec.Prefixes() {
+			if err := dst.FetchPrefix(ctx, prefix, true); err != nil {
+				plog.Fatal(err)
+			}
+
+			sync := index.NewSyncIndexJob(src, dst)
+			sync.DestinationPrefix(prefix)
+			sync.DirectoryHTML(dSpec.DirectoryHTML)
+			sync.IndexHTML(dSpec.IndexHTML)
+			sync.Delete(true)
+			if err := sync.Do(ctx); err != nil {
+				plog.Fatal(err)
+			}
+		}
+
+		// Now refresh the parent directory index.
+		parent := index.NewIndexJob(dst)
+		parent.DirectoryHTML(dSpec.DirectoryHTML)
+		parent.IndexHTML(dSpec.IndexHTML)
+		parent.Recursive(false)
+		parent.Delete(true)
+		if err := parent.Do(ctx); err != nil {
+			plog.Fatal(err)
+		}
+	}
+}

--- a/cmd/plume/specs.go
+++ b/cmd/plume/specs.go
@@ -33,9 +33,17 @@ type storageSpec struct {
 	IndexHTML     bool
 }
 
+type gceSpec struct {
+	Project string // GCE project name
+	Image   string // File name of image source
+	Publish string // Write published image name to given file
+	Limit   int    // Limit on # of old images to keep
+}
+
 type channelSpec struct {
 	BaseURL      string // Copy from $BaseURL/$Board/$Version
 	Destinations []storageSpec
+	GCE          gceSpec
 }
 
 var (
@@ -69,6 +77,12 @@ var (
 				DirectoryHTML: true,
 				IndexHTML:     true,
 			}},
+			GCE: gceSpec{
+				Project: "coreos-cloud",
+				Image:   "coreos_production_gce.tar.gz",
+				Publish: "coreos_production_gce.txt",
+				Limit:   25,
+			},
 		},
 		"beta": channelSpec{
 			BaseURL: "gs://builds.release.core-os.net/beta/boards",
@@ -93,6 +107,12 @@ var (
 				DirectoryHTML: true,
 				IndexHTML:     true,
 			}},
+			GCE: gceSpec{
+				Project: "coreos-cloud",
+				Image:   "coreos_production_gce.tar.gz",
+				Publish: "coreos_production_gce.txt",
+				Limit:   25,
+			},
 		},
 		"stable": channelSpec{
 			BaseURL: "gs://builds.release.core-os.net/stable/boards",
@@ -108,6 +128,12 @@ var (
 				DirectoryHTML: true,
 				IndexHTML:     true,
 			}},
+			GCE: gceSpec{
+				Project: "coreos-cloud",
+				Image:   "coreos_production_gce.tar.gz",
+				Publish: "coreos_production_gce.txt",
+				Limit:   25,
+			},
 		},
 	}
 )

--- a/cmd/plume/specs.go
+++ b/cmd/plume/specs.go
@@ -1,0 +1,184 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/coreos/mantle/Godeps/_workspace/src/github.com/spf13/pflag"
+
+	"github.com/coreos/mantle/lang/maps"
+	"github.com/coreos/mantle/sdk"
+)
+
+type storageSpec struct {
+	BaseURL       string
+	NamedPath     string // Copy to $BaseURL/$Board/$NamedPath
+	VersionPath   bool   // Copy to $BaseURL/$Board/$Version
+	DirectoryHTML bool
+	IndexHTML     bool
+}
+
+type channelSpec struct {
+	BaseURL      string // Copy from $BaseURL/$Board/$Version
+	Destinations []storageSpec
+}
+
+var (
+	specFlags   *pflag.FlagSet
+	specBoard   string
+	specChannel string
+	specVersion string
+	specs       = map[string]channelSpec{
+		"alpha": channelSpec{
+			BaseURL: "gs://builds.release.core-os.net/alpha/boards",
+			Destinations: []storageSpec{storageSpec{
+				BaseURL:     "gs://alpha.release.core-os.net",
+				NamedPath:   "current",
+				VersionPath: true,
+				IndexHTML:   true,
+			}, storageSpec{
+				BaseURL:       "gs://coreos-alpha",
+				NamedPath:     "current",
+				VersionPath:   true,
+				DirectoryHTML: true,
+				IndexHTML:     true,
+			}, storageSpec{
+				BaseURL:     "gs://storage.core-os.net/coreos",
+				NamedPath:   "alpha",
+				VersionPath: true,
+				IndexHTML:   true,
+			}, storageSpec{
+				BaseURL:       "gs://coreos-net-storage/coreos",
+				NamedPath:     "alpha",
+				VersionPath:   true,
+				DirectoryHTML: true,
+				IndexHTML:     true,
+			}},
+		},
+		"beta": channelSpec{
+			BaseURL: "gs://builds.release.core-os.net/beta/boards",
+			Destinations: []storageSpec{storageSpec{
+				BaseURL:     "gs://beta.release.core-os.net",
+				NamedPath:   "current",
+				VersionPath: true,
+				IndexHTML:   true,
+			}, storageSpec{
+				BaseURL:       "gs://coreos-beta",
+				NamedPath:     "current",
+				VersionPath:   true,
+				DirectoryHTML: true,
+				IndexHTML:     true,
+			}, storageSpec{
+				BaseURL:   "gs://storage.core-os.net/coreos",
+				NamedPath: "beta",
+				IndexHTML: true,
+			}, storageSpec{
+				BaseURL:       "gs://coreos-net-storage/coreos",
+				NamedPath:     "beta",
+				DirectoryHTML: true,
+				IndexHTML:     true,
+			}},
+		},
+		"stable": channelSpec{
+			BaseURL: "gs://builds.release.core-os.net/stable/boards",
+			Destinations: []storageSpec{storageSpec{
+				BaseURL:     "gs://stable.release.core-os.net",
+				NamedPath:   "current",
+				VersionPath: true,
+				IndexHTML:   true,
+			}, storageSpec{
+				BaseURL:       "gs://coreos-stable",
+				NamedPath:     "current",
+				VersionPath:   true,
+				DirectoryHTML: true,
+				IndexHTML:     true,
+			}},
+		},
+	}
+)
+
+func AddSpecFlags(flags *pflag.FlagSet) {
+	board := sdk.DefaultBoard()
+	channels := strings.Join(maps.SortedKeys(specs), " ")
+	versions, _ := sdk.VersionsFromManifest()
+	flags.StringVarP(&specBoard, "board", "B",
+		board, "target board")
+	flags.StringVarP(&specChannel, "channel", "C",
+		"alpha", "channels: "+channels)
+	flags.StringVarP(&specVersion, "version", "V",
+		versions.VersionID, "release version")
+}
+
+func ChannelSpec() channelSpec {
+	if specBoard == "" {
+		plog.Fatal("--board is required")
+	}
+	if specChannel == "" {
+		plog.Fatal("--channel is required")
+	}
+	if specVersion == "" {
+		plog.Fatal("--version is required")
+	}
+
+	spec, ok := specs[specChannel]
+	if !ok {
+		plog.Fatalf("Unknown channel: %s", specChannel)
+	}
+
+	return spec
+}
+
+func (cs channelSpec) SourceURL() string {
+	u, err := url.Parse(cs.BaseURL)
+	if err != nil {
+		panic(err)
+	}
+	u.Path = path.Join(u.Path, specBoard, specVersion)
+	return u.String()
+}
+
+func (ss storageSpec) ParentURL() string {
+	u, err := url.Parse(ss.BaseURL)
+	if err != nil {
+		panic(err)
+	}
+	u.Path = path.Join(u.Path, specBoard)
+	return u.String()
+}
+
+func (ss storageSpec) Prefixes() []string {
+	u, err := url.Parse(ss.BaseURL)
+	if err != nil {
+		plog.Panic(err)
+	}
+
+	prefixes := []string{}
+	if ss.VersionPath {
+		prefixes = append(prefixes,
+			path.Join(u.Path, specBoard, specVersion))
+	}
+	if ss.NamedPath != "" {
+		prefixes = append(prefixes,
+			path.Join(u.Path, specBoard, ss.NamedPath))
+	}
+	if len(prefixes) == 0 {
+		plog.Panicf("Invalid destination: %#v", ss)
+	}
+
+	return prefixes
+}

--- a/storage/index/job.go
+++ b/storage/index/job.go
@@ -32,6 +32,10 @@ type IndexJob struct {
 	notRecursive        bool // inverted because recursive is default
 }
 
+func NewIndexJob(bucket *storage.Bucket) *IndexJob {
+	return &IndexJob{Bucket: bucket}
+}
+
 // Name overrides Bucket's name in page titles.
 func (ij *IndexJob) Name(name string) {
 	ij.name = &name


### PR DESCRIPTION
The first commit here is the pretty one, it's the happy layer on top of all the storage infrastructure code I've been working on the past couple weeks. The second one for GCE, not so much. The existing code doesn't quite do all I need it to but today is not the day to invest in it. Cleanups will come later.

This replaces `core_promote` except for updating the roller channel which we have tended to do separately anyway.