### PR TITLE
cmd/kola: always set a userdata in spawn

### DIFF
--- a/cmd/kola/spawn.go
+++ b/cmd/kola/spawn.go
@@ -54,6 +54,9 @@ func runSpawn(cmd *cobra.Command, args []string) {
 		if err != nil {
 			die("Reading userdata failed: %v", err)
 		}
+	} else {
+		// ensure a key is injected
+		userdata = []byte("#cloud-config")
 	}
 
 	switch kolaPlatform {


### PR DESCRIPTION
empty configs are now truely empty, and have no ssh keys injected.

if a config isn't provided, make up a cloud-config so an ssh key gets
injected so that ssh works.