### PR TITLE
Remove the systemd-resolved listeners

### DIFF
--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -84,7 +84,6 @@ func NetworkListeners(c cluster.TestCluster) error {
 	UDPListeners := []listener{
 		{"systemd-n", "dhcpv6-client"},
 		{"systemd-n", "bootpc"},
-		{"systemd-r", "domain"},
 	}
 	err := checkListeners(m, "TCP", "TCP:LISTEN", TCPListeners)
 	if err != nil {

--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -79,7 +79,6 @@ func NetworkListeners(c cluster.TestCluster) error {
 
 	TCPListeners := []listener{
 		{"systemd", "ssh"},
-		{"systemd-r", "domain"},
 	}
 	UDPListeners := []listener{
 		{"systemd-n", "dhcpv6-client"},


### PR DESCRIPTION
CoreOS is now shipping systemd-resolved without enabling its DNS stub resolver by default.