### PR TITLE
platform/api/gcloud: respect basename option

### DIFF
--- a/platform/api/gcloud/compute.go
+++ b/platform/api/gcloud/compute.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (a *API) vmname() string {
-	return fmt.Sprintf("mantle-%x", rand.Int63())
+	return fmt.Sprintf("%s-%x", a.options.BaseName, rand.Int63())
 }
 
 // Taken from: https://github.com/golang/build/blob/master/buildlet/gce.go


### PR DESCRIPTION
Somewhere in the shuffle this option stopped being respected. This means its difficult to tell from which CI job rogue kola instances are from and know which ones are safe to reap. Useful now that kola tests are being run in more places also won't harm anything not utilizing the basename option.

cc @marineam  