### PR TITLE
qemu: add support for passing Ignition configs

### DIFF
--- a/platform/conf/conf.go
+++ b/platform/conf/conf.go
@@ -121,3 +121,8 @@ func keysToStrings(keys []*agent.Key) (keyStrs []string) {
 	}
 	return
 }
+
+// IsIgnition returns true if the config is for Ignition.
+func (c *Conf) IsIgnition() bool {
+	return c.ignitionV1 != nil || c.ignitionV2 != nil
+}


### PR DESCRIPTION
On QEMU systems Ignition configs must be passed via fw_cfg instead of a config drive.