### PR TITLE
kola/tests/misc: allow systemd-resolved dns stub resolver in coreos.n…

### DIFF
--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -82,6 +82,7 @@ func NetworkListeners(c cluster.TestCluster) error {
 	UDPListeners := []listener{
 		{"systemd-n", "dhcpv6-client"},
 		{"systemd-n", "bootpc"},
+		{"systemd-r", "domain"},
 	}
 	err := checkListeners(m, "TCP", "TCP:LISTEN", TCPListeners)
 	if err != nil {


### PR DESCRIPTION
…etwork.listeners