### PR TITLE
Disable test using ignition on qemu

### DIFF
--- a/kola/tests/coretest/core.go
+++ b/kola/tests/coretest/core.go
@@ -50,6 +50,7 @@ func init() {
 			"EtcdUpdateValue":    TestEtcdUpdateValue,
 			"FleetctlRunService": TestFleetctlRunService,
 		},
+		Platforms: []string{"aws", "gce"},
 		UserData: `{
   "ignition": { "version": "2.0.0" },
   "systemd": {

--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -34,6 +34,7 @@ func init() {
 		Manual:      true,
 		ClusterSize: 3,
 		Name:        "coreos.etcd0.discovery",
+		Platforms:   []string{"aws", "gce"},
 		UserData: `{
   "ignition": { "version": "2.0.0" },
   "systemd": {
@@ -56,6 +57,7 @@ func init() {
 		Run:         Discovery,
 		ClusterSize: 3,
 		Name:        "coreos.etcd2.discovery",
+		Platforms:   []string{"aws", "gce"},
 		UserData: `{
   "ignition": { "version": "2.0.0" },
   "systemd": {

--- a/kola/tests/fleet/fleet.go
+++ b/kola/tests/fleet/fleet.go
@@ -105,6 +105,7 @@ func init() {
 		Run:         Proxy,
 		ClusterSize: 0,
 		Name:        "coreos.fleet.etcdproxy",
+		Platforms:   []string{"aws", "gce"},
 		UserData:    `#cloud-config`,
 	})
 }

--- a/kola/tests/locksmith/locksmith.go
+++ b/kola/tests/locksmith/locksmith.go
@@ -32,6 +32,7 @@ func init() {
 		Name:        "coreos.locksmith.cluster",
 		Run:         locksmithCluster,
 		ClusterSize: 3,
+		Platforms:   []string{"aws", "gce"},
 		UserData: `{
   "ignition": { "version": "2.0.0" },
   "systemd": {


### PR DESCRIPTION
Many tests were converted to use ignition for configuration without implementing ignition support in the qemu platform code. Disable for now, I'm in the middle of cleaning up the qemu code and will add ignition support in the process.