### PR TITLE
kola/tests/rkt: fix ignition config syntax

### DIFF
--- a/kola/tests/rkt/rkt.go
+++ b/kola/tests/rkt/rkt.go
@@ -32,7 +32,7 @@ var conf = `{
 	"systemd": {
 		"units": [{
 			"name": "etcd3-wrapper.service",
-			"enable": true,
+			"enable": true
 		}]
 	}
 }`


### PR DESCRIPTION
probably still broken due to churn in the wrapper.