### PR TITLE
sdk: ensure / is a mount point

### DIFF
--- a/sdk/enter.go
+++ b/sdk/enter.go
@@ -95,6 +95,12 @@ func (e *enter) MountAPI() error {
 		{"/run", "tmpfs", "nosuid,nodev,mode=755"},
 	}
 
+	// Make sure the new root directory itself is a mount point.
+	// `unshare` assumes that `mount --make-rprivate /` works.
+	if err := system.RecursiveBind(e.Chroot, e.Chroot); err != nil {
+		return err
+	}
+
 	for _, fs := range apis {
 		target := filepath.Join(e.Chroot, fs.Path)
 		if err := system.Mount("", target, fs.Type, fs.Opts); err != nil {


### PR DESCRIPTION
Something something doomed to [repeat][1] [history][2].

[1]: https://github.com/coreos/scripts/commit/09851b8460010a60168e1803388cca3bc218216c
[2]: https://github.com/coreos/scripts/commit/3fdd2033dc12e5bc10f0690b3755600e4dc47a35