### PR TITLE
Revert "kola: disable empty ignition config test"

### DIFF
--- a/kola/tests/ignition/v1/empty.go
+++ b/kola/tests/ignition/v1/empty.go
@@ -32,7 +32,5 @@ func init() {
 }
 
 func empty(_ platform.TestCluster) error {
-	// Requires environment configuration that doesn't exist in
-	// our current CI. Disabled until that gets sorted out...
-	return register.Skip
+	return nil
 }


### PR DESCRIPTION
Reverts coreos/mantle#316

Returning Skip doesn't do anything, the test fails before this function even runs. Nevermind...