### PR TITLE
kola/tests/misc: ignore unfinished systemd child listeners

### DIFF
--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -68,7 +68,12 @@ func checkListeners(m platform.Machine, protocol string, filter string, listener
 			}
 		}
 		if valid != true {
-			return fmt.Errorf("Unexpected %q listener process: %q (pid %s) on %q", protocol, processname, pid, port)
+			// systemd renames child processes in parentheses before closing their fds
+			if processname[0] == '(' {
+				plog.Infof("Ignoring %q listener process: %q (pid %s) on %q", protocol, processname, pid, port)
+			} else {
+				return fmt.Errorf("Unexpected %q listener process: %q (pid %s) on %q", protocol, processname, pid, port)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
I believe this fixes a rare race condition, where the TCP listener check fails because `(agetty` is listening on the SSH port.  When systemd forks a service process, it renames the child as the executable name in parentheses, then closes the fds.  So, in theory, the `lsof` command runs between renaming the child process and closing the fds when it's still got the SSH socket it inherited from PID 1.  (We don't need to care about the time before renaming, since it will still be named `systemd` which is whitelisted.)