### PR TITLE
kola/tests/rkt: make etcd-wrapper test work again

### DIFF
--- a/kola/tests/rkt/rkt.go
+++ b/kola/tests/rkt/rkt.go
@@ -31,8 +31,12 @@ var conf = `{
 	},
 	"systemd": {
 		"units": [{
-			"name": "etcd3-wrapper.service",
-			"enable": true
+			"name": "etcd-wrapper.service",
+			"enable": true,
+			"dropins": [{
+				"name": "10-tag.conf",
+				"contents": "[Service]\nEnvironment=ETCD_TAG=v3.0.4\n"
+			}]
 		}]
 	}
 }`
@@ -44,7 +48,7 @@ func init() {
 		Platforms:   []string{"aws", "gce"},
 		Name:        "coreos.rkt.etcd3",
 		UserData:    conf,
-		MinVersion:  semver.Version{Major: 1106},
+		MinVersion:  semver.Version{Major: 1122},
 	})
 }
 


### PR DESCRIPTION
the service name changed from etcd3-wrapper to etcd-wrapper, and we must
specify a tag now.