### PR TITLE
platform/api/gcloud: allow http and https

### DIFF
--- a/platform/api/gcloud/compute.go
+++ b/platform/api/gcloud/compute.go
@@ -53,6 +53,12 @@ func (a *API) mkinstance(userdata, name string, keys []*agent.Key) *compute.Inst
 		Metadata: &compute.Metadata{
 			Items: metadataItems,
 		},
+		Tags: &compute.Tags{
+			// Apparently you need this tag in addition to the
+			// firewall rules to open the port because these ports
+			// are special?
+			Items: []string{"https-server", "http-server"},
+		},
 		Disks: []*compute.AttachedDisk{
 			{
 				AutoDelete: true,


### PR DESCRIPTION
This tags are needed in addition to the default firewall rules for the
project which in our case already allow it.