### PR TITLE
Fix kola on GCE ... mostly

### DIFF
--- a/kola/tests/coretest/core.go
+++ b/kola/tests/coretest/core.go
@@ -50,23 +50,29 @@ func init() {
 			"EtcdUpdateValue":    TestEtcdUpdateValue,
 			"FleetctlRunService": TestFleetctlRunService,
 		},
-		UserData: `#cloud-config
-
-coreos:
-  etcd2:
-    name: $name
-    discovery: $discovery
-    advertise-client-urls: http://$private_ipv4:2379
-    initial-advertise-peer-urls: http://$private_ipv4:2380
-    listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
-    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
-  fleet:
-    etcd-request-timeout: 15 
-  units:
-    - name: etcd2.service
-      command: start
-    - name: fleet.service
-      command: start`,
+		UserData: `{
+  "ignition": { "version": "2.0.0" },
+  "systemd": {
+    "units": [
+      {
+        "name": "etcd2.service",
+        "enable": true,
+        "dropins": [{
+          "name": "metadata.conf",
+          "contents": "[Unit]\nWants=coreos-metadata.service\nAfter=coreos-metadata.service\n\n[Service]\nEnvironmentFile=-/run/metadata/coreos\nExecStart=\nExecStart=/usr/bin/etcd2 --discovery=$discovery --advertise-client-urls=http://$private_ipv4:2379 --initial-advertise-peer-urls=http://$private_ipv4:2380 --listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001 --listen-peer-urls=http://$private_ipv4:2380,http://$private_ipv4:7001"
+        }]
+      },
+      {
+        "name": "fleet.service",
+        "enable": true,
+        "dropins": [{
+          "name": "environment.conf",
+          "contents": "[Service]\nEnvironment=FLEET_ETCD_REQUEST_TIMEOUT=15"
+        }]
+      }
+    ]
+  }
+}`,
 	})
 
 	// tests requiring network connection to internet

--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -16,14 +16,13 @@ package etcd
 
 import (
 	"fmt"
-	"time"
+	"strings"
 
 	"github.com/coreos/pkg/capnslog"
 
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/platform"
-	"github.com/coreos/mantle/util"
 )
 
 var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "kola/tests/etcd")
@@ -31,126 +30,77 @@ var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "kola/tests/etc
 func init() {
 	// test etcd discovery with 0.4.7
 	register.Register(&register.Test{
-		Run:         DiscoveryV1,
+		Run:         Discovery,
 		Manual:      true,
 		ClusterSize: 3,
 		Name:        "coreos.etcd0.discovery",
-		UserData: `#cloud-config
-coreos:
-  etcd:
-    name: $name
-    discovery: $discovery
-    addr: $private_ipv4:2379
-    peer-addr: $private_ipv4:2380`,
+		UserData: `{
+  "ignition": { "version": "2.0.0" },
+  "systemd": {
+    "units": [
+      {
+        "name": "etcd.service",
+        "enable": true,
+        "dropins": [{
+          "name": "metadata.conf",
+          "contents": "[Unit]\nWants=coreos-metadata.service\nAfter=coreos-metadata.service\n\n[Service]\nEnvironmentFile=-/run/metadata/coreos\nExecStart=\nExecStart=/usr/bin/etcd --name=$name --discovery=$discovery --addr=$private_ipv4:2379 --peer-addr=$private_ipv4:2380"
+        }]
+      }
+    ]
+  }
+}`,
 	})
 
 	// test etcd discovery with 2.0 with new cloud config
 	register.Register(&register.Test{
-		Run:         DiscoveryV2,
+		Run:         Discovery,
 		ClusterSize: 3,
 		Name:        "coreos.etcd2.discovery",
-		UserData: `#cloud-config
-
-coreos:
-  etcd2:
-    name: $name
-    discovery: $discovery
-    advertise-client-urls: http://$private_ipv4:2379
-    initial-advertise-peer-urls: http://$private_ipv4:2380
-    listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
-    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001`,
+		UserData: `{
+  "ignition": { "version": "2.0.0" },
+  "systemd": {
+    "units": [
+      {
+        "name": "etcd2.service",
+        "enable": true,
+        "dropins": [{
+          "name": "metadata.conf",
+          "contents": "[Unit]\nWants=coreos-metadata.service\nAfter=coreos-metadata.service\n\n[Service]\nEnvironmentFile=-/run/metadata/coreos\nExecStart=\nExecStart=/usr/bin/etcd2 --name=$name --discovery=$discovery --advertise-client-urls=http://$private_ipv4:2379 --initial-advertise-peer-urls=http://$private_ipv4:2380 --listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001 --listen-peer-urls=http://$private_ipv4:2380,http://$private_ipv4:7001"
+        }]
+      }
+    ]
+  }
+}`,
 	})
 }
 
-func DiscoveryV2(c cluster.TestCluster) error {
-	return discovery(c, 2)
-}
+func Discovery(c cluster.TestCluster) error {
+	var err error
 
-func DiscoveryV1(c cluster.TestCluster) error {
-	return discovery(c, 1)
-}
-
-func doStart(m platform.Machine, version int, block bool) error {
-	// start etcd instance
-	var etcdStart string
-	if version == 1 {
-		etcdStart = "sudo systemctl start etcd.service"
-	} else if version == 2 {
-		etcdStart = "sudo systemctl start etcd2.service"
-	} else {
-		return fmt.Errorf("etcd version unspecified")
-	}
-
-	if !block {
-		etcdStart += " --no-block"
-	}
-
-	_, err := m.SSH(etcdStart)
-	if err != nil {
-		return fmt.Errorf("SSH cmd to %v failed: %s", m.IP(), err)
-	}
-
-	return nil
-}
-
-func discovery(cluster platform.Cluster, version int) error {
 	if plog.LevelAt(capnslog.DEBUG) {
 		// get journalctl -f from all machines before starting
-		for _, m := range cluster.Machines() {
-			if err := platform.StreamJournal(m); err != nil {
+		for _, m := range c.Machines() {
+			if err = platform.StreamJournal(m); err != nil {
 				return fmt.Errorf("failed to start journal: %v", err)
 			}
 		}
 	}
 
-	// start etcd on each machine asynchronously.
-	for _, m := range cluster.Machines() {
-		if err := doStart(m, version, false); err != nil {
-			return err
-		}
-	}
-
-	// block until each instance is reported as started.
-	for i, m := range cluster.Machines() {
-		if err := doStart(m, version, true); err != nil {
-			return err
-		}
-		plog.Infof("etcd instance%d started", i)
-	}
-
 	// NOTE(pb): this check makes the next code somewhat redundant
-	if err := GetClusterHealth(cluster.Machines()[0], len(cluster.Machines())); err != nil {
+	if err = GetClusterHealth(c.Machines()[0], len(c.Machines())); err != nil {
 		return fmt.Errorf("discovery failed cluster-health check: %v", err)
 	}
 
 	var keyMap map[string]string
-	var retryFuncs []func() error
+	keyMap, err = setKeys(c, 5)
+	if err != nil {
+		return fmt.Errorf("failed to set keys: %v", err)
+	}
 
-	retryFuncs = append(retryFuncs, func() error {
-		var err error
-		keyMap, err = setKeys(cluster, 5)
-		if err != nil {
-			return err
-		}
-		return nil
-	})
-	retryFuncs = append(retryFuncs, func() error {
-		var quorumRead bool
-		if version == 2 {
-			quorumRead = true
-		}
-		if err := checkKeys(cluster, keyMap, quorumRead); err != nil {
-			return err
-		}
-		return nil
-	})
-	for _, retry := range retryFuncs {
-		if err := util.Retry(5, 5*time.Second, retry); err != nil {
-			return fmt.Errorf("discovery failed set/get check: %v", err)
-		}
-		// NOTE(pb): etcd1 seems to fail in an odd way when I try quorum
-		// read, instead just sleep between setting and getting.
-		time.Sleep(2 * time.Second)
+	var quorumRead bool
+	quorumRead = strings.Contains(c.Name, "etcd2")
+	if err = checkKeys(c, keyMap, quorumRead); err != nil {
+		return fmt.Errorf("failed to check keys: %v", err)
 	}
 
 	return nil

--- a/kola/tests/flannel/flannel.go
+++ b/kola/tests/flannel/flannel.go
@@ -83,7 +83,7 @@ func init() {
 // get docker bridge ip from a machine
 func mach2bip(m platform.Machine, ifname string) (string, error) {
 	// note the escaped % in awk.
-	out, err := m.SSH(fmt.Sprintf(`ip -4 -o addr show dev %s primary | awk -F " +|/" '{printf "%%s", $4}'`, ifname))
+	out, err := m.SSH(fmt.Sprintf(`/usr/lib/systemd/systemd-networkd-wait-online --interface=%s --timeout=60 ; ip -4 -o addr show dev %s primary | awk -F " +|/" '{printf "%%s", $4}'`, ifname, ifname))
 	if err != nil {
 		return "", err
 	}

--- a/kola/tests/flannel/flannel.go
+++ b/kola/tests/flannel/flannel.go
@@ -54,6 +54,13 @@ var (
         }]
       },
       {
+        "name": "flannel-docker-opts.service",
+        "dropins": [{
+          "name": "retry.conf",
+          "contents": "[Service]\nTimeoutStartSec=300\nExecStart=\nExecStart=/bin/sh -exc 'for try in 1 2 3 4 5 6 ; do /usr/lib/coreos/flannel-wrapper -d /run/flannel/flannel_docker_opts.env -i && break || sleep 10 ; try=fail ; done ; [ $try != fail ]'"
+        }]
+      },
+      {
         "name": "docker.service",
         "enable": true
       }

--- a/kola/tests/fleet/fleet.go
+++ b/kola/tests/fleet/fleet.go
@@ -20,69 +20,84 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/coreos-cloudinit/config"
 	"github.com/coreos/pkg/capnslog"
 
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
-	"github.com/coreos/mantle/platform"
+	"github.com/coreos/mantle/kola/tests/etcd"
 	"github.com/coreos/mantle/util"
 )
 
 var (
 	plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "kola/tests/fleet")
 
-	masterconf = config.CloudConfig{
-		CoreOS: config.CoreOS{
-			Etcd2: config.Etcd2{
-				AdvertiseClientURLs:      "http://$private_ipv4:2379",
-				InitialAdvertisePeerURLs: "http://$private_ipv4:2380",
-				ListenClientURLs:         "http://0.0.0.0:2379,http://0.0.0.0:4001",
-				ListenPeerURLs:           "http://$private_ipv4:2380,http://$private_ipv4:7001",
-			},
-			Fleet: config.Fleet{
-				EtcdRequestTimeout: 15,
-			},
-			Units: []config.Unit{
-				config.Unit{
-					Name:    "etcd2.service",
-					Command: "start",
-				},
-				config.Unit{
-					Name:    "fleet.service",
-					Command: "start",
-				},
-			},
-		},
-		Hostname: "master",
-	}
+	masterconf = `{
+  "ignition": { "version": "2.0.0" },
+  "systemd": {
+    "units": [
+      {
+        "name": "etcd2.service",
+        "enable": true,
+        "dropins": [{
+          "name": "metadata.conf",
+          "contents": "[Unit]\nWants=coreos-metadata.service\nAfter=coreos-metadata.service\n\n[Service]\nEnvironmentFile=-/run/metadata/coreos\nExecStart=\nExecStart=/usr/bin/etcd2 --discovery=$discovery --advertise-client-urls=http://$private_ipv4:2379 --initial-advertise-peer-urls=http://$private_ipv4:2380 --listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001 --listen-peer-urls=http://$private_ipv4:2380,http://$private_ipv4:7001"
+        }]
+      },
+      {
+        "name": "fleet.service",
+        "enable": true,
+        "dropins": [{
+          "name": "environment.conf",
+          "contents": "[Service]\nEnvironment=FLEET_ETCD_REQUEST_TIMEOUT=15"
+        }]
+      }
+    ]
+  },
+  "storage": {
+    "files": [{
+      "filesystem": "root",
+      "path": "/etc/hostname",
+      "contents": { "source": "data:,master" },
+      "mode": 420
+    }]
+  }
+}`
 
-	proxyconf = config.CloudConfig{
-		CoreOS: config.CoreOS{
-			Etcd2: config.Etcd2{
-				Proxy:            "on",
-				ListenClientURLs: "http://0.0.0.0:2379,http://0.0.0.0:4001",
-			},
-			Units: []config.Unit{
-				config.Unit{
-					Name:    "etcd2.service",
-					Command: "start",
-				},
-				config.Unit{
-					Name:    "fleet.service",
-					Command: "start",
-				},
-			},
-		},
-		Hostname: "proxy",
-	}
-
-	fleetunit = `
-[Unit]
-Description=simple fleet test
-[Service]
-ExecStart=/bin/sh -c "while sleep 1; do echo hello world; done"
-`
+	proxyconf = `{
+  "ignition": { "version": "2.0.0" },
+  "systemd": {
+    "units": [
+      {
+        "name": "etcd2.service",
+        "enable": true,
+        "dropins": [{
+          "name": "metadata.conf",
+          "contents": "[Unit]\nWants=coreos-metadata.service\nAfter=coreos-metadata.service\n\n[Service]\nEnvironmentFile=-/run/metadata/coreos\nExecStart=\nExecStart=/usr/bin/etcd2 --discovery=$discovery --proxy=on --listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001"
+        }]
+      },
+      {
+        "name": "fleet.service",
+        "enable": true
+      }
+    ]
+  },
+  "storage": {
+    "files": [
+      {
+        "filesystem": "root",
+        "path": "/etc/hostname",
+        "contents": { "source": "data:,proxy" },
+        "mode": 420
+      },
+      {
+        "filesystem": "root",
+        "path": "/home/core/hello.service",
+        "contents": { "source": "data:,%5BUnit%5D%0ADescription=simple%20fleet%20test%0A%5BService%5D%0AExecStart=/bin/sh%20-c%20%22while%20sleep%201%3B%20do%20echo%20hello%20world%3B%20done%22" },
+        "mode": 420
+      }
+    ]
+  }
+}`
 )
 
 func init() {
@@ -96,30 +111,33 @@ func init() {
 
 // Test fleet running through an etcd2 proxy.
 func Proxy(c cluster.TestCluster) error {
-	masterconf.CoreOS.Etcd2.Discovery, _ = c.GetDiscoveryURL(1)
-	master, err := c.NewMachine(masterconf.String())
+	discoveryURL, _ := c.GetDiscoveryURL(1)
+
+	master, err := c.NewMachine(strings.Replace(masterconf, "$discovery", discoveryURL, -1))
 	if err != nil {
-		return fmt.Errorf("Cluster.NewMachine: %s", err)
+		return fmt.Errorf("Cluster.NewMachine master: %s", err)
 	}
 	defer master.Destroy()
 
-	proxyconf.CoreOS.Etcd2.Discovery = masterconf.CoreOS.Etcd2.Discovery
-	proxy, err := c.NewMachine(proxyconf.String())
+	proxy, err := c.NewMachine(strings.Replace(proxyconf, "$discovery", discoveryURL, -1))
 	if err != nil {
-		return fmt.Errorf("Cluster.NewMachine: %s", err)
+		return fmt.Errorf("Cluster.NewMachine proxy: %s", err)
 	}
 	defer proxy.Destroy()
 
-	err = platform.InstallFile(strings.NewReader(fleetunit), proxy, "/home/core/hello.service")
-	if err != nil {
-		return fmt.Errorf("InstallFile: %s", err)
+	// Wait for all etcd cluster nodes to be ready.
+	if err = etcd.GetClusterHealth(master, 1); err != nil {
+		return fmt.Errorf("cluster health master: %v", err)
+	}
+	if err = etcd.GetClusterHealth(proxy, 1); err != nil {
+		return fmt.Errorf("cluster health proxy: %v", err)
 	}
 
-	// settling...
+	// Several seconds can pass after etcd is ready before fleet notices.
 	fleetStart := func() error {
 		_, err = proxy.SSH("fleetctl start /home/core/hello.service")
 		if err != nil {
-			return fmt.Errorf("fleetctl start: %s", err)
+			return fmt.Errorf("fleetctl start: %v", err)
 		}
 		return nil
 	}
@@ -127,23 +145,13 @@ func Proxy(c cluster.TestCluster) error {
 		return fmt.Errorf("fleetctl start failed: %v", err)
 	}
 
-	var status []byte
-
-	fleetList := func() error {
-		status, err = proxy.SSH("fleetctl list-units -l -fields active -no-legend")
-		if err != nil {
-			return fmt.Errorf("fleetctl list-units: %s", err)
-		}
-
-		if !bytes.Equal(status, []byte("active")) {
-			return fmt.Errorf("unit not active")
-		}
-
-		return nil
+	status, err := proxy.SSH("fleetctl list-units -l -fields active -no-legend")
+	if err != nil {
+		return fmt.Errorf("fleetctl list-units failed: %v", err)
 	}
 
-	if err := util.Retry(5, 1*time.Second, fleetList); err != nil {
-		return fmt.Errorf("fleetctl list-units failed: %v", err)
+	if !bytes.Equal(status, []byte("active")) {
+		return fmt.Errorf("unit not active")
 	}
 
 	return nil

--- a/kola/tests/locksmith/locksmith.go
+++ b/kola/tests/locksmith/locksmith.go
@@ -16,15 +16,14 @@ package locksmith
 
 import (
 	"fmt"
-	"time"
 
 	"golang.org/x/net/context"
 
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
+	"github.com/coreos/mantle/kola/tests/etcd"
 	"github.com/coreos/mantle/lang/worker"
 	"github.com/coreos/mantle/platform"
-	"github.com/coreos/mantle/util"
 )
 
 func init() {
@@ -32,39 +31,41 @@ func init() {
 		Name:        "coreos.locksmith.cluster",
 		Run:         locksmithCluster,
 		ClusterSize: 3,
-		UserData: `#cloud-config
-
-coreos:
-  update:
-    reboot-strategy: etcd-lock
-  etcd2:
-    name: $name
-    discovery: $discovery
-    advertise-client-urls: http://$private_ipv4:2379
-    initial-advertise-peer-urls: http://$private_ipv4:2380
-    listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
-    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
-  units:
-    - name: etcd2.service
-      command: start
-`,
+		UserData: `{
+  "ignition": { "version": "2.0.0" },
+  "systemd": {
+    "units": [
+      {
+        "name": "etcd2.service",
+        "enable": true,
+        "dropins": [{
+          "name": "metadata.conf",
+          "contents": "[Unit]\nWants=coreos-metadata.service\nAfter=coreos-metadata.service\n\n[Service]\nEnvironmentFile=-/run/metadata/coreos\nExecStart=\nExecStart=/usr/bin/etcd2 --name=$name --discovery=$discovery --advertise-client-urls=http://$private_ipv4:2379 --initial-advertise-peer-urls=http://$private_ipv4:2380 --listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001 --listen-peer-urls=http://$private_ipv4:2380,http://$private_ipv4:7001"
+        }]
+      }
+    ]
+  },
+  "files": [{
+    "filesystem": "root",
+    "path": "/etc/coreos/update.conf",
+    "contents": { "source": "data:,REBOOT_STRATEGY=etcd-lock%0A" },
+    "mode": 420
+  }]
+}`,
 	})
 }
 
 func locksmithCluster(c cluster.TestCluster) error {
 	machs := c.Machines()
 
-	// make sure etcd is ready
-	etcdCheck := func() error {
-		output, err := machs[0].SSH("locksmithctl status")
-		if err != nil {
-			return fmt.Errorf("cluster health: %q: %v", output, err)
-		}
-		return nil
+	// Wait for all etcd cluster nodes to be ready.
+	if err := etcd.GetClusterHealth(machs[0], len(machs)); err != nil {
+		return fmt.Errorf("cluster health: %v", err)
 	}
 
-	if err := util.Retry(6, 5*time.Second, etcdCheck); err != nil {
-		return fmt.Errorf("etcd bootstrap failed: %v", err)
+	output, err := machs[0].SSH("locksmithctl status")
+	if err != nil {
+		return fmt.Errorf("locksmithctl status: %q: %v", output, err)
 	}
 
 	ctx := context.Background()

--- a/platform/machine/aws/cluster.go
+++ b/platform/machine/aws/cluster.go
@@ -16,6 +16,7 @@ package aws
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/api/aws"
@@ -62,6 +63,12 @@ func NewCluster(opts *aws.Options) (platform.Cluster, error) {
 }
 
 func (ac *cluster) NewMachine(userdata string) (platform.Machine, error) {
+	// hacky solution for unified ignition metadata variables
+	if strings.Contains(userdata, `"ignition":`) {
+		userdata = strings.Replace(userdata, "$public_ipv4", "${COREOS_EC2_IPV4_PUBLIC}", -1)
+		userdata = strings.Replace(userdata, "$private_ipv4", "${COREOS_EC2_IPV4_LOCAL}", -1)
+	}
+
 	conf, err := conf.New(userdata)
 	if err != nil {
 		return nil, err

--- a/platform/machine/gcloud/cluster.go
+++ b/platform/machine/gcloud/cluster.go
@@ -16,6 +16,8 @@
 package gcloud
 
 import (
+	"strings"
+
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/api/gcloud"
 	"github.com/coreos/mantle/platform/conf"
@@ -47,6 +49,12 @@ func NewCluster(opts *gcloud.Options) (platform.Cluster, error) {
 
 // Calling in parallel is ok
 func (gc *cluster) NewMachine(userdata string) (platform.Machine, error) {
+	// hacky solution for unified ignition metadata variables
+	if strings.Contains(userdata, `"ignition":`) {
+		userdata = strings.Replace(userdata, "$public_ipv4", "${COREOS_GCE_IP_EXTERNAL_0}", -1)
+		userdata = strings.Replace(userdata, "$private_ipv4", "${COREOS_GCE_IP_LOCAL_0}", -1)
+	}
+
 	conf, err := conf.New(userdata)
 	if err != nil {
 		return nil, err

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	sshRetries = 10
-	sshTimeout = 5 * time.Second
+	sshRetries = 30
+	sshTimeout = 10 * time.Second
 )
 
 var (

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -243,7 +243,7 @@ func CheckMachine(m Machine) error {
 	// ensure ssh works and the system is ready
 	sshChecker := func() error {
 		out, err := m.SSH("systemctl is-system-running")
-		if !bytes.Contains([]byte("initializing starting running"), out) {
+		if !bytes.Contains([]byte("initializing starting running stopping"), out) {
 			return nil // stop retrying if the system went haywire
 		}
 		return err

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -240,13 +240,13 @@ func NewMachines(c Cluster, userdatas []string) ([]Machine, error) {
 //
 // TODO(mischief): better error messages.
 func CheckMachine(m Machine) error {
-	// ensure ssh works
+	// ensure ssh works and the system is ready
 	sshChecker := func() error {
-		_, err := m.SSH("true")
-		if err != nil {
-			return err
+		out, err := m.SSH("systemctl is-system-running")
+		if !bytes.Contains([]byte("initializing starting running"), out) {
+			return nil // stop retrying if the system went haywire
 		}
-		return nil
+		return err
 	}
 
 	if err := util.Retry(sshRetries, sshTimeout, sshChecker); err != nil {


### PR DESCRIPTION
For fun, here is a list of some of the race conditions I can recall offhand from running kola on GCE (in addition to the non-race problems).

  * All tests assume they can run immediately when SSH connects.  There are no service dependency relations between `sshd` and anything being tested.
  * Similarly, the cloud-config service has no dependencies with tested services, so even when SSH would connect and start services itself, the services' configuration files sometimes weren't written yet.
  * There were the usual `find` races, where files could sometimes be deleted between `readdir` and `stat`.  (This one was fixed separately in #430.)
  * The etcd commands will all happily run and fail before the cluster is healthy.  This includes all services acting as etcd clients.
  * The fleet daemon doesn't block or use etcd immediately, so `systemctl start fleet ; fleetctl status` will fail even if the etcd cluster is healthy.
  * When stopping sshd before locksmith reboots, the connection would still sometimes terminate too soon resulting in error.
  * For locksmith reboots, the tests would sometimes start checking for the newly booted system before it went down.
  * Network interfaces are created asynchronously, so they don't always exist between flannel running and the `ip` commands.

So...  There are still four failures that I can recall seeing that are not addressed here.  The two Kubernetes tests fail randomly, and this is likely due to the cloud-config races (and probably others) described above.  There was also a failure to reach the GCE metadata service, and I've seen flannel's vxlan test fail seemingly because an etcd system lost its connection to the cluster.  The first two need work on the Kubernetes setup, and the other two sound like they could have been problems with GCE itself.  I'll ignore those for the time being, in the interest of getting semi-functional GCE tests now.