### PR TITLE
kola/tests: fix a bunch of race conditions in files tests

### DIFF
--- a/kola/tests/misc/files.go
+++ b/kola/tests/misc/files.go
@@ -53,7 +53,7 @@ func init() {
 func sugidFiles(m platform.Machine, validfiles []string, mode string) error {
 	badfiles := make([]string, 0, 0)
 
-	command := fmt.Sprintf("sudo find / -path /sys -prune -o -path /proc -prune -o -path /var/lib/rkt -prune -o -type f -perm -%v -print", mode)
+	command := fmt.Sprintf("sudo find / -ignore_readdir_race -path /sys -prune -o -path /proc -prune -o -path /var/lib/rkt -prune -o -type f -perm -%v -print", mode)
 
 	output, err := m.SSH(command)
 	if err != nil {
@@ -124,7 +124,7 @@ func SGIDFiles(c cluster.TestCluster) error {
 func WritableFiles(c cluster.TestCluster) error {
 	m := c.Machines()[0]
 
-	output, err := m.SSH("sudo find / -path /sys -prune -o -path /proc -prune -o -path /var/lib/rkt -prune -o -type f -perm -0002 -print")
+	output, err := m.SSH("sudo find / -ignore_readdir_race -path /sys -prune -o -path /proc -prune -o -path /var/lib/rkt -prune -o -type f -perm -0002 -print")
 	if err != nil {
 		return fmt.Errorf("Failed to run find: output %s, status: %v", output, err)
 	}
@@ -139,7 +139,7 @@ func WritableFiles(c cluster.TestCluster) error {
 func WritableDirs(c cluster.TestCluster) error {
 	m := c.Machines()[0]
 
-	output, err := m.SSH("sudo find / -path /sys -prune -o -path /proc -prune -o -path /var/lib/rkt -prune -o -type d -perm -0002 -a ! -perm -1000 -print")
+	output, err := m.SSH("sudo find / -ignore_readdir_race -path /sys -prune -o -path /proc -prune -o -path /var/lib/rkt -prune -o -type d -perm -0002 -a ! -perm -1000 -print")
 	if err != nil {
 		return fmt.Errorf("Failed to run find: output %s, status: %v", output, err)
 	}


### PR DESCRIPTION
The tests are checking if files exist with problematic modes, so we
don't care about them if they are deleted before stat is called.