### PR TITLE
Fix the `--debug` flag for the `ore` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *.sw?
-bin/
-
+/bin/
+/gopath/

--- a/cmd/ore/azure/azure.go
+++ b/cmd/ore/azure/azure.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/coreos/mantle/auth"
+	"github.com/coreos/mantle/cli"
 	"github.com/coreos/mantle/platform/api/azure"
 )
 
@@ -26,9 +27,8 @@ var (
 	plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "ore/azure")
 
 	Azure = &cobra.Command{
-		Use:              "azure [command]",
-		Short:            "azure image and vm utilities",
-		PersistentPreRun: preauth,
+		Use:   "azure [command]",
+		Short: "azure image and vm utilities",
 	}
 
 	azureProfile      string
@@ -38,13 +38,14 @@ var (
 )
 
 func init() {
-	sv := Azure.PersistentFlags().StringVar
+	cli.WrapPreRun(Azure, preauth)
 
+	sv := Azure.PersistentFlags().StringVar
 	sv(&azureProfile, "azure-profile", "", "Azure Profile json file")
 	sv(&azureSubscription, "azure-subscription", "", "Azure subscription name. If unset, the first is used.")
 }
 
-func preauth(cmd *cobra.Command, args []string) {
+func preauth(cmd *cobra.Command, args []string) error {
 	plog.Printf("Creating Azure API...")
 
 	prof, err := auth.ReadAzureProfile(azureProfile)
@@ -63,4 +64,5 @@ func preauth(cmd *cobra.Command, args []string) {
 	}
 
 	api = a
+	return nil
 }

--- a/cmd/ore/ore.go
+++ b/cmd/ore/ore.go
@@ -24,15 +24,18 @@ import (
 
 var (
 	root = &cobra.Command{
-		Use:               "ore [command]",
-		Short:             "gce image creation and upload tools",
-		PersistentPreRunE: preauth,
+		Use:   "ore [command]",
+		Short: "gce image creation and upload tools",
 	}
 
 	opts = gcloud.Options{Options: &platform.Options{}}
 
 	api *gcloud.API
 )
+
+func init() {
+	cli.WrapPreRun(root, preauth)
+}
 
 func preauth(cmd *cobra.Command, args []string) error {
 	a, err := gcloud.New(&opts)


### PR DESCRIPTION
Per the commit descriptions.

Before this change:
```
$ ./bin/ore --debug version    
mantle/ore version 0.0.0
```
With this change:
```
$ ./bin/ore --debug version
2017-01-25T23:14:14Z cli: Started logging at level DEBUG
mantle/ore version 0.0.0
```