### PR TITLE
platform: fix enabling SELinux

### DIFF
--- a/platform/util.go
+++ b/platform/util.go
@@ -101,11 +101,11 @@ func StreamJournal(m Machine) error {
 	return nil
 }
 
-// Enable SELinux on a machine
+// Enable SELinux on a machine (skip on machines without SELinux support)
 func EnableSelinux(m Machine) error {
-	err, output := m.SSH("sudo setenforce 1")
+	_, err := m.SSH("if type -P setenforce; then sudo setenforce 1; fi")
 	if err != nil {
-		return fmt.Errorf("Unable to enable SELinux: %v: %s", err, output)
+		return fmt.Errorf("Unable to enable SELinux: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
The return values were swapped so the error check was actually testing
for non-nil stdout. However error messages generally go to stderr so
failures were always ignored. Fix error check and just ignore stdout.

In fixing this I need to still tolerate images that do not have SELinux,
such as ancient versions (for upgrade tests) or non-amd64 ports.