### PR TITLE
kola/tests/kubernetes: test docker and rkt runtime

### DIFF
--- a/kola/tests/kubernetes/setup.go
+++ b/kola/tests/kubernetes/setup.go
@@ -66,7 +66,6 @@ func setupCluster(c cluster.TestCluster, nodes int, version, runtime string) (*k
 		"K8S_SERVICE_IP":       "10.3.0.1",
 		"K8S_VER":              version,
 		"CONTAINER_RUNTIME":    runtime,
-		"KUBELET_PATH":         "/usr/lib/coreos/kubelet-wrapper",
 	}
 
 	// generate TLS assets on master
@@ -265,11 +264,8 @@ func stripSemverSuffix(v string) (string, error) {
 
 // Run and configure the coreos-kubernetes generic install scripts.
 func runInstallScript(m platform.Machine, script string, options map[string]string) error {
-	// attempt to directly use kubelet if kubelet-wrapper not on disk
-	// on-disk wrapper should exist as of release 962.0.0
 	if _, err := m.SSH("sudo stat /usr/lib/coreos/kubelet-wrapper"); err != nil {
-		plog.Errorf("on-disk kubelet-wrapper not found, using CoreOS built-in kubelet")
-		options["KUBELET_PATH"] = "/usr/bin/kubelet"
+		return fmt.Errorf("kubelet-wrapper not found on disk")
 	}
 
 	var buffer = new(bytes.Buffer)

--- a/kola/tests/kubernetes/setup.go
+++ b/kola/tests/kubernetes/setup.go
@@ -40,10 +40,9 @@ type kCluster struct {
 	workers []platform.Machine
 }
 
-// Setup a multi-node cluster based on official coreos guides for manual
-// installation.
-// https://coreos.com/kubernetes/docs/latest/getting-started.html
-func setupCluster(c cluster.TestCluster, nodes int, version string) (*kCluster, error) {
+// Setup a multi-node cluster based on generic scrips from coreos-kubernetes repo.
+// https://github.com/coreos/coreos-kubernetes/tree/master/multi-node/generic
+func setupCluster(c cluster.TestCluster, nodes int, version, runtime string) (*kCluster, error) {
 	// start single-node etcd
 	etcdNode, err := c.NewMachine(etcdConfig)
 	if err != nil {
@@ -60,13 +59,14 @@ func setupCluster(c cluster.TestCluster, nodes int, version string) (*kCluster, 
 	}
 
 	options := map[string]string{
-		"HYPERKUBE_ACI":       "quay.io/coreos/hyperkube",
-		"MASTER_HOST":         master.PrivateIP(),
-		"ETCD_ENDPOINTS":      fmt.Sprintf("http://%v:2379", etcdNode.PrivateIP()),
-		"CONTROLLER_ENDPOINT": fmt.Sprintf("https://%v:443", master.PrivateIP()),
-		"K8S_SERVICE_IP":      "10.3.0.1",
-		"K8S_VER":             version,
-		"KUBELET_PATH":        "/usr/lib/coreos/kubelet-wrapper",
+		"HYPERKUBE_IMAGE_REPO": "quay.io/coreos/hyperkube",
+		"MASTER_HOST":          master.PrivateIP(),
+		"ETCD_ENDPOINTS":       fmt.Sprintf("http://%v:2379", etcdNode.PrivateIP()),
+		"CONTROLLER_ENDPOINT":  fmt.Sprintf("https://%v:443", master.PrivateIP()),
+		"K8S_SERVICE_IP":       "10.3.0.1",
+		"K8S_VER":              version,
+		"CONTAINER_RUNTIME":    runtime,
+		"KUBELET_PATH":         "/usr/lib/coreos/kubelet-wrapper",
 	}
 
 	// generate TLS assets on master

--- a/kola/tests/kubernetes/workerInstall.go
+++ b/kola/tests/kubernetes/workerInstall.go
@@ -1,5 +1,8 @@
 package kubernetes
 
+// https://github.com/coreos/coreos-kubernetes/tree/master/multi-node/generic.
+// The only change besides paramaterizing the env vars was:
+// s/COREOS_PUBLIC_IP/COREOS_PRIVATE so this works on GCE.
 const workerInstallScript = `#!/bin/bash
 set -e
 
@@ -14,9 +17,18 @@ export CONTROLLER_ENDPOINT={{.CONTROLLER_ENDPOINT}}
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
 export K8S_VER={{.K8S_VER}}
 
+# Hyperkube image repository to use.
+export HYPERKUBE_IMAGE_REPO={{.HYPERKUBE_IMAGE_REPO}}
+
 # The IP address of the cluster DNS service.
 # This must be the same DNS_SERVICE_IP used when configuring the controller nodes.
 export DNS_SERVICE_IP=10.3.0.10
+
+# Whether to use Calico for Kubernetes network policy.
+export USE_CALICO=false
+
+# Determines the container runtime for kubernetes to use. Accepts 'docker' or 'rkt'.
+export CONTAINER_RUNTIME={{.CONTAINER_RUNTIME}}
 
 # The above settings can optionally be overridden using an environment file:
 ENV_FILE=/run/coreos-kubernetes/options.env
@@ -24,7 +36,7 @@ ENV_FILE=/run/coreos-kubernetes/options.env
 # -------------
 
 function init_config {
-    local REQUIRED=( 'ADVERTISE_IP' 'ETCD_ENDPOINTS' 'CONTROLLER_ENDPOINT' 'DNS_SERVICE_IP' 'K8S_VER' )
+    local REQUIRED=( 'ADVERTISE_IP' 'ETCD_ENDPOINTS' 'CONTROLLER_ENDPOINT' 'DNS_SERVICE_IP' 'K8S_VER' 'HYPERKUBE_IMAGE_REPO' 'USE_CALICO' )
 
     if [ -f $ENV_FILE ]; then
         export $(cat $ENV_FILE | xargs)
@@ -44,16 +56,29 @@ function init_config {
 
 function init_templates {
     local TEMPLATE=/etc/systemd/system/kubelet.service
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
 [Service]
-Environment=KUBELET_VERSION={{.K8S_VER}}
-Environment=KUBELET_ACI={{.HYPERKUBE_ACI}}
+Environment=KUBELET_VERSION=${K8S_VER}
+Environment=KUBELET_ACI=${HYPERKUBE_IMAGE_REPO}
+Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
+  --mount volume=dns,target=/etc/resolv.conf \
+  --volume=rkt,kind=host,source=/opt/bin/host-rkt \
+  --mount volume=rkt,target=/usr/bin/rkt \
+  --volume var-lib-rkt,kind=host,source=/var/lib/rkt \
+  --mount volume=var-lib-rkt,target=/var/lib/rkt \
+  --volume=stage,kind=host,source=/tmp \
+  --mount volume=stage,target=/tmp"
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
-ExecStart={{.KUBELET_PATH}} \
+ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api-servers=${CONTROLLER_ENDPOINT} \
+  --network-plugin-dir=/etc/kubernetes/cni/net.d \
+  --network-plugin=cni \
+  --container-runtime=${CONTAINER_RUNTIME} \
+  --rkt-path=/usr/bin/rkt \
+  --rkt-stage1-image=coreos.com/rkt/stage1-coreos \
   --register-node=true \
   --allow-privileged=true \
   --config=/etc/kubernetes/manifests \
@@ -65,13 +90,104 @@ ExecStart={{.KUBELET_PATH}} \
   --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem
 Restart=always
 RestartSec=10
+
 [Install]
 WantedBy=multi-user.target
 EOF
-    }
+    fi
+
+    local TEMPLATE=/opt/bin/host-rkt
+    if [ ! -f $TEMPLATE ]; then
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+#!/bin/sh
+# This is bind mounted into the kubelet rootfs and all rkt shell-outs go
+# through this rkt wrapper. It essentially enters the host mount namespace
+# (which it is already in) only for the purpose of breaking out of the chroot
+# before calling rkt. It makes things like rkt gc work and avoids bind mounting
+# in certain rkt filesystem dependancies into the kubelet rootfs. This can
+# eventually be obviated when the write-api stuff gets upstream and rkt gc is
+# through the api-server. Related issue:
+# https://github.com/coreos/rkt/issues/2878
+exec nsenter -m -u -i -n -p -t 1 -- /usr/bin/rkt "\$@"
+EOF
+    fi
+
+    local TEMPLATE=/etc/systemd/system/load-rkt-stage1.service
+    if [ ${CONTAINER_RUNTIME} = "rkt" ] && [ ! -f $TEMPLATE ]; then
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+[Unit]
+Description=Load rkt stage1 images
+Documentation=http://github.com/coreos/rkt
+Requires=network-online.target
+After=network-online.target
+Before=rkt-api.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/rkt fetch /usr/lib/rkt/stage1-images/stage1-coreos.aci /usr/lib/rkt/stage1-images/stage1-fly.aci  --insecure-options=image
+
+[Install]
+RequiredBy=rkt-api.service
+EOF
+    fi
+
+    local TEMPLATE=/etc/systemd/system/rkt-api.service
+    if [ ${CONTAINER_RUNTIME} = "rkt" ] && [ ! -f $TEMPLATE ]; then
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+[Unit]
+Before=kubelet.service
+
+[Service]
+ExecStart=/usr/bin/rkt api-service
+Restart=always
+RestartSec=10
+
+[Install]
+RequiredBy=kubelet.service
+EOF
+    fi
+
+    local TEMPLATE=/etc/systemd/system/calico-node.service
+    if [ "${USE_CALICO}" = "true" ] && [ ! -f "${TEMPLATE}" ]; then
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+[Unit]
+Description=Calico per-host agent
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+Slice=machine.slice
+Environment=CALICO_DISABLE_FILE_LOGGING=true
+Environment=HOSTNAME=${ADVERTISE_IP}
+Environment=IP=${ADVERTISE_IP}
+Environment=FELIX_FELIXHOSTNAME=${ADVERTISE_IP}
+Environment=CALICO_NETWORKING=false
+Environment=NO_DEFAULT_POOLS=true
+Environment=ETCD_ENDPOINTS=${ETCD_ENDPOINTS}
+ExecStart=/usr/bin/rkt run --inherit-env --stage1-from-dir=stage1-fly.aci \
+--volume=modules,kind=host,source=/lib/modules,readOnly=false \
+--mount=volume=modules,target=/lib/modules \
+--trust-keys-from-https quay.io/calico/node:v0.19.0
+KillMode=mixed
+Restart=always
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    fi
 
     local TEMPLATE=/etc/kubernetes/worker-kubeconfig.yaml
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -93,10 +209,10 @@ contexts:
   name: kubelet-context
 current-context: kubelet-context
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/kubernetes/manifests/kube-proxy.yaml
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
@@ -105,76 +221,141 @@ kind: Pod
 metadata:
   name: kube-proxy
   namespace: kube-system
+  annotations:
+    rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
 spec:
   hostNetwork: true
   containers:
   - name: kube-proxy
-    image: {{.HYPERKUBE_ACI}}:$K8S_VER
+    image: ${HYPERKUBE_IMAGE_REPO}:$K8S_VER
     command:
     - /hyperkube
     - proxy
     - --master=${CONTROLLER_ENDPOINT}
     - --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml
-    - --proxy-mode=iptables
     securityContext:
       privileged: true
     volumeMounts:
-      - mountPath: /etc/ssl/certs
-        name: "ssl-certs"
-      - mountPath: /etc/kubernetes/worker-kubeconfig.yaml
-        name: "kubeconfig"
-        readOnly: true
-      - mountPath: /etc/kubernetes/ssl
-        name: "etc-kube-ssl"
-        readOnly: true
+    - mountPath: /etc/ssl/certs
+      name: "ssl-certs"
+    - mountPath: /etc/kubernetes/worker-kubeconfig.yaml
+      name: "kubeconfig"
+      readOnly: true
+    - mountPath: /etc/kubernetes/ssl
+      name: "etc-kube-ssl"
+      readOnly: true
+    - mountPath: /var/run/dbus
+      name: dbus
+      readOnly: false
   volumes:
-    - name: "ssl-certs"
-      hostPath:
-        path: "/usr/share/ca-certificates"
-    - name: "kubeconfig"
-      hostPath:
-        path: "/etc/kubernetes/worker-kubeconfig.yaml"
-    - name: "etc-kube-ssl"
-      hostPath:
-        path: "/etc/kubernetes/ssl"
+  - name: "ssl-certs"
+    hostPath:
+      path: "/usr/share/ca-certificates"
+  - name: "kubeconfig"
+    hostPath:
+      path: "/etc/kubernetes/worker-kubeconfig.yaml"
+  - name: "etc-kube-ssl"
+    hostPath:
+      path: "/etc/kubernetes/ssl"
+  - hostPath:
+      path: /var/run/dbus
+    name: dbus
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/flannel/options.env
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
 FLANNELD_IFACE=$ADVERTISE_IP
 FLANNELD_ETCD_ENDPOINTS=$ETCD_ENDPOINTS
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/systemd/system/flanneld.service.d/40-ExecStartPre-symlink.conf.conf
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
 [Service]
 ExecStartPre=/usr/bin/ln -sf /etc/flannel/options.env /run/flannel/options.env
 EOF
-    }
+    fi
 
     local TEMPLATE=/etc/systemd/system/docker.service.d/40-flannel.conf
-    [ -f $TEMPLATE ] || {
+    if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
         cat << EOF > $TEMPLATE
 [Unit]
 Requires=flanneld.service
 After=flanneld.service
+[Service]
+ExecStart=
+ExecStart=/usr/lib/coreos/dockerd daemon --host=fd:// \$DOCKER_OPTS \$DOCKER_CGROUPS \$DOCKER_OPT_MTU
 EOF
+    fi
+
+    local TEMPLATE=/etc/kubernetes/cni/net.d/10-calico.conf
+    if [ "${USE_CALICO}" = "true" ] && [ ! -f "${TEMPLATE}" ]; then
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+    "name": "calico",
+    "type": "flannel",
+    "delegate": {
+        "type": "calico",
+        "etcd_endpoints": "$ETCD_ENDPOINTS",
+        "log_level": "none",
+        "log_level_stderr": "info",
+        "hostname": "${ADVERTISE_IP}",
+        "policy": {
+            "type": "k8s",
+            "k8s_api_root": "${CONTROLLER_ENDPOINT}:443/api/v1/",
+            "k8s_client_key": "/etc/kubernetes/ssl/worker-key.pem",
+            "k8s_client_certificate": "/etc/kubernetes/ssl/worker.pem"
+        }
     }
+}
+EOF
+    fi
+
+    local TEMPLATE=/etc/kubernetes/cni/net.d/10-flannel.conf
+    if [ "${USE_CALICO}" = "false" ] && [ ! -f "${TEMPLATE}" ]; then
+        echo "TEMPLATE: $TEMPLATE"
+        mkdir -p $(dirname $TEMPLATE)
+        cat << EOF > $TEMPLATE
+{
+    "name": "podnet",
+    "type": "flannel",
+    "delegate": {
+        "isDefaultGateway": true
+    }
+}
+EOF
+    fi
 
 }
 
 init_config
 init_templates
 
+chmod +x /opt/bin/host-rkt
+
+systemctl stop update-engine; systemctl mask update-engine
+
 systemctl daemon-reload
-systemctl enable kubelet; systemctl start kubelet`
+
+if [ $CONTAINER_RUNTIME = "rkt" ]; then
+        systemctl enable load-rkt-stage1
+        systemctl enable rkt-api
+fi
+
+systemctl enable flanneld; systemctl start flanneld
+systemctl enable kubelet; systemctl start kubelet
+
+if [ $USE_CALICO = "true" ]; then
+        systemctl enable calico-node; systemctl start calico-node
+fi`


### PR DESCRIPTION
Bumps this test to using our v1.3 coreos-kubernetes scripts found [here](https://github.com/coreos/coreos-kubernetes/tree/master/multi-node/generic) which allows testing of kubernetes with rkt as a runtime.

I generally am OK leaving this test as just testing one version of kubernetes and serving as smoke test for the OS since the scripts in coreos-kubernetes only really support one minor version of kubernetes at a time. 

Tested rkt and docker runtimes on 1122.0.0, tested docker runtime on 1068.9