### PR TITLE
kola/tests/ignition: add tests for ext4

### DIFF
--- a/kola/tests/ignition/v2/root.go
+++ b/kola/tests/ignition/v2/root.go
@@ -16,6 +16,7 @@ package ignition
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/platform"
@@ -101,6 +102,61 @@ func init() {
 		MinVersion:  semver.Version{Major: 1045},
 		UserData:    xfsConfig,
 	})
+
+	// Reformat the root as ext4
+	ext4Config := `{
+		             "ignition": {
+		                 "version": "2.0.0"
+		             },
+		             "storage": {
+		                 "filesystems": [
+		                     {
+		                         "mount": {
+		                             "device": "/dev/disk/by-label/ROOT",
+		                             "format": "ext4",
+		                             "create": {
+		                                 "force": true,
+		                                 "options": [
+		                                     "-L", "ROOT"
+		                                 ]
+		                             }
+		                         }
+		                     }
+		                 ]
+		             }
+		         }`
+	register.Register(&register.Test{
+		Name:        "coreos.ignition.v2.ext4Root.aws",
+		Run:         ext4Root,
+		ClusterSize: 1,
+		Platforms:   []string{"aws"},
+		MinVersion:  semver.Version{Major: 1010},
+		UserData:    ext4Config,
+	})
+	register.Register(&register.Test{
+		Name:        "coreos.ignition.v2.ext4Root.gce",
+		Run:         ext4Root,
+		ClusterSize: 1,
+		Platforms:   []string{"gce"},
+		MinVersion:  semver.Version{Major: 1045},
+		UserData:    ext4Config,
+	})
+	register.Register(&register.Test{
+		Name:        "coreos.ignition.v2.ext4CheckExisting.aws",
+		Run:         ext4CheckExisting,
+		ClusterSize: 1,
+		Platforms:   []string{"aws"},
+		MinVersion:  semver.Version{Major: 1010},
+		UserData:    ext4Config,
+	})
+	register.Register(&register.Test{
+		Name:        "coreos.ignition.v2.ext4CheckExisting.gce",
+		Run:         ext4CheckExisting,
+		ClusterSize: 1,
+		Platforms:   []string{"gce"},
+		MinVersion:  semver.Version{Major: 1045},
+		UserData:    ext4Config,
+	})
 }
 
 func btrfsRoot(c platform.TestCluster) error {
@@ -109,6 +165,14 @@ func btrfsRoot(c platform.TestCluster) error {
 
 func xfsRoot(c platform.TestCluster) error {
 	return testRoot(c, "xfs")
+}
+
+func ext4Root(c platform.TestCluster) error {
+	// Since the image's root partition is formatted to ext4 by default,
+	// this test wont be able to differentiate between the original filesystem
+	// and a newly created one. If mkfs.ext4 never ran, it would still pass.
+	// It will ensure that if mkfs.ext4 ran, it ran successfully.
+	return testRoot(c, "ext4")
 }
 
 func testRoot(c platform.TestCluster, fs string) error {
@@ -121,6 +185,23 @@ func testRoot(c platform.TestCluster, fs string) error {
 
 	if string(out) != fs {
 		return fmt.Errorf("root wasn't correctly reformatted:\n%s", out)
+	}
+
+	return nil
+}
+
+func ext4CheckExisting(c platform.TestCluster) error {
+	m := c.Machines()[0]
+
+	// Redirect /dev/null to stdin so isatty(stdin) fails and the -p flag can be
+	// checked
+	out, err := m.SSH("sudo mkfs.ext4 -p /dev/disk/by-label/ROOT < /dev/null")
+	if err == nil {
+		return fmt.Errorf("mkfs.ext4 returned sucessfully when it should have failed")
+	}
+
+	if !strings.HasPrefix(string(out), "/dev/disk/by-label/ROOT contains a ext4 file system labelled 'ROOT'") {
+		return fmt.Errorf("mkfs.ext4 did not check for existing filesystems.\nmkfs.ext4: %s", out)
 	}
 
 	return nil


### PR DESCRIPTION
Add tests for creating ext4 filesystems in ignition. Test both creating
a new ext4 filesystem in ignition and tests not overwriting an existing
filesystem.