### PR TITLE
allow selection of image project for gce

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -52,7 +52,7 @@ func init() {
 	sv(&kola.QEMUOptions.BIOSImage, "qemu-bios", "", "BIOS to use for QEMU vm")
 
 	// gce-specific options
-	sv(&kola.GCEOptions.Image, "gce-image", "latest", "GCE image")
+	sv(&kola.GCEOptions.Image, "gce-image", "latest", "GCE image, full api endpoints names are accepted if resource is in a different project")
 	sv(&kola.GCEOptions.Project, "gce-project", "coreos-gce-testing", "GCE project name")
 	sv(&kola.GCEOptions.Zone, "gce-zone", "us-central1-a", "GCE zone name")
 	sv(&kola.GCEOptions.MachineType, "gce-machinetype", "n1-standard-1", "GCE machine type")

--- a/platform/api/gcloud/api.go
+++ b/platform/api/gcloud/api.go
@@ -16,7 +16,9 @@
 package gcloud
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/coreos/pkg/capnslog"
 	"google.golang.org/api/compute/v1"
@@ -47,6 +49,19 @@ type API struct {
 }
 
 func New(opts *Options) (*API, error) {
+	const endpointPrefix = "https://www.googleapis.com/compute/v1/"
+
+	// If the image name isn't a full api endpoint accept a name beginning
+	// with "projects/" to specify a different project from the instance.
+	// Also accept a short name and use instance project.
+	if strings.HasPrefix(opts.Image, "projects/") {
+		opts.Image = endpointPrefix + opts.Image
+	} else if !strings.Contains(opts.Image, "/") {
+		opts.Image = fmt.Sprintf("%sprojects/%s/global/images/%s", endpointPrefix, opts.Project, opts.Image)
+	} else if !strings.HasPrefix(opts.Image, endpointPrefix) {
+		return nil, fmt.Errorf("GCE Image argument must be the full api endpoint, begin with 'projects/', or use the short name")
+	}
+
 	var (
 		client *http.Client
 		err    error

--- a/platform/api/gcloud/compute.go
+++ b/platform/api/gcloud/compute.go
@@ -46,10 +46,11 @@ func (a *API) mkinstance(userdata, name string, keys []*agent.Key) *compute.Inst
 		})
 	}
 
-	prefix := "https://www.googleapis.com/compute/v1/projects/" + a.options.Project
+	instancePrefix := "https://www.googleapis.com/compute/v1/projects/" + a.options.Project
+
 	instance := &compute.Instance{
 		Name:        name,
-		MachineType: prefix + "/zones/" + a.options.Zone + "/machineTypes/" + a.options.MachineType,
+		MachineType: instancePrefix + "/zones/" + a.options.Zone + "/machineTypes/" + a.options.MachineType,
 		Metadata: &compute.Metadata{
 			Items: metadataItems,
 		},
@@ -66,7 +67,7 @@ func (a *API) mkinstance(userdata, name string, keys []*agent.Key) *compute.Inst
 				Type:       "PERSISTENT",
 				InitializeParams: &compute.AttachedDiskInitializeParams{
 					DiskName:    name,
-					SourceImage: prefix + "/global/images/" + a.options.Image,
+					SourceImage: a.options.Image,
 					DiskType:    "/zones/" + a.options.Zone + "/diskTypes/" + a.options.DiskType,
 				},
 			},
@@ -79,7 +80,7 @@ func (a *API) mkinstance(userdata, name string, keys []*agent.Key) *compute.Inst
 						Name: "External NAT",
 					},
 				},
-				Network: prefix + "/global/networks/" + a.options.Network,
+				Network: instancePrefix + "/global/networks/" + a.options.Network,
 			},
 		},
 	}


### PR DESCRIPTION
The gcloud should distinguish the image project from the instance project. Mainly, its useful to be able to select vm images from a project like coreos-cloud but have the instances still spawned on the coreos-gce-testing project. Otherwise one has to guess which jenkin's created image is good. 

cc @marineam @mischief 