### PR TITLE
New package for processing journals from remote sources

### DIFF
--- a/network/journal/entry.go
+++ b/network/journal/entry.go
@@ -1,0 +1,111 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package journal
+
+import (
+	"strconv"
+	"time"
+)
+
+// Journal entry field strings which correspond to:
+// http://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html
+const (
+	// User Journal Fields
+	FIELD_MESSAGE           = "MESSAGE"
+	FIELD_MESSAGE_ID        = "MESSAGE_ID"
+	FIELD_PRIORITY          = "PRIORITY"
+	FIELD_CODE_FILE         = "CODE_FILE"
+	FIELD_CODE_LINE         = "CODE_LINE"
+	FIELD_CODE_FUNC         = "CODE_FUNC"
+	FIELD_ERRNO             = "ERRNO"
+	FIELD_SYSLOG_FACILITY   = "SYSLOG_FACILITY"
+	FIELD_SYSLOG_IDENTIFIER = "SYSLOG_IDENTIFIER"
+	FIELD_SYSLOG_PID        = "SYSLOG_PID"
+
+	// Trusted Journal Fields
+	FIELD_PID                       = "_PID"
+	FIELD_UID                       = "_UID"
+	FIELD_GID                       = "_GID"
+	FIELD_COMM                      = "_COMM"
+	FIELD_EXE                       = "_EXE"
+	FIELD_CMDLINE                   = "_CMDLINE"
+	FIELD_CAP_EFFECTIVE             = "_CAP_EFFECTIVE"
+	FIELD_AUDIT_SESSION             = "_AUDIT_SESSION"
+	FIELD_AUDIT_LOGINUID            = "_AUDIT_LOGINUID"
+	FIELD_SYSTEMD_CGROUP            = "_SYSTEMD_CGROUP"
+	FIELD_SYSTEMD_SESSION           = "_SYSTEMD_SESSION"
+	FIELD_SYSTEMD_UNIT              = "_SYSTEMD_UNIT"
+	FIELD_SYSTEMD_USER_UNIT         = "_SYSTEMD_USER_UNIT"
+	FIELD_SYSTEMD_OWNER_UID         = "_SYSTEMD_OWNER_UID"
+	FIELD_SYSTEMD_SLICE             = "_SYSTEMD_SLICE"
+	FIELD_SELINUX_CONTEXT           = "_SELINUX_CONTEXT"
+	FIELD_SOURCE_REALTIME_TIMESTAMP = "_SOURCE_REALTIME_TIMESTAMP"
+	FIELD_BOOT_ID                   = "_BOOT_ID"
+	FIELD_MACHINE_ID                = "_MACHINE_ID"
+	FIELD_HOSTNAME                  = "_HOSTNAME"
+	FIELD_TRANSPORT                 = "_TRANSPORT"
+
+	// Kernel Journal Fields
+	FIELD_KERNEL_DEVICE    = "_KERNEL_DEVICE"
+	FIELD_KERNEL_SUBSYSTEM = "_KERNEL_SUBSYSTEM"
+	FIELD_UDEV_SYSNAME     = "_UDEV_SYSNAME"
+	FIELD_UDEV_DEVNODE     = "_UDEV_DEVNODE"
+	FIELD_UDEV_DEVLINK     = "_UDEV_DEVLINK"
+
+	// Fields to log on behalf of a different program
+	FIELD_COREDUMP_UNIT            = "COREDUMP_UNIT"
+	FIELD_COREDUMP_USER_UNIT       = "COREDUMP_USER_UNIT"
+	FIELD_OBJECT_PID               = "OBJECT_PID"
+	FIELD_OBJECT_UID               = "OBJECT_UID"
+	FIELD_OBJECT_GID               = "OBJECT_GID"
+	FIELD_OBJECT_COMM              = "OBJECT_COMM"
+	FIELD_OBJECT_EXE               = "OBJECT_EXE"
+	FIELD_OBJECT_CMDLINE           = "OBJECT_CMDLINE"
+	FIELD_OBJECT_AUDIT_SESSION     = "OBJECT_AUDIT_SESSION"
+	FIELD_OBJECT_AUDIT_LOGINUID    = "OBJECT_AUDIT_LOGINUID"
+	FIELD_OBJECT_SYSTEMD_CGROUP    = "OBJECT_SYSTEMD_CGROUP"
+	FIELD_OBJECT_SYSTEMD_SESSION   = "OBJECT_SYSTEMD_SESSION"
+	FIELD_OBJECT_SYSTEMD_UNIT      = "OBJECT_SYSTEMD_UNIT"
+	FIELD_OBJECT_SYSTEMD_USER_UNIT = "OBJECT_SYSTEMD_USER_UNIT"
+	FIELD_OBJECT_SYSTEMD_OWNER_UID = "OBJECT_SYSTEMD_OWNER_UID"
+
+	// Address Fields
+	FIELD_CURSOR              = "__CURSOR"
+	FIELD_REALTIME_TIMESTAMP  = "__REALTIME_TIMESTAMP"
+	FIELD_MONOTONIC_TIMESTAMP = "__MONOTONIC_TIMESTAMP"
+)
+
+// Entry is a map of fields representing a single journal entry.
+type Entry map[string][]byte
+
+// Realtime parses the SOURCE_REALTIME_TIMESTAMP or REALTIME_TIMESTAMP
+// field, preferring the former when available.
+func (e Entry) Realtime() time.Time {
+	timestamp, ok := e[FIELD_SOURCE_REALTIME_TIMESTAMP]
+	if !ok {
+		timestamp, ok = e[FIELD_REALTIME_TIMESTAMP]
+		if !ok {
+			return time.Time{}
+		}
+	}
+
+	usec, err := strconv.ParseUint(string(timestamp), 10, 64)
+	if err != nil || usec < 1e6 {
+		return time.Time{}
+	}
+	sec := usec / 1e6
+	nsec := (usec - (sec * 1e6)) * 1000
+	return time.Unix(int64(sec), int64(nsec))
+}

--- a/network/journal/entry_test.go
+++ b/network/journal/entry_test.go
@@ -1,0 +1,66 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package journal
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEntryRealtime(t *testing.T) {
+	for _, testcase := range []struct {
+		name   string
+		entry  Entry
+		expect time.Time
+	}{{
+		name:   "zero",
+		entry:  Entry{},
+		expect: time.Time{},
+	}, {
+		name: "has_source",
+		entry: Entry{
+			FIELD_SOURCE_REALTIME_TIMESTAMP: []byte("1342540861416351"),
+			FIELD_REALTIME_TIMESTAMP:        []byte("1342540861416409"),
+		},
+		expect: time.Unix(1342540861, 416351000),
+	}, {
+		name: "no_source",
+		entry: Entry{
+			FIELD_REALTIME_TIMESTAMP: []byte("1342540861416409"),
+		},
+		expect: time.Unix(1342540861, 416409000),
+	}, {
+		name: "invalid_source",
+		entry: Entry{
+			FIELD_SOURCE_REALTIME_TIMESTAMP: []byte("bob"),
+			FIELD_REALTIME_TIMESTAMP:        []byte("1342540861416409"),
+		},
+		expect: time.Time{},
+	}, {
+		name: "invalid_both",
+		entry: Entry{
+			FIELD_REALTIME_TIMESTAMP: []byte("bob"),
+		},
+		expect: time.Time{},
+	},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			result := testcase.entry.Realtime()
+			if result != testcase.expect {
+				t.Errorf("%s != %s", result, testcase.expect)
+			}
+		})
+	}
+}

--- a/network/journal/export.go
+++ b/network/journal/export.go
@@ -1,0 +1,112 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package journal
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+)
+
+type ExportReader struct {
+	buf *bufio.Reader
+}
+
+func NewExportReader(r io.Reader) *ExportReader {
+	return &ExportReader{
+		buf: bufio.NewReader(r),
+	}
+}
+
+// ReadEntry reads one journal entry from the stream and returns it as a map.
+func (e *ExportReader) ReadEntry() (map[string][]byte, error) {
+	entry := make(map[string][]byte)
+	for {
+		name, value, err := e.readField()
+		if err != nil {
+			return nil, err
+		}
+		if name == "" {
+			if len(entry) != 0 {
+				// terminate entry on a trailing newline.
+				return entry, nil
+			}
+			// skip any leading newlines.
+			continue
+		}
+		entry[name] = value
+	}
+}
+
+// read a text or binary field name and value.
+func (e *ExportReader) readField() (name string, value []byte, err error) {
+	line, err := e.readLine()
+	if err != nil {
+		return
+	}
+	if len(line) == 0 {
+		return
+	}
+
+	eq := bytes.IndexByte(line, '=')
+	if eq == 0 {
+		err = errors.New("journal: empty field name")
+		return
+	} else if eq > 0 {
+		name = string(line[:eq])
+		value = line[eq+1:]
+		return
+	} else {
+		name = string(line)
+		value, err = e.readBinary()
+		return
+	}
+}
+
+// read the next line, trim the trailing newline.
+func (e *ExportReader) readLine() ([]byte, error) {
+	line, err := e.buf.ReadBytes('\n')
+	if err != nil {
+		return nil, err
+	}
+	// trim the trailing newline
+	return line[:len(line)-1], nil
+}
+
+// read binary field value
+func (e *ExportReader) readBinary() ([]byte, error) {
+	// first, a little-endian 64bit data size
+	size := make([]byte, 8)
+	if _, err := io.ReadFull(e.buf, size); err != nil {
+		return nil, err
+	}
+
+	// then, the data
+	value := make([]byte, binary.LittleEndian.Uint64(size))
+	if _, err := io.ReadFull(e.buf, value); err != nil {
+		return nil, err
+	}
+
+	// finally, a trailing newline before the next field.
+	if newline, err := e.buf.ReadByte(); err != nil {
+		return nil, err
+	} else if newline != '\n' {
+		return nil, errors.New("journal: binary field missing terminating newline")
+	}
+
+	return value, nil
+}

--- a/network/journal/export.go
+++ b/network/journal/export.go
@@ -33,8 +33,8 @@ func NewExportReader(r io.Reader) *ExportReader {
 }
 
 // ReadEntry reads one journal entry from the stream and returns it as a map.
-func (e *ExportReader) ReadEntry() (map[string][]byte, error) {
-	entry := make(map[string][]byte)
+func (e *ExportReader) ReadEntry() (Entry, error) {
+	entry := make(Entry)
 	for {
 		name, value, err := e.readField()
 		if err != nil {

--- a/network/journal/export_test.go
+++ b/network/journal/export_test.go
@@ -109,11 +109,23 @@ _SOURCE_REALTIME_TIMESTAMP=1423944916372858
 
 func TestExportReaderText(t *testing.T) {
 	er := NewExportReader(strings.NewReader(exportText))
-	if _, err := er.ReadEntry(); err != nil {
+	if entry, err := er.ReadEntry(); err != nil {
 		t.Errorf("first read failed: %v", err)
+	} else {
+		const expect = "AccountsService-DEBUG(+): ActUserManager: ignoring unspecified session '8' since it's not graphical: Success"
+		msg := string(entry[FIELD_MESSAGE])
+		if msg != expect {
+			t.Errorf("%q != %q", msg, expect)
+		}
 	}
-	if _, err := er.ReadEntry(); err != nil {
+	if entry, err := er.ReadEntry(); err != nil {
 		t.Errorf("second read failed: %v", err)
+	} else {
+		const expect = "(root) CMD (run-parts /etc/cron.hourly)"
+		msg := string(entry[FIELD_MESSAGE])
+		if msg != expect {
+			t.Errorf("%q != %q", msg, expect)
+		}
 	}
 	if _, err := er.ReadEntry(); err != io.EOF {
 		t.Errorf("final read didn't return EOF: %v", err)
@@ -122,11 +134,23 @@ func TestExportReaderText(t *testing.T) {
 
 func TestExportReaderLeadingNewline(t *testing.T) {
 	er := NewExportReader(strings.NewReader("\n" + exportText))
-	if _, err := er.ReadEntry(); err != nil {
+	if entry, err := er.ReadEntry(); err != nil {
 		t.Errorf("first read failed: %v", err)
+	} else {
+		const expect = "AccountsService-DEBUG(+): ActUserManager: ignoring unspecified session '8' since it's not graphical: Success"
+		msg := string(entry[FIELD_MESSAGE])
+		if msg != expect {
+			t.Errorf("%q != %q", msg, expect)
+		}
 	}
-	if _, err := er.ReadEntry(); err != nil {
+	if entry, err := er.ReadEntry(); err != nil {
 		t.Errorf("second read failed: %v", err)
+	} else {
+		const expect = "(root) CMD (run-parts /etc/cron.hourly)"
+		msg := string(entry[FIELD_MESSAGE])
+		if msg != expect {
+			t.Errorf("%q != %q", msg, expect)
+		}
 	}
 	if _, err := er.ReadEntry(); err != io.EOF {
 		t.Errorf("final read didn't return EOF: %v", err)
@@ -135,8 +159,14 @@ func TestExportReaderLeadingNewline(t *testing.T) {
 
 func TestExportReaderBinary(t *testing.T) {
 	er := NewExportReader(strings.NewReader(exportBinary))
-	if _, err := er.ReadEntry(); err != nil {
+	if entry, err := er.ReadEntry(); err != nil {
 		t.Errorf("first read failed: %v", err)
+	} else {
+		const expect = "foo\nbar"
+		msg := string(entry[FIELD_MESSAGE])
+		if msg != expect {
+			t.Errorf("%q != %q", msg, expect)
+		}
 	}
 	if _, err := er.ReadEntry(); err != io.EOF {
 		t.Errorf("final read didn't return EOF: %v", err)

--- a/network/journal/export_test.go
+++ b/network/journal/export_test.go
@@ -1,0 +1,159 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package journal
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+const (
+	exportText = `__CURSOR=s=739ad463348b4ceca5a9e69c95a3c93f;i=4ece7;b=6c7c6013a26343b29e964691ff25d04c;m=4fc72436e;t=4c508a72423d9;x=d3e5610681098c10;p=system.journal
+__REALTIME_TIMESTAMP=1342540861416409
+__MONOTONIC_TIMESTAMP=21415215982
+_BOOT_ID=6c7c6013a26343b29e964691ff25d04c
+_TRANSPORT=syslog
+PRIORITY=4
+SYSLOG_FACILITY=3
+SYSLOG_IDENTIFIER=gdm-password]
+SYSLOG_PID=587
+MESSAGE=AccountsService-DEBUG(+): ActUserManager: ignoring unspecified session '8' since it's not graphical: Success
+_PID=587
+_UID=0
+_GID=500
+_COMM=gdm-session-wor
+_EXE=/usr/libexec/gdm-session-worker
+_CMDLINE=gdm-session-worker [pam/gdm-password]
+_AUDIT_SESSION=2
+_AUDIT_LOGINUID=500
+_SYSTEMD_CGROUP=/user/lennart/2
+_SYSTEMD_SESSION=2
+_SELINUX_CONTEXT=system_u:system_r:xdm_t:s0-s0:c0.c1023
+_SOURCE_REALTIME_TIMESTAMP=1342540861413961
+_MACHINE_ID=a91663387a90b89f185d4e860000001a
+_HOSTNAME=epsilon
+
+__CURSOR=s=739ad463348b4ceca5a9e69c95a3c93f;i=4ece8;b=6c7c6013a26343b29e964691ff25d04c;m=4fc72572f;t=4c508a7243799;x=68597058a89b7246;p=system.journal
+__REALTIME_TIMESTAMP=1342540861421465
+__MONOTONIC_TIMESTAMP=21415221039
+_BOOT_ID=6c7c6013a26343b29e964691ff25d04c
+_TRANSPORT=syslog
+PRIORITY=6
+SYSLOG_FACILITY=9
+SYSLOG_IDENTIFIER=/USR/SBIN/CROND
+SYSLOG_PID=8278
+MESSAGE=(root) CMD (run-parts /etc/cron.hourly)
+_PID=8278
+_UID=0
+_GID=0
+_COMM=run-parts
+_EXE=/usr/bin/bash
+_CMDLINE=/bin/bash /bin/run-parts /etc/cron.hourly
+_AUDIT_SESSION=8
+_AUDIT_LOGINUID=0
+_SYSTEMD_CGROUP=/user/root/8
+_SYSTEMD_SESSION=8
+_SELINUX_CONTEXT=system_u:system_r:crond_t:s0-s0:c0.c1023
+_SOURCE_REALTIME_TIMESTAMP=1342540861416351
+_MACHINE_ID=a91663387a90b89f185d4e860000001a
+_HOSTNAME=epsilon
+
+`
+
+	exportBinary = `
+__CURSOR=s=bcce4fb8ffcb40e9a6e05eee8b7831bf;i=5ef603;b=ec25d6795f0645619ddac9afdef453ee;m=545242e7049;t=50f1202
+__REALTIME_TIMESTAMP=1423944916375353
+__MONOTONIC_TIMESTAMP=5794517905481
+_BOOT_ID=ec25d6795f0645619ddac9afdef453ee
+_TRANSPORT=journal
+_UID=1001
+_GID=1001
+_CAP_EFFECTIVE=0
+_SYSTEMD_OWNER_UID=1001
+_SYSTEMD_SLICE=user-1001.slice
+_MACHINE_ID=5833158886a8445e801d437313d25eff
+_HOSTNAME=bupkis
+_AUDIT_LOGINUID=1001
+_SELINUX_CONTEXT=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
+CODE_LINE=1
+CODE_FUNC=<module>
+SYSLOG_IDENTIFIER=python3
+_COMM=python3
+_EXE=/usr/bin/python3.4
+_AUDIT_SESSION=35898
+_SYSTEMD_CGROUP=/user.slice/user-1001.slice/session-35898.scope
+_SYSTEMD_SESSION=35898
+_SYSTEMD_UNIT=session-35898.scope
+MESSAGE
+` + "\x07\x00\x00\x00\x00\x00\x00\x00foo\nbar" + `
+CODE_FILE=<string>
+_PID=16853
+_CMDLINE=python3 -c from systemd import journal; journal.send("foo\nbar")
+_SOURCE_REALTIME_TIMESTAMP=1423944916372858
+
+`
+)
+
+func TestExportReaderText(t *testing.T) {
+	er := NewExportReader(strings.NewReader(exportText))
+	if _, err := er.ReadEntry(); err != nil {
+		t.Errorf("first read failed: %v", err)
+	}
+	if _, err := er.ReadEntry(); err != nil {
+		t.Errorf("second read failed: %v", err)
+	}
+	if _, err := er.ReadEntry(); err != io.EOF {
+		t.Errorf("final read didn't return EOF: %v", err)
+	}
+}
+
+func TestExportReaderLeadingNewline(t *testing.T) {
+	er := NewExportReader(strings.NewReader("\n" + exportText))
+	if _, err := er.ReadEntry(); err != nil {
+		t.Errorf("first read failed: %v", err)
+	}
+	if _, err := er.ReadEntry(); err != nil {
+		t.Errorf("second read failed: %v", err)
+	}
+	if _, err := er.ReadEntry(); err != io.EOF {
+		t.Errorf("final read didn't return EOF: %v", err)
+	}
+}
+
+func TestExportReaderBinary(t *testing.T) {
+	er := NewExportReader(strings.NewReader(exportBinary))
+	if _, err := er.ReadEntry(); err != nil {
+		t.Errorf("first read failed: %v", err)
+	}
+	if _, err := er.ReadEntry(); err != io.EOF {
+		t.Errorf("final read didn't return EOF: %v", err)
+	}
+}
+
+func BenchmarkExportReader(b *testing.B) {
+	testData := strings.Repeat(exportText+exportBinary, 10)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		er := NewExportReader(strings.NewReader(testData))
+		for {
+			if _, err := er.ReadEntry(); err == io.EOF {
+				break
+			} else if err != nil {
+				b.Error(err)
+			}
+		}
+	}
+}

--- a/network/journal/format.go
+++ b/network/journal/format.go
@@ -1,0 +1,100 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package journal
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"time"
+	"unicode"
+	"unicode/utf8"
+)
+
+// ShortWriter writes journal entries in a format similar to journalctl's
+// "short-precise" format, excluding hostname for conciseness.
+type ShortWriter struct {
+	w io.Writer
+}
+
+func NewShortWriter(w io.Writer) *ShortWriter {
+	return &ShortWriter{
+		w: w,
+	}
+}
+
+func (s *ShortWriter) WriteEntry(entry Entry) error {
+	realtime := entry.Realtime()
+	message, ok := entry[FIELD_MESSAGE]
+	if realtime.IsZero() || !ok {
+		// Simply skip entries that are woefully incomplete.
+		return nil
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString(realtime.Format(time.StampMicro))
+
+	if identifier, ok := entry[FIELD_SYSLOG_IDENTIFIER]; ok {
+		buf.WriteByte(' ')
+		buf.Write(identifier)
+	} else {
+		buf.WriteString(" unknown")
+	}
+
+	if pid, ok := entry[FIELD_PID]; ok {
+		buf.WriteByte('[')
+		buf.Write(pid)
+		buf.WriteByte(']')
+	} else if pid, ok := entry[FIELD_SYSLOG_PID]; ok {
+		buf.WriteByte('[')
+		buf.Write(pid)
+		buf.WriteByte(']')
+	}
+
+	buf.WriteString(": ")
+	indent := buf.Len()
+	lines := bytes.Split(message, []byte{'\n'})
+	writeEscaped(&buf, lines[0])
+	for _, line := range lines[1:] {
+		buf.WriteByte('\n')
+		buf.Write(bytes.Repeat([]byte{' '}, indent))
+		writeEscaped(&buf, line)
+	}
+
+	buf.WriteByte('\n')
+
+	_, err := buf.WriteTo(s.w)
+	return err
+}
+
+func writeEscaped(buf *bytes.Buffer, line []byte) {
+	const tab = "        " // 8 spaces
+	for len(line) > 0 {
+		r, n := utf8.DecodeRune(line)
+		switch r {
+		case utf8.RuneError:
+			fmt.Fprintf(buf, "\\x%02x", line[0])
+		case '\t':
+			buf.WriteString(tab)
+		default:
+			if unicode.IsPrint(r) {
+				buf.Write(line[:n])
+			} else {
+				fmt.Fprintf(buf, "\\u%04x", r)
+			}
+		}
+		line = line[n:]
+	}
+}

--- a/network/journal/format.go
+++ b/network/journal/format.go
@@ -26,13 +26,20 @@ import (
 // ShortWriter writes journal entries in a format similar to journalctl's
 // "short-precise" format, excluding hostname for conciseness.
 type ShortWriter struct {
-	w io.Writer
+	w  io.Writer
+	tz *time.Location
 }
 
 func NewShortWriter(w io.Writer) *ShortWriter {
 	return &ShortWriter{
-		w: w,
+		w:  w,
+		tz: time.Local,
 	}
+}
+
+// SetTimezone updates the time location. The default is local time.
+func (s *ShortWriter) SetTimezone(tz *time.Location) {
+	s.tz = tz
 }
 
 func (s *ShortWriter) WriteEntry(entry Entry) error {
@@ -44,7 +51,7 @@ func (s *ShortWriter) WriteEntry(entry Entry) error {
 	}
 
 	var buf bytes.Buffer
-	buf.WriteString(realtime.Format(time.StampMicro))
+	buf.WriteString(realtime.In(s.tz).Format(time.StampMicro))
 
 	if identifier, ok := entry[FIELD_SYSLOG_IDENTIFIER]; ok {
 		buf.WriteByte(' ')

--- a/network/journal/format_test.go
+++ b/network/journal/format_test.go
@@ -17,6 +17,7 @@ package journal
 import (
 	"bytes"
 	"testing"
+	"time"
 )
 
 func TestFormatShort(t *testing.T) {
@@ -34,7 +35,7 @@ func TestFormatShort(t *testing.T) {
 			FIELD_PID:                       []byte("8278"),
 			FIELD_MESSAGE:                   []byte("(root) CMD (run-parts /etc/cron.hourly)"),
 		},
-		expect: "Jul 17 09:01:01.416351 /USR/SBIN/CROND[8278]: (root) CMD (run-parts /etc/cron.hourly)\n",
+		expect: "Jul 17 16:01:01.416351 /USR/SBIN/CROND[8278]: (root) CMD (run-parts /etc/cron.hourly)\n",
 	}, {
 		name: "multiline",
 		entry: Entry{
@@ -45,7 +46,7 @@ func TestFormatShort(t *testing.T) {
 			FIELD_PID:                       []byte("8278"),
 			FIELD_MESSAGE:                   []byte("first\nsecond"),
 		},
-		expect: "Jul 17 09:01:01.416351 /USR/SBIN/CROND[8278]: first\n                                              second\n",
+		expect: "Jul 17 16:01:01.416351 /USR/SBIN/CROND[8278]: first\n                                              second\n",
 	}, {
 		name: "syslog_pid",
 		entry: Entry{
@@ -55,7 +56,7 @@ func TestFormatShort(t *testing.T) {
 			FIELD_SYSLOG_PID:                []byte("8278"),
 			FIELD_MESSAGE:                   []byte("(root) CMD (run-parts /etc/cron.hourly)"),
 		},
-		expect: "Jul 17 09:01:01.416351 /USR/SBIN/CROND[8278]: (root) CMD (run-parts /etc/cron.hourly)\n",
+		expect: "Jul 17 16:01:01.416351 /USR/SBIN/CROND[8278]: (root) CMD (run-parts /etc/cron.hourly)\n",
 	}, {
 		name: "no_pid",
 		entry: Entry{
@@ -64,7 +65,7 @@ func TestFormatShort(t *testing.T) {
 			FIELD_SYSLOG_IDENTIFIER:         []byte("/USR/SBIN/CROND"),
 			FIELD_MESSAGE:                   []byte("(root) CMD (run-parts /etc/cron.hourly)"),
 		},
-		expect: "Jul 17 09:01:01.416351 /USR/SBIN/CROND: (root) CMD (run-parts /etc/cron.hourly)\n",
+		expect: "Jul 17 16:01:01.416351 /USR/SBIN/CROND: (root) CMD (run-parts /etc/cron.hourly)\n",
 	}, {
 		name: "no_ident",
 		entry: Entry{
@@ -74,7 +75,7 @@ func TestFormatShort(t *testing.T) {
 			FIELD_PID:                       []byte("8278"),
 			FIELD_MESSAGE:                   []byte("(root) CMD (run-parts /etc/cron.hourly)"),
 		},
-		expect: "Jul 17 09:01:01.416351 unknown[8278]: (root) CMD (run-parts /etc/cron.hourly)\n",
+		expect: "Jul 17 16:01:01.416351 unknown[8278]: (root) CMD (run-parts /etc/cron.hourly)\n",
 	}, {
 		name: "no_ident_pid",
 		entry: Entry{
@@ -82,7 +83,7 @@ func TestFormatShort(t *testing.T) {
 			FIELD_SOURCE_REALTIME_TIMESTAMP: []byte("1342540861416351"),
 			FIELD_MESSAGE:                   []byte("(root) CMD (run-parts /etc/cron.hourly)"),
 		},
-		expect: "Jul 17 09:01:01.416351 unknown: (root) CMD (run-parts /etc/cron.hourly)\n",
+		expect: "Jul 17 16:01:01.416351 unknown: (root) CMD (run-parts /etc/cron.hourly)\n",
 	}, {
 		name: "no_source",
 		entry: Entry{
@@ -92,7 +93,7 @@ func TestFormatShort(t *testing.T) {
 			FIELD_PID:                []byte("8278"),
 			FIELD_MESSAGE:            []byte("(root) CMD (run-parts /etc/cron.hourly)"),
 		},
-		expect: "Jul 17 09:01:01.421465 /USR/SBIN/CROND[8278]: (root) CMD (run-parts /etc/cron.hourly)\n",
+		expect: "Jul 17 16:01:01.421465 /USR/SBIN/CROND[8278]: (root) CMD (run-parts /etc/cron.hourly)\n",
 	}, {
 		name: "no_time",
 		entry: Entry{
@@ -136,6 +137,7 @@ func TestFormatShort(t *testing.T) {
 		t.Run(testcase.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			w := NewShortWriter(&buf)
+			w.SetTimezone(time.UTC) // Needed for consistent test results.
 			if err := w.WriteEntry(testcase.entry); err != nil {
 				t.Error(err)
 			}

--- a/network/journal/format_test.go
+++ b/network/journal/format_test.go
@@ -1,0 +1,147 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package journal
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestFormatShort(t *testing.T) {
+	for _, testcase := range []struct {
+		name   string
+		entry  Entry
+		expect string
+	}{{
+		name: "all",
+		entry: Entry{
+			FIELD_REALTIME_TIMESTAMP:        []byte("1342540861421465"),
+			FIELD_SOURCE_REALTIME_TIMESTAMP: []byte("1342540861416351"),
+			FIELD_SYSLOG_IDENTIFIER:         []byte("/USR/SBIN/CROND"),
+			FIELD_SYSLOG_PID:                []byte("8278"),
+			FIELD_PID:                       []byte("8278"),
+			FIELD_MESSAGE:                   []byte("(root) CMD (run-parts /etc/cron.hourly)"),
+		},
+		expect: "Jul 17 09:01:01.416351 /USR/SBIN/CROND[8278]: (root) CMD (run-parts /etc/cron.hourly)\n",
+	}, {
+		name: "multiline",
+		entry: Entry{
+			FIELD_REALTIME_TIMESTAMP:        []byte("1342540861421465"),
+			FIELD_SOURCE_REALTIME_TIMESTAMP: []byte("1342540861416351"),
+			FIELD_SYSLOG_IDENTIFIER:         []byte("/USR/SBIN/CROND"),
+			FIELD_SYSLOG_PID:                []byte("8278"),
+			FIELD_PID:                       []byte("8278"),
+			FIELD_MESSAGE:                   []byte("first\nsecond"),
+		},
+		expect: "Jul 17 09:01:01.416351 /USR/SBIN/CROND[8278]: first\n                                              second\n",
+	}, {
+		name: "syslog_pid",
+		entry: Entry{
+			FIELD_REALTIME_TIMESTAMP:        []byte("1342540861421465"),
+			FIELD_SOURCE_REALTIME_TIMESTAMP: []byte("1342540861416351"),
+			FIELD_SYSLOG_IDENTIFIER:         []byte("/USR/SBIN/CROND"),
+			FIELD_SYSLOG_PID:                []byte("8278"),
+			FIELD_MESSAGE:                   []byte("(root) CMD (run-parts /etc/cron.hourly)"),
+		},
+		expect: "Jul 17 09:01:01.416351 /USR/SBIN/CROND[8278]: (root) CMD (run-parts /etc/cron.hourly)\n",
+	}, {
+		name: "no_pid",
+		entry: Entry{
+			FIELD_REALTIME_TIMESTAMP:        []byte("1342540861421465"),
+			FIELD_SOURCE_REALTIME_TIMESTAMP: []byte("1342540861416351"),
+			FIELD_SYSLOG_IDENTIFIER:         []byte("/USR/SBIN/CROND"),
+			FIELD_MESSAGE:                   []byte("(root) CMD (run-parts /etc/cron.hourly)"),
+		},
+		expect: "Jul 17 09:01:01.416351 /USR/SBIN/CROND: (root) CMD (run-parts /etc/cron.hourly)\n",
+	}, {
+		name: "no_ident",
+		entry: Entry{
+			FIELD_REALTIME_TIMESTAMP:        []byte("1342540861421465"),
+			FIELD_SOURCE_REALTIME_TIMESTAMP: []byte("1342540861416351"),
+			FIELD_SYSLOG_PID:                []byte("8278"),
+			FIELD_PID:                       []byte("8278"),
+			FIELD_MESSAGE:                   []byte("(root) CMD (run-parts /etc/cron.hourly)"),
+		},
+		expect: "Jul 17 09:01:01.416351 unknown[8278]: (root) CMD (run-parts /etc/cron.hourly)\n",
+	}, {
+		name: "no_ident_pid",
+		entry: Entry{
+			FIELD_REALTIME_TIMESTAMP:        []byte("1342540861421465"),
+			FIELD_SOURCE_REALTIME_TIMESTAMP: []byte("1342540861416351"),
+			FIELD_MESSAGE:                   []byte("(root) CMD (run-parts /etc/cron.hourly)"),
+		},
+		expect: "Jul 17 09:01:01.416351 unknown: (root) CMD (run-parts /etc/cron.hourly)\n",
+	}, {
+		name: "no_source",
+		entry: Entry{
+			FIELD_REALTIME_TIMESTAMP: []byte("1342540861421465"),
+			FIELD_SYSLOG_IDENTIFIER:  []byte("/USR/SBIN/CROND"),
+			FIELD_SYSLOG_PID:         []byte("8278"),
+			FIELD_PID:                []byte("8278"),
+			FIELD_MESSAGE:            []byte("(root) CMD (run-parts /etc/cron.hourly)"),
+		},
+		expect: "Jul 17 09:01:01.421465 /USR/SBIN/CROND[8278]: (root) CMD (run-parts /etc/cron.hourly)\n",
+	}, {
+		name: "no_time",
+		entry: Entry{
+			FIELD_SYSLOG_IDENTIFIER: []byte("/USR/SBIN/CROND"),
+			FIELD_SYSLOG_PID:        []byte("8278"),
+			FIELD_PID:               []byte("8278"),
+			FIELD_MESSAGE:           []byte("(root) CMD (run-parts /etc/cron.hourly)"),
+		},
+		expect: "",
+	}, {
+		name: "zero_time",
+		entry: Entry{
+			FIELD_REALTIME_TIMESTAMP: []byte("0"),
+			FIELD_SYSLOG_IDENTIFIER:  []byte("/USR/SBIN/CROND"),
+			FIELD_SYSLOG_PID:         []byte("8278"),
+			FIELD_PID:                []byte("8278"),
+			FIELD_MESSAGE:            []byte("(root) CMD (run-parts /etc/cron.hourly)"),
+		},
+		expect: "",
+	}, {
+		name: "nearly_zero_time",
+		entry: Entry{
+			FIELD_REALTIME_TIMESTAMP: []byte("2"),
+			FIELD_SYSLOG_IDENTIFIER:  []byte("/USR/SBIN/CROND"),
+			FIELD_SYSLOG_PID:         []byte("8278"),
+			FIELD_PID:                []byte("8278"),
+			FIELD_MESSAGE:            []byte("(root) CMD (run-parts /etc/cron.hourly)"),
+		},
+		expect: "",
+	}, {
+		name: "no_message",
+		entry: Entry{
+			FIELD_REALTIME_TIMESTAMP:        []byte("1342540861421465"),
+			FIELD_SOURCE_REALTIME_TIMESTAMP: []byte("1342540861416351"),
+			FIELD_SYSLOG_IDENTIFIER:         []byte("/USR/SBIN/CROND"),
+			FIELD_SYSLOG_PID:                []byte("8278"),
+			FIELD_PID:                       []byte("8278"),
+		},
+		expect: "",
+	}} {
+		t.Run(testcase.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := NewShortWriter(&buf)
+			if err := w.WriteEntry(testcase.entry); err != nil {
+				t.Error(err)
+			}
+			if buf.String() != testcase.expect {
+				t.Errorf("%q != %q", buf.String(), testcase.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This implements a parser for the journal export format used by journalctl and various journal remote tools:

https://www.freedesktop.org/wiki/Software/systemd/export/

The reason for implementing this is it will enable a higher level journal slurper to SSH to a remote host multiple times and each time resume reading the log where it left off because it'll have access to the __CURSOR field.

Since the export format is overly verbose for humans I've implemented support for writing logs in a format similar to journalctl's default output.

