### PR TITLE
make importing OS tests optional from using harness

### DIFF
--- a/cmd/kola/kola.go
+++ b/cmd/kola/kola.go
@@ -26,6 +26,9 @@ import (
 	"github.com/coreos/mantle/cli"
 	"github.com/coreos/mantle/kola"
 	"github.com/coreos/mantle/kola/register"
+
+	// register OS test suite
+	_ "github.com/coreos/mantle/kola/registry"
 )
 
 var (

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -36,21 +36,6 @@ import (
 	"github.com/coreos/mantle/platform/machine/aws"
 	"github.com/coreos/mantle/platform/machine/gcloud"
 	"github.com/coreos/mantle/platform/machine/qemu"
-
-	// Tests imported for registration side effects.
-	_ "github.com/coreos/mantle/kola/tests/coretest"
-	_ "github.com/coreos/mantle/kola/tests/docker"
-	_ "github.com/coreos/mantle/kola/tests/etcd"
-	_ "github.com/coreos/mantle/kola/tests/flannel"
-	_ "github.com/coreos/mantle/kola/tests/fleet"
-	_ "github.com/coreos/mantle/kola/tests/ignition/v1"
-	_ "github.com/coreos/mantle/kola/tests/ignition/v2"
-	_ "github.com/coreos/mantle/kola/tests/kubernetes"
-	_ "github.com/coreos/mantle/kola/tests/locksmith"
-	_ "github.com/coreos/mantle/kola/tests/metadata"
-	_ "github.com/coreos/mantle/kola/tests/misc"
-	_ "github.com/coreos/mantle/kola/tests/rkt"
-	_ "github.com/coreos/mantle/kola/tests/systemd"
 )
 
 var (

--- a/kola/registry/registry.go
+++ b/kola/registry/registry.go
@@ -1,0 +1,18 @@
+package registry
+
+// Tests imported for registration side effects. These make up the OS test suite and is explicitly imported from the main package.
+import (
+	_ "github.com/coreos/mantle/kola/tests/coretest"
+	_ "github.com/coreos/mantle/kola/tests/docker"
+	_ "github.com/coreos/mantle/kola/tests/etcd"
+	_ "github.com/coreos/mantle/kola/tests/flannel"
+	_ "github.com/coreos/mantle/kola/tests/fleet"
+	_ "github.com/coreos/mantle/kola/tests/ignition/v1"
+	_ "github.com/coreos/mantle/kola/tests/ignition/v2"
+	_ "github.com/coreos/mantle/kola/tests/kubernetes"
+	_ "github.com/coreos/mantle/kola/tests/locksmith"
+	_ "github.com/coreos/mantle/kola/tests/metadata"
+	_ "github.com/coreos/mantle/kola/tests/misc"
+	_ "github.com/coreos/mantle/kola/tests/rkt"
+	_ "github.com/coreos/mantle/kola/tests/systemd"
+)


### PR DESCRIPTION
I have a project vendoring mantle to maintain a separate test suite from the OS test suite. In this scenario I have no control over whether the OS test suite is registered if I wish to use the kola harness from my main package. I could just edit the kola code but I'd like to strictly maintain it as vendored upstream library so all changes to kola go back to this repo.

Moving the registration list to a separate package explicity imported by the main package allows the projects vendoring this code to choose not to register the OS test suite.

Alternatively this list of imports could all just go in the main package instead of having this indirect registry package. I have no opinion on which I like more.

cc @mischief  @crawford