### PR TITLE
kola/tests: update etcd wrapper test

### DIFF
--- a/kola/tests/rkt/rkt.go
+++ b/kola/tests/rkt/rkt.go
@@ -31,12 +31,8 @@ var conf = `{
 	},
 	"systemd": {
 		"units": [{
-			"name": "etcd-wrapper.service",
-			"enable": true,
-			"dropins": [{
-				"name": "10-tag.conf",
-				"contents": "[Service]\nEnvironment=ETCD_TAG=v3.0.4\n"
-			}]
+			"name": "etcd-member.service",
+			"enable": true
 		}]
 	}
 }`
@@ -48,7 +44,7 @@ func init() {
 		Platforms:   []string{"aws", "gce"},
 		Name:        "coreos.rkt.etcd3",
 		UserData:    conf,
-		MinVersion:  semver.Version{Major: 1122},
+		MinVersion:  semver.Version{Major: 1213},
 	})
 }
 


### PR DESCRIPTION
This variable name changed with the new implementation of the wrapper
script. We aren't worrying about backward compatibility here because the
existance of this script was never advertised.