### PR TITLE
platform: Enable selinux when bringing up or rebooting machines

### DIFF
--- a/platform/machine/aws/cluster.go
+++ b/platform/machine/aws/cluster.go
@@ -85,6 +85,11 @@ func (ac *cluster) NewMachine(userdata string) (platform.Machine, error) {
 		return nil, fmt.Errorf("machine %q failed basic checks: %v", mach.ID(), err)
 	}
 
+	if err := platform.EnableSelinux(mach); err != nil {
+		mach.Destroy()
+		return nil, err
+	}
+
 	ac.AddMach(mach)
 
 	return mach, nil

--- a/platform/machine/gcloud/cluster.go
+++ b/platform/machine/gcloud/cluster.go
@@ -78,6 +78,10 @@ func (gc *cluster) NewMachine(userdata string) (platform.Machine, error) {
 		return nil, err
 	}
 
+	if err := platform.EnableSelinux(gm); err != nil {
+		gm.Destroy()
+		return nil, err
+	}
 	gc.AddMach(gm)
 
 	return gm, nil

--- a/platform/machine/qemu/cluster.go
+++ b/platform/machine/qemu/cluster.go
@@ -192,6 +192,10 @@ func (qc *Cluster) NewMachine(cfg string) (platform.Machine, error) {
 		return nil, err
 	}
 
+	if err := platform.EnableSelinux(qm); err != nil {
+		qm.Destroy()
+		return nil, err
+	}
 	qc.AddMach(qm)
 
 	return qm, nil

--- a/platform/util.go
+++ b/platform/util.go
@@ -101,6 +101,15 @@ func StreamJournal(m Machine) error {
 	return nil
 }
 
+// Enable SELinux on a machine
+func EnableSelinux(m Machine) error {
+	err, output := m.SSH("sudo setenforce 1")
+	if err != nil {
+		return fmt.Errorf("Unable to enable SELinux: %v: %s", err, output)
+	}
+	return nil
+}
+
 // Reboots a machine and blocks until the system to be accessible by SSH again.
 // It will return an error if the machine is not accessible after a timeout.
 func Reboot(m Machine) error {
@@ -111,5 +120,14 @@ func Reboot(m Machine) error {
 		return fmt.Errorf("issuing reboot command failed: %v", out)
 	}
 
-	return CheckMachine(m)
+	err = CheckMachine(m)
+	if err != nil {
+		return err
+	}
+
+	err = EnableSelinux(m)
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
Ensure that selinux is enabled when running tests - we want to ensure that
thing we expect to work.