### PR TITLE
kola/tests/rkt: avoid startup racing with the SSH check

### DIFF
--- a/kola/tests/rkt/rkt.go
+++ b/kola/tests/rkt/rkt.go
@@ -32,7 +32,11 @@ var conf = `{
 	"systemd": {
 		"units": [{
 			"name": "etcd-member.service",
-			"enable": true
+			"enable": true,
+			"dropins": [{
+				"name": "fix-test-races.conf",
+				"contents": "[Unit]\nBefore=sshd.service"
+			}]
 		}]
 	}
 }`


### PR DESCRIPTION
This seems to fix a random failure in `coreos.rkt.etcd3` (so far).  If this really does address the race condition, it appears that similar changes would allow removing the retries from many other tests.