### PR TITLE
platform: change Machine.SSH to also return stderr

### DIFF
--- a/cmd/kola/bootchart.go
+++ b/cmd/kola/bootchart.go
@@ -79,7 +79,7 @@ func runBootchart(cmd *cobra.Command, args []string) {
 	}
 	defer m.Destroy()
 
-	out, err := m.SSH("systemd-analyze plot")
+	out, _, err := m.SSH("systemd-analyze plot")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "SSH failed: %v\n", err)
 		os.Exit(1)

--- a/cmd/kola/qemu.go
+++ b/cmd/kola/qemu.go
@@ -60,7 +60,7 @@ func runQemu(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	out, err := m.SSH("uname -a")
+	out, _, err := m.SSH("uname -a")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "SSH failed: %v\n", err)
 		os.Exit(1)

--- a/cmd/kola/updatepayload.go
+++ b/cmd/kola/updatepayload.go
@@ -176,7 +176,7 @@ func runUpdateTest() error {
 	}
 
 	// Invalidate USR-A to ensure the update is legit.
-	if out, err := m.SSH("sudo coreos-setgoodroot && " +
+	if out, _, err := m.SSH("sudo coreos-setgoodroot && " +
 		"sudo wipefs /dev/disk/by-partlabel/USR-A"); err != nil {
 		return fmt.Errorf("invalidating USR-A failed: %v: %v", out, err)
 	}
@@ -201,7 +201,7 @@ func tryUpdate(m platform.Machine) error {
 	plog.Infof("Triggering update_engine")
 
 	/* trigger update, monitor the progress. */
-	out, err := m.SSH("update_engine_client -check_for_update")
+	out, _, err := m.SSH("update_engine_client -check_for_update")
 	if err != nil {
 		return fmt.Errorf("Executing update_engine_client failed: %v: %v", out, err)
 	}
@@ -211,7 +211,7 @@ func tryUpdate(m platform.Machine) error {
 	for status != "UPDATE_STATUS_UPDATED_NEED_REBOOT" && time.Since(start) < updateTimeout {
 		time.Sleep(10 * time.Second)
 
-		envs, err := m.SSH("update_engine_client -status 2>/dev/null")
+		envs, _, err := m.SSH("update_engine_client -status 2>/dev/null")
 		if err != nil {
 			return fmt.Errorf("checking status failed: %v", err)
 		}
@@ -295,7 +295,7 @@ func checkUsrB(m platform.Machine) error {
 // checkUsrPartition inspects /proc/cmdline of the machine, looking for the
 // expected partition mounted at /usr.
 func checkUsrPartition(m platform.Machine, accept []string) error {
-	out, err := m.SSH("cat /proc/cmdline")
+	out, _, err := m.SSH("cat /proc/cmdline")
 	if err != nil {
 		return fmt.Errorf("cat /proc/cmdline: %v: %v", out, err)
 	}

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -337,7 +337,7 @@ func getClusterSemver(pltfrm string) (*semver.Version, error) {
 		return nil, fmt.Errorf("creating new machine for semver check: %v", err)
 	}
 
-	out, err := m.SSH("grep ^VERSION_ID= /etc/os-release")
+	out, _, err := m.SSH("grep ^VERSION_ID= /etc/os-release")
 	if err != nil {
 		return nil, fmt.Errorf("parsing /etc/os-release: %v", err)
 	}

--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -166,7 +166,7 @@ func dockerResources(c cluster.TestCluster) error {
 
 		worker := func(c context.Context) error {
 			// TODO: pass context thru to SSH
-			output, err := m.SSH(cmd)
+			output, _, err := m.SSH(cmd)
 			if err != nil {
 				return fmt.Errorf("failed to run %q: output: %q status: %q", dockerCmd, output, err)
 			}
@@ -198,7 +198,7 @@ func dockerNetwork(c cluster.TestCluster) error {
 
 	listener := func(c context.Context) error {
 		// Will block until a message is recieved
-		out, err := dest.SSH(
+		out, _, err := dest.SSH(
 			`echo "HELLO FROM SERVER" | docker run -i -p 9988:9988 ncat ncat --idle-timeout 20 --listen 0.0.0.0 9988`,
 		)
 		if err != nil {
@@ -215,7 +215,7 @@ func dockerNetwork(c cluster.TestCluster) error {
 	talker := func(c context.Context) error {
 		// Wait until listener is ready before trying anything
 		for {
-			_, err := dest.SSH("sudo lsof -i TCP:9988 -s TCP:LISTEN | grep 9988 -q")
+			_, _, err := dest.SSH("sudo lsof -i TCP:9988 -s TCP:LISTEN | grep 9988 -q")
 			if err == nil {
 				break // socket is ready
 			}
@@ -235,7 +235,7 @@ func dockerNetwork(c cluster.TestCluster) error {
 		}
 
 		srcCmd := fmt.Sprintf(`echo "HELLO FROM CLIENT" | docker run -i ncat ncat %s 9988`, dest.PrivateIP())
-		out, err := src.SSH(srcCmd)
+		out, _, err := src.SSH(srcCmd)
 		if err != nil {
 			return err
 		}
@@ -268,7 +268,7 @@ func dockerOldClient(c cluster.TestCluster) error {
 		return fmt.Errorf("failed to create echo container: %v", err)
 	}
 
-	output, err := m.SSH("/home/core/docker-1.9.1 run echo echo 'IT WORKED'")
+	output, _, err := m.SSH("/home/core/docker-1.9.1 run echo echo 'IT WORKED'")
 	if err != nil {
 		return fmt.Errorf("failed to run old docker client: %q status: %q", output, err)
 	}

--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -85,7 +85,7 @@ func doStart(m platform.Machine, version int, block bool) error {
 		etcdStart += " --no-block"
 	}
 
-	_, err := m.SSH(etcdStart)
+	_, _, err := m.SSH(etcdStart)
 	if err != nil {
 		return fmt.Errorf("SSH cmd to %v failed: %s", m.IP(), err)
 	}

--- a/kola/tests/flannel/flannel.go
+++ b/kola/tests/flannel/flannel.go
@@ -90,7 +90,7 @@ func init() {
 // get docker bridge ip from a machine
 func mach2bip(m platform.Machine, ifname string) (string, error) {
 	// note the escaped % in awk.
-	out, err := m.SSH(fmt.Sprintf(`ip -4 -o addr show dev %s primary | awk -F " +|/" '{printf "%%s", $4}'`, ifname))
+	out, _, err := m.SSH(fmt.Sprintf(`ip -4 -o addr show dev %s primary | awk -F " +|/" '{printf "%%s", $4}'`, ifname))
 	if err != nil {
 		return "", err
 	}
@@ -124,7 +124,7 @@ func ping(a, b platform.Machine, ifname string) error {
 	plog.Infof("ping from %s(%s) to %s(%s)", a.ID(), srcip, b.ID(), dstip)
 
 	cmd := fmt.Sprintf("ping -c 10 -I %s %s", srcip, dstip)
-	out, err := a.SSH(cmd)
+	out, _, err := a.SSH(cmd)
 	if err != nil {
 		return fmt.Errorf("ping from %s to %s failed: %s: %v", a.ID(), b.ID(), out, err)
 	}

--- a/kola/tests/fleet/fleet.go
+++ b/kola/tests/fleet/fleet.go
@@ -117,7 +117,7 @@ func Proxy(c cluster.TestCluster) error {
 
 	// settling...
 	fleetStart := func() error {
-		_, err = proxy.SSH("fleetctl start /home/core/hello.service")
+		_, _, err = proxy.SSH("fleetctl start /home/core/hello.service")
 		if err != nil {
 			return fmt.Errorf("fleetctl start: %s", err)
 		}
@@ -130,7 +130,7 @@ func Proxy(c cluster.TestCluster) error {
 	var status []byte
 
 	fleetList := func() error {
-		status, err = proxy.SSH("fleetctl list-units -l -fields active -no-legend")
+		status, _, err = proxy.SSH("fleetctl list-units -l -fields active -no-legend")
 		if err != nil {
 			return fmt.Errorf("fleetctl list-units: %s", err)
 		}

--- a/kola/tests/ignition/v1/root.go
+++ b/kola/tests/ignition/v1/root.go
@@ -104,7 +104,7 @@ func xfsRoot(c cluster.TestCluster) error {
 func testRoot(c cluster.TestCluster, fs string) error {
 	m := c.Machines()[0]
 
-	out, err := m.SSH("findmnt --noheadings --output FSTYPE --target /")
+	out, _, err := m.SSH("findmnt --noheadings --output FSTYPE --target /")
 	if err != nil {
 		return fmt.Errorf("failed to run findmnt: %s: %v", out, err)
 	}

--- a/kola/tests/ignition/v1/sethostname.go
+++ b/kola/tests/ignition/v1/sethostname.go
@@ -69,7 +69,7 @@ func init() {
 func setHostname(c cluster.TestCluster) error {
 	m := c.Machines()[0]
 
-	out, err := m.SSH("hostnamectl")
+	out, _, err := m.SSH("hostnamectl")
 	if err != nil {
 		return fmt.Errorf("failed to run hostnamectl: %s: %v", out, err)
 	}

--- a/kola/tests/ignition/v2/root.go
+++ b/kola/tests/ignition/v2/root.go
@@ -178,7 +178,7 @@ func ext4Root(c cluster.TestCluster) error {
 func testRoot(c cluster.TestCluster, fs string) error {
 	m := c.Machines()[0]
 
-	out, err := m.SSH("findmnt --noheadings --output FSTYPE --target /")
+	out, _, err := m.SSH("findmnt --noheadings --output FSTYPE --target /")
 	if err != nil {
 		return fmt.Errorf("failed to run findmnt: %s: %v", out, err)
 	}
@@ -195,7 +195,7 @@ func ext4CheckExisting(c cluster.TestCluster) error {
 
 	// Redirect /dev/null to stdin so isatty(stdin) fails and the -p flag can be
 	// checked
-	out, err := m.SSH("sudo mkfs.ext4 -p /dev/disk/by-partlabel/ROOT < /dev/null")
+	out, _, err := m.SSH("sudo mkfs.ext4 -p /dev/disk/by-partlabel/ROOT < /dev/null")
 	if err == nil {
 		return fmt.Errorf("mkfs.ext4 returned sucessfully when it should have failed")
 	}

--- a/kola/tests/ignition/v2/sethostname.go
+++ b/kola/tests/ignition/v2/sethostname.go
@@ -69,7 +69,7 @@ func init() {
 func setHostname(c cluster.TestCluster) error {
 	m := c.Machines()[0]
 
-	out, err := m.SSH("hostnamectl")
+	out, _, err := m.SSH("hostnamectl")
 	if err != nil {
 		return fmt.Errorf("failed to run hostnamectl: %s: %v", out, err)
 	}

--- a/kola/tests/kubernetes/basic.go
+++ b/kola/tests/kubernetes/basic.go
@@ -86,7 +86,7 @@ func CoreOSBasic(c cluster.TestCluster, version, runtime string) error {
 }
 
 func nodeCheck(master platform.Machine, nodes []platform.Machine) error {
-	b, err := master.SSH("./kubectl get nodes")
+	b, _, err := master.SSH("./kubectl get nodes")
 	if err != nil {
 		return err
 	}
@@ -117,12 +117,12 @@ func nginxCheck(master platform.Machine, nodes []platform.Machine) error {
 	if err := platform.InstallFile(pod, master, "./nginx-pod.yaml"); err != nil {
 		return err
 	}
-	if _, err := master.SSH("./kubectl create -f nginx-pod.yaml"); err != nil {
+	if _, _, err := master.SSH("./kubectl create -f nginx-pod.yaml"); err != nil {
 		return err
 	}
 	// wait for pod status to be 'Running'
 	podIsRunning := func() error {
-		b, err := master.SSH("./kubectl get pod nginx --template={{.status.phase}}")
+		b, _, err := master.SSH("./kubectl get pod nginx --template={{.status.phase}}")
 		if err != nil {
 			return err
 		}
@@ -136,7 +136,7 @@ func nginxCheck(master platform.Machine, nodes []platform.Machine) error {
 	}
 
 	// delete pod
-	_, err := master.SSH("./kubectl delete pods nginx")
+	_, _, err := master.SSH("./kubectl delete pods nginx")
 	if err != nil {
 		return err
 	}
@@ -155,15 +155,15 @@ func secretCheck(master platform.Machine, nodes []platform.Machine) error {
 		return err
 	}
 
-	if _, err := master.SSH("./kubectl create -f secret.yaml"); err != nil {
+	if _, _, err := master.SSH("./kubectl create -f secret.yaml"); err != nil {
 		return err
 	}
-	_, err := master.SSH("./kubectl describe secret test-secret")
+	_, _, err := master.SSH("./kubectl describe secret test-secret")
 	if err != nil {
 		return err
 	}
 
-	b, err := master.SSH("./kubectl create -f secret-pod.yaml")
+	b, _, err := master.SSH("./kubectl create -f secret-pod.yaml")
 	if err != nil {
 		return err
 	}

--- a/kola/tests/kubernetes/setup.go
+++ b/kola/tests/kubernetes/setup.go
@@ -158,7 +158,7 @@ func generateMasterTLSAssets(master platform.Machine, options map[string]string)
 	}
 
 	for _, cmd := range cmds {
-		b, err := master.SSH(cmd)
+		b, _, err := master.SSH(cmd)
 		if err != nil {
 			return fmt.Errorf("Failed on cmd: %s with error: %s and output %s", cmd, err, b)
 		}
@@ -202,7 +202,7 @@ func generateWorkerTLSAssets(master platform.Machine, workers []platform.Machine
 		}
 
 		for _, cmd := range cmds {
-			b, err := worker.SSH(cmd)
+			b, _, err := worker.SSH(cmd)
 			if err != nil {
 				return fmt.Errorf("Failed on cmd: %s with error: %s and output %s", cmd, err, b)
 			}
@@ -226,10 +226,10 @@ func configureKubectl(m platform.Machine, server string, version string) error {
 		kubeURL   = fmt.Sprintf("https://storage.googleapis.com/kubernetes-release/release/%v/bin/linux/amd64/kubectl", version)
 	)
 
-	if _, err := m.SSH("wget -q " + kubeURL); err != nil {
+	if _, _, err := m.SSH("wget -q " + kubeURL); err != nil {
 		return err
 	}
-	if _, err := m.SSH("chmod +x ./kubectl"); err != nil {
+	if _, _, err := m.SSH("chmod +x ./kubectl"); err != nil {
 		return err
 	}
 
@@ -241,7 +241,7 @@ func configureKubectl(m platform.Machine, server string, version string) error {
 		"./kubectl config use-context default-system",
 	}
 	for _, cmd := range cmds {
-		b, err := m.SSH(cmd)
+		b, _, err := m.SSH(cmd)
 		if err != nil {
 			return fmt.Errorf("Failed on cmd: %s with error: %s and output %s", cmd, err, b)
 		}
@@ -264,7 +264,7 @@ func stripSemverSuffix(v string) (string, error) {
 
 // Run and configure the coreos-kubernetes generic install scripts.
 func runInstallScript(m platform.Machine, script string, options map[string]string) error {
-	if _, err := m.SSH("sudo stat /usr/lib/coreos/kubelet-wrapper"); err != nil {
+	if _, _, err := m.SSH("sudo stat /usr/lib/coreos/kubelet-wrapper"); err != nil {
 		return fmt.Errorf("kubelet-wrapper not found on disk")
 	}
 

--- a/kola/tests/locksmith/locksmith.go
+++ b/kola/tests/locksmith/locksmith.go
@@ -56,7 +56,7 @@ func locksmithCluster(c cluster.TestCluster) error {
 
 	// make sure etcd is ready
 	etcdCheck := func() error {
-		output, err := machs[0].SSH("locksmithctl status")
+		output, _, err := machs[0].SSH("locksmithctl status")
 		if err != nil {
 			return fmt.Errorf("cluster health: %q: %v", output, err)
 		}
@@ -76,7 +76,7 @@ func locksmithCluster(c cluster.TestCluster) error {
 			// XXX: stop sshd so checkmachine verifies correctly if reboot worked
 			// XXX: run locksmithctl under systemd-run so our current connection doesn't drop suddenly
 			cmd := "sudo systemctl stop sshd.socket; sudo systemd-run --quiet --on-active=2 --no-block locksmithctl send-need-reboot"
-			output, err := m.SSH(cmd)
+			output, _, err := m.SSH(cmd)
 			if err != nil {
 				return fmt.Errorf("failed to run %q: output: %q status: %q", cmd, output, err)
 			}

--- a/kola/tests/metadata/contents.go
+++ b/kola/tests/metadata/contents.go
@@ -75,7 +75,7 @@ func init() {
 func verifyAWS(c cluster.TestCluster) error {
 	m := c.Machines()[0]
 
-	out, err := m.SSH("coreos-metadata --version")
+	out, _, err := m.SSH("coreos-metadata --version")
 	if err != nil {
 		return fmt.Errorf("failed to cat /run/metadata/coreos: %s: %v", out, err)
 	}
@@ -100,7 +100,7 @@ func verifyAzure(c cluster.TestCluster) error {
 func verify(c cluster.TestCluster, keys ...string) error {
 	m := c.Machines()[0]
 
-	out, err := m.SSH("cat /run/metadata/coreos")
+	out, _, err := m.SSH("cat /run/metadata/coreos")
 	if err != nil {
 		return fmt.Errorf("failed to cat /run/metadata/coreos: %s: %v", out, err)
 	}

--- a/kola/tests/misc/files.go
+++ b/kola/tests/misc/files.go
@@ -55,7 +55,7 @@ func sugidFiles(m platform.Machine, validfiles []string, mode string) error {
 
 	command := fmt.Sprintf("sudo find / -path /sys -prune -o -path /proc -prune -o -path /var/lib/rkt -prune -o -type f -perm -%v -print", mode)
 
-	output, err := m.SSH(command)
+	output, _, err := m.SSH(command)
 	if err != nil {
 		return fmt.Errorf("Failed to run find: output %s, status: %v", output, err)
 	}
@@ -124,7 +124,7 @@ func SGIDFiles(c cluster.TestCluster) error {
 func WritableFiles(c cluster.TestCluster) error {
 	m := c.Machines()[0]
 
-	output, err := m.SSH("sudo find / -path /sys -prune -o -path /proc -prune -o -path /var/lib/rkt -prune -o -type f -perm -0002 -print")
+	output, _, err := m.SSH("sudo find / -path /sys -prune -o -path /proc -prune -o -path /var/lib/rkt -prune -o -type f -perm -0002 -print")
 	if err != nil {
 		return fmt.Errorf("Failed to run find: output %s, status: %v", output, err)
 	}
@@ -139,7 +139,7 @@ func WritableFiles(c cluster.TestCluster) error {
 func WritableDirs(c cluster.TestCluster) error {
 	m := c.Machines()[0]
 
-	output, err := m.SSH("sudo find / -path /sys -prune -o -path /proc -prune -o -path /var/lib/rkt -prune -o -type d -perm -0002 -a ! -perm -1000 -print")
+	output, _, err := m.SSH("sudo find / -path /sys -prune -o -path /proc -prune -o -path /var/lib/rkt -prune -o -type d -perm -0002 -a ! -perm -1000 -print")
 	if err != nil {
 		return fmt.Errorf("Failed to run find: output %s, status: %v", output, err)
 	}

--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -44,7 +44,7 @@ func checkListeners(m platform.Machine, protocol string, filter string, listener
 	} else {
 		command = fmt.Sprintf("sudo lsof -i%v", protocol)
 	}
-	output, err := m.SSH(command)
+	output, _, err := m.SSH(command)
 	if err != nil {
 		return fmt.Errorf("Failed to run %s: output %s, status: %v", command, output, err)
 	}

--- a/kola/tests/misc/nfs.go
+++ b/kola/tests/misc/nfs.go
@@ -99,7 +99,7 @@ func testNFS(c cluster.TestCluster, nfsversion int) error {
 	plog.Info("NFS server booted.")
 
 	/* poke a file in /tmp */
-	tmp, err := m1.SSH("mktemp")
+	tmp, _, err := m1.SSH("mktemp")
 	if err != nil {
 		return fmt.Errorf("Machine.SSH: %s", err)
 	}
@@ -131,7 +131,7 @@ func testNFS(c cluster.TestCluster, nfsversion int) error {
 	plog.Info("Waiting for NFS mount on client...")
 
 	checkmount := func() error {
-		status, err := m2.SSH("systemctl is-active mnt.mount")
+		status, _, err := m2.SSH("systemctl is-active mnt.mount")
 		if err != nil || string(status) != "active" {
 			return fmt.Errorf("mnt.mount status is %q: %v", status, err)
 		}
@@ -144,7 +144,7 @@ func testNFS(c cluster.TestCluster, nfsversion int) error {
 		return err
 	}
 
-	_, err = m2.SSH(fmt.Sprintf("stat /mnt/%s", path.Base(string(tmp))))
+	_, _, err = m2.SSH(fmt.Sprintf("stat /mnt/%s", path.Base(string(tmp))))
 	if err != nil {
 		return fmt.Errorf("file %q does not exist", tmp)
 	}

--- a/kola/tests/misc/ntp.go
+++ b/kola/tests/misc/ntp.go
@@ -42,7 +42,7 @@ func NTP(c cluster.TestCluster) error {
 	}
 	defer m.Destroy()
 
-	out, err := m.SSH("networkctl status eth0")
+	out, _, err := m.SSH("networkctl status eth0")
 	if err != nil {
 		return fmt.Errorf("networkctl: %v", err)
 	}
@@ -53,7 +53,7 @@ func NTP(c cluster.TestCluster) error {
 	plog.Info("Waiting for systemd-timesyncd.service")
 
 	checker := func() error {
-		out, err = m.SSH("systemctl status systemd-timesyncd.service")
+		out, _, err = m.SSH("systemctl status systemd-timesyncd.service")
 		if err != nil {
 			return fmt.Errorf("systemctl: %v", err)
 		}

--- a/kola/tests/misc/omaha.go
+++ b/kola/tests/misc/omaha.go
@@ -67,7 +67,7 @@ func OmahaPing(c cluster.TestCluster) error {
 
 	m := c.Machines()[0]
 
-	out, err := m.SSH("update_engine_client -check_for_update")
+	out, _, err := m.SSH("update_engine_client -check_for_update")
 	if err != nil {
 		return fmt.Errorf("failed to execute update_engine_client -check_for_update: %v: %v", out, err)
 	}

--- a/kola/tests/misc/selinux.go
+++ b/kola/tests/misc/selinux.go
@@ -43,7 +43,7 @@ func SelinuxEnforce(c cluster.TestCluster) error {
 		{"getenforce", true, "Enforcing"},
 		{"systemctl --no-pager is-active system.slice", true, "active"},
 	} {
-		output, err := m.SSH(cmd.cmdline)
+		output, _, err := m.SSH(cmd.cmdline)
 		if err != nil {
 			return fmt.Errorf("failed to run %q: output: %q status: %q", cmd.cmdline, output, err)
 		}

--- a/kola/tests/misc/users.go
+++ b/kola/tests/misc/users.go
@@ -44,7 +44,7 @@ func CheckUserShells(c cluster.TestCluster) error {
 		"core":     "/bin/bash",
 	}
 
-	output, err := m.SSH("getent passwd")
+	output, _, err := m.SSH("getent passwd")
 	if err != nil {
 		return fmt.Errorf("Failed to run grep: output %s, status: %v", output, err)
 	}

--- a/kola/tests/misc/verity.go
+++ b/kola/tests/misc/verity.go
@@ -49,13 +49,13 @@ func VerityVerify(c cluster.TestCluster) error {
 	m := c.Machines()[0]
 
 	// extract verity hash from kernel
-	hash, err := m.SSH("dd if=/boot/coreos/vmlinuz-a skip=64 count=64 bs=1 2>/dev/null")
+	hash, _, err := m.SSH("dd if=/boot/coreos/vmlinuz-a skip=64 count=64 bs=1 2>/dev/null")
 	if err != nil {
 		return fmt.Errorf("failed to extract verity hash from kernel: %v: %v", hash, err)
 	}
 
 	// find /usr dev
-	usrdev, err := m.SSH("findmnt -no SOURCE /usr")
+	usrdev, _, err := m.SSH("findmnt -no SOURCE /usr")
 	if err != nil {
 		return fmt.Errorf("failed to find device for /usr: %v: %v", usrdev, err)
 	}
@@ -63,14 +63,14 @@ func VerityVerify(c cluster.TestCluster) error {
 	// XXX: if the /usr dev is /dev/mapper/usr, we're on a verity enabled
 	// image, so use dmsetup to find the real device.
 	if strings.TrimSpace(string(usrdev)) == "/dev/mapper/usr" {
-		usrdev, err = m.SSH("echo -n /dev/$(sudo dmsetup info --noheadings -Co blkdevs_used usr)")
+		usrdev, _, err = m.SSH("echo -n /dev/$(sudo dmsetup info --noheadings -Co blkdevs_used usr)")
 		if err != nil {
 			return fmt.Errorf("failed to find device for /usr: %v: %v", usrdev, err)
 		}
 	}
 
 	// figure out partition size for hash dev offset
-	offset, err := m.SSH("sudo e2size " + string(usrdev))
+	offset, _, err := m.SSH("sudo e2size " + string(usrdev))
 	if err != nil {
 		return fmt.Errorf("failed to find /usr partition size: %v: %v", offset, err)
 	}
@@ -78,7 +78,7 @@ func VerityVerify(c cluster.TestCluster) error {
 	offset = bytes.TrimSpace(offset)
 	veritycmd := fmt.Sprintf("sudo veritysetup verify --verbose --hash-offset=%s %s %s %s", offset, usrdev, usrdev, hash)
 
-	verify, err := m.SSH(veritycmd)
+	verify, _, err := m.SSH(veritycmd)
 	if err != nil {
 		return fmt.Errorf("verity hash verification on %s failed: %v: %v", usrdev, verify, err)
 	}
@@ -91,7 +91,7 @@ func VerityVerify(c cluster.TestCluster) error {
 func VerityCorruption(c cluster.TestCluster) error {
 	m := c.Machines()[0]
 	// figure out if we are actually using verity
-	out, err := m.SSH("sudo veritysetup status usr")
+	out, _, err := m.SSH("sudo veritysetup status usr")
 	if err != nil && bytes.Equal(out, []byte("/dev/mapper/usr is inactive.")) {
 		// verity not in use, so skip.
 		c.Skip("verity is not enabled")
@@ -100,7 +100,7 @@ func VerityCorruption(c cluster.TestCluster) error {
 	}
 
 	// assert that dm shows verity is in use and the device is valid (V)
-	out, err = m.SSH("sudo dmsetup --target verity status usr")
+	out, _, err = m.SSH("sudo dmsetup --target verity status usr")
 	if err != nil {
 		return fmt.Errorf("failed checking dmsetup status of usr: %s: %v", out, err)
 	}
@@ -118,31 +118,31 @@ func VerityCorruption(c cluster.TestCluster) error {
 	// try setting NAME=CoreOS to NAME=LulzOS in /usr/lib/os-release
 
 	// get usr device, probably vda3
-	usrdev, err := m.SSH("echo /dev/$(sudo dmsetup info --noheadings -Co blkdevs_used usr)")
+	usrdev, _, err := m.SSH("echo /dev/$(sudo dmsetup info --noheadings -Co blkdevs_used usr)")
 	if err != nil {
 		return fmt.Errorf("failed getting /usr device from dmsetup: %s: %v", out, err)
 	}
 
 	// poke bytes into /usr/lib/os-release
-	out, err = m.SSH(fmt.Sprintf(`echo NAME=LulzOS | sudo dd of=%s seek=$(expr $(sudo debugfs -R "blocks /lib/os-release" %s 2>/dev/null) \* 4096) bs=1 2>/dev/null`, usrdev, usrdev))
+	out, _, err = m.SSH(fmt.Sprintf(`echo NAME=LulzOS | sudo dd of=%s seek=$(expr $(sudo debugfs -R "blocks /lib/os-release" %s 2>/dev/null) \* 4096) bs=1 2>/dev/null`, usrdev, usrdev))
 	if err != nil {
 		return fmt.Errorf("failed overwriting disk block: %s: %v", out, err)
 	}
 
 	// make sure we flush everything so cat has to go through to the device backing verity.
-	out, err = m.SSH("sudo /bin/sh -c 'sync; echo -n 3 >/proc/sys/vm/drop_caches'")
+	out, _, err = m.SSH("sudo /bin/sh -c 'sync; echo -n 3 >/proc/sys/vm/drop_caches'")
 	if err != nil {
 		return fmt.Errorf("failed dropping disk caches: %s: %v", out, err)
 	}
 
 	// read the file back. if we can read it successfully, verity did not do its job.
-	out, err = m.SSH("cat /usr/lib/os-release")
+	out, _, err = m.SSH("cat /usr/lib/os-release")
 	if err == nil {
 		return fmt.Errorf("verity did not prevent reading a corrupted file!")
 	}
 
 	// assert that dm shows verity device is now corrupted (C)
-	out, err = m.SSH("sudo dmsetup --target verity status usr")
+	out, _, err = m.SSH("sudo dmsetup --target verity status usr")
 	if err != nil {
 		return fmt.Errorf("failed checking dmsetup status of usr: %s: %v", out, err)
 	}

--- a/kola/tests/rkt/rkt.go
+++ b/kola/tests/rkt/rkt.go
@@ -53,7 +53,7 @@ func rktEtcd(t cluster.TestCluster) error {
 
 	etcdCmd := "etcdctl cluster-health"
 	etcdCheck := func() error {
-		output, err := m.SSH(etcdCmd)
+		output, _, err := m.SSH(etcdCmd)
 		if err != nil {
 			return fmt.Errorf("failed to run %q: output: %q status: %q", etcdCmd, output, err)
 		}

--- a/kola/tests/systemd/journald.go
+++ b/kola/tests/systemd/journald.go
@@ -86,7 +86,7 @@ func journalRemote(c cluster.TestCluster, journalFmt string) error {
 
 	// log a unique message on gatewayd machine
 	msg := "supercalifragilisticexpialidocious"
-	out, err := gateway.SSH("logger " + msg)
+	out, _, err := gateway.SSH("logger " + msg)
 	if err != nil {
 		return fmt.Errorf("logger: %v: %v", out, err)
 	}
@@ -100,7 +100,7 @@ func journalRemote(c cluster.TestCluster, journalFmt string) error {
 
 	// collect logs from gatewayd machine
 	cmd := fmt.Sprintf("sudo systemd-run --unit systemd-journal-remote-client /usr/lib/systemd/systemd-journal-remote --url http://%s:19531", gateway.PrivateIP())
-	out, err = collector.SSH(cmd)
+	out, _, err = collector.SSH(cmd)
 	if err != nil {
 		return fmt.Errorf("failed to start systemd-journal-remote: %v: %v", out, err)
 	}
@@ -108,7 +108,7 @@ func journalRemote(c cluster.TestCluster, journalFmt string) error {
 	// find the message on the collector
 	journalReader := func() error {
 		cmd = fmt.Sprintf("sudo journalctl _HOSTNAME=%s -t core --file "+journalFmt, gatewayconf.Hostname, gateway.PrivateIP())
-		out, err = collector.SSH(cmd)
+		out, _, err = collector.SSH(cmd)
 		if err != nil {
 			return fmt.Errorf("journalctl: %v: %v", out, err)
 		}

--- a/kola/tests/systemd/sysusers.go
+++ b/kola/tests/systemd/sysusers.go
@@ -55,7 +55,7 @@ func gshadowParser(c cluster.TestCluster) error {
 		`sudo sh -c "echo 'grp2:*::root' >> /etc/gshadow"`,
 		`sudo systemd-sysusers`,
 	} {
-		output, err := m.SSH(cmd)
+		output, _, err := m.SSH(cmd)
 		if err != nil {
 			return fmt.Errorf("failed to run %q: output: %q status: %v", cmd, output, err)
 		}

--- a/platform/machine/aws/machine.go
+++ b/platform/machine/aws/machine.go
@@ -44,7 +44,7 @@ func (am *machine) PasswordSSHClient(user string, password string) (*ssh.Client,
 	return am.cluster.PasswordSSHClient(am.IP(), user, password)
 }
 
-func (am *machine) SSH(cmd string) ([]byte, error) {
+func (am *machine) SSH(cmd string) ([]byte, []byte, error) {
 	return am.cluster.SSH(am, cmd)
 }
 

--- a/platform/machine/gcloud/machine.go
+++ b/platform/machine/gcloud/machine.go
@@ -31,7 +31,7 @@ func (gm *machine) PasswordSSHClient(user string, password string) (*ssh.Client,
 	return gm.gc.PasswordSSHClient(gm.IP(), user, password)
 }
 
-func (gm *machine) SSH(cmd string) ([]byte, error) {
+func (gm *machine) SSH(cmd string) ([]byte, []byte, error) {
 	return gm.gc.SSH(gm, cmd)
 }
 

--- a/platform/machine/qemu/machine.go
+++ b/platform/machine/qemu/machine.go
@@ -49,7 +49,7 @@ func (m *machine) PasswordSSHClient(user string, password string) (*ssh.Client, 
 	return m.qc.PasswordSSHClient(m.IP(), user, password)
 }
 
-func (m *machine) SSH(cmd string) ([]byte, error) {
+func (m *machine) SSH(cmd string) ([]byte, []byte, error) {
 	return m.qc.SSH(m, cmd)
 }
 

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -156,7 +156,7 @@ func ReadFile(m Machine, path string) (io.ReadCloser, error) {
 // InstallFile copies data from in to the path to on m.
 func InstallFile(in io.Reader, m Machine, to string) error {
 	dir := filepath.Dir(to)
-	out, err := m.SSH(fmt.Sprintf("sudo mkdir -p %s", dir))
+	out, _, err := m.SSH(fmt.Sprintf("sudo mkdir -p %s", dir))
 	if err != nil {
 		return fmt.Errorf("failed creating directory %s: %s", dir, out)
 	}
@@ -242,7 +242,7 @@ func NewMachines(c Cluster, userdatas []string) ([]Machine, error) {
 func CheckMachine(m Machine) error {
 	// ensure ssh works
 	sshChecker := func() error {
-		_, err := m.SSH("true")
+		_, _, err := m.SSH("true")
 		if err != nil {
 			return err
 		}
@@ -254,7 +254,7 @@ func CheckMachine(m Machine) error {
 	}
 
 	// ensure we're talking to a CoreOS system
-	out, err := m.SSH("grep ^ID= /etc/os-release")
+	out, _, err := m.SSH("grep ^ID= /etc/os-release")
 	if err != nil {
 		return fmt.Errorf("no /etc/os-release file")
 	}
@@ -264,14 +264,14 @@ func CheckMachine(m Machine) error {
 	}
 
 	// ensure no systemd units failed during boot
-	out, err = m.SSH("systemctl --no-legend --state failed list-units")
+	out, _, err = m.SSH("systemctl --no-legend --state failed list-units")
 	if err != nil {
 		return fmt.Errorf("systemctl: %v: %v", out, err)
 	}
 
 	if len(out) > 0 {
 		if plog.LevelAt(capnslog.DEBUG) {
-			log, err := m.SSH("journalctl -b")
+			log, _, err := m.SSH("journalctl -b")
 			if err != nil {
 				plog.Errorf("Failed to read journal: %v", err)
 			} else {

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -55,7 +55,7 @@ type Machine interface {
 	PasswordSSHClient(user string, password string) (*ssh.Client, error)
 
 	// SSH runs a single command over a new SSH connection.
-	SSH(cmd string) ([]byte, error)
+	SSH(cmd string) (stdout, stderr []byte, err error)
 
 	// Destroy terminates the machine and frees associated resources.
 	Destroy() error

--- a/platform/util.go
+++ b/platform/util.go
@@ -103,7 +103,7 @@ func StreamJournal(m Machine) error {
 
 // Enable SELinux on a machine (skip on machines without SELinux support)
 func EnableSelinux(m Machine) error {
-	_, err := m.SSH("if type -P setenforce; then sudo setenforce 1; fi")
+	_, _, err := m.SSH("if type -P setenforce; then sudo setenforce 1; fi")
 	if err != nil {
 		return fmt.Errorf("Unable to enable SELinux: %v", err)
 	}
@@ -115,7 +115,7 @@ func EnableSelinux(m Machine) error {
 func Reboot(m Machine) error {
 	// stop sshd so that commonMachineChecks will only work if the machine
 	// actually rebooted
-	out, err := m.SSH("sudo systemctl stop sshd.socket && sudo reboot")
+	out, _, err := m.SSH("sudo systemctl stop sshd.socket && sudo reboot")
 	if _, ok := err.(*ssh.ExitMissingError); ok {
 		// A terminated session is perfectly normal during reboot.
 		err = nil


### PR DESCRIPTION
This is probably the most used function of the platform interfaces used
by test writers. Adding stderr allows test writers to provide far more
helpful error messages without reaching for the verbose SSHClient to
accomplish that. Often SSH commands that fail just return the err code
up the stack which is useless. Also, sometimes the stderr output
provides useful logs even if the command didn't fail which is why I
didn't just replace the error code with stderr.