### PR TITLE
kola: add support for dumping arbitrary test data

### DIFF
--- a/cmd/kola/bootchart.go
+++ b/cmd/kola/bootchart.go
@@ -56,8 +56,15 @@ func runBootchart(cmd *cobra.Command, args []string) {
 		cluster platform.Cluster
 		err     error
 	)
+
+	outputDir, err = kola.CleanOutputDir(outputDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Setup failed: %v\n", err)
+		os.Exit(1)
+	}
+
 	if kolaPlatform == "qemu" {
-		cluster, err = qemu.NewCluster(&kola.QEMUOptions)
+		cluster, err = qemu.NewCluster(&kola.QEMUOptions, outputDir)
 	} else if kolaPlatform == "gce" {
 		cluster, err = gcloud.NewCluster(&kola.GCEOptions)
 	} else if kolaPlatform == "aws" {

--- a/cmd/kola/etcdupgrade.go
+++ b/cmd/kola/etcdupgrade.go
@@ -90,7 +90,13 @@ coreos:
 	kola.RegisterTestOption("EtcdUpgradeBin", etcdUpgradeBin)
 	kola.RegisterTestOption("EtcdUpgradeBin2", etcdUpgradeBin2)
 
-	if err := kola.RunTest(t, "gce"); err != nil {
+	outputDir, err := kola.CleanOutputDir(outputDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Setup failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := kola.RunTest(t, "gce", outputDir); err != nil {
 		fmt.Fprintf(os.Stderr, "--- FAIL: %v", err)
 		os.Exit(1)
 	}

--- a/cmd/kola/kola.go
+++ b/cmd/kola/kola.go
@@ -84,7 +84,7 @@ func runRun(cmd *cobra.Command, args []string) {
 		pattern = "*" // run all tests by default
 	}
 
-	err := kola.RunTests(pattern, kolaPlatform)
+	err := kola.RunTests(pattern, kolaPlatform, outputDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -23,6 +23,7 @@ import (
 )
 
 var (
+	outputDir          string
 	kolaPlatform       string
 	defaultTargetBoard = sdk.DefaultBoard()
 	kolaDefaultImages  = map[string]string{
@@ -41,6 +42,7 @@ func init() {
 	bv := root.PersistentFlags().BoolVar
 
 	// general options
+	sv(&outputDir, "output-dir", "_kola_temp", "Temporary output directory for test data and logs")
 	sv(&kolaPlatform, "platform", "qemu", "VM platform: qemu, gce, aws")
 	root.PersistentFlags().IntVar(&kola.TestParallelism, "parallel", 1, "number of tests to run in parallel")
 	sv(&kola.TAPFile, "tapfile", "", "file to write TAP results to")

--- a/cmd/kola/qemu.go
+++ b/cmd/kola/qemu.go
@@ -47,14 +47,20 @@ func runQemu(cmd *cobra.Command, args []string) {
 		os.Exit(2)
 	}
 
-	cluster, err := qemu.NewCluster(&kola.QEMUOptions)
+	outputDir, err := kola.CleanOutputDir(outputDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Setup failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	cluster, err := qemu.NewCluster(&kola.QEMUOptions, outputDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Cluster failed: %v\n", err)
 		os.Exit(1)
 	}
 	defer cluster.Destroy()
 
-	m, err := cluster.NewMachine("#cloud-config")
+	m, err := cluster.NewMachine(`{"ignition": { "version": "2.0.0" }}`)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Machine failed: %v\n", err)
 		os.Exit(1)

--- a/cmd/kola/spawn.go
+++ b/cmd/kola/spawn.go
@@ -78,9 +78,15 @@ func runSpawn(cmd *cobra.Command, args []string) {
 		userdata = "#cloud-config"
 	}
 
+	outputDir, err = kola.CleanOutputDir(outputDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Setup failed: %v\n", err)
+		os.Exit(1)
+	}
+
 	switch kolaPlatform {
 	case "qemu":
-		cluster, err = qemu.NewCluster(&kola.QEMUOptions)
+		cluster, err = qemu.NewCluster(&kola.QEMUOptions, outputDir)
 	case "gce":
 		cluster, err = gcloud.NewCluster(&kola.GCEOptions)
 	case "aws":

--- a/cmd/kola/updatepayload.go
+++ b/cmd/kola/updatepayload.go
@@ -130,7 +130,7 @@ func runUpdatePayload(cmd *cobra.Command, args []string) {
 }
 
 func runUpdateTest() error {
-	cluster, err := qemu.NewCluster(&kola.QEMUOptions)
+	cluster, err := qemu.NewCluster(&kola.QEMUOptions, outputDir)
 	if err != nil {
 		return fmt.Errorf("new cluster: %v", err)
 	}

--- a/platform/conf/conf.go
+++ b/platform/conf/conf.go
@@ -16,6 +16,7 @@ package conf
 
 import (
 	"encoding/json"
+	"io/ioutil"
 
 	cci "github.com/coreos/coreos-cloudinit/config"
 	v2 "github.com/coreos/ignition/config"
@@ -83,6 +84,16 @@ func (c *Conf) String() string {
 	}
 
 	return ""
+}
+
+// WriteFile writes the userdata in Conf to a local file.
+func (c *Conf) WriteFile(name string) error {
+	return ioutil.WriteFile(name, []byte(c.String()), 0666)
+}
+
+// Bytes returns the serialized userdata in Conf.
+func (c *Conf) Bytes() []byte {
+	return []byte(c.String())
 }
 
 func (c *Conf) copyKeysIgnitionV1(keys []*agent.Key) {

--- a/platform/local/cluster.go
+++ b/platform/local/cluster.go
@@ -35,6 +35,7 @@ import (
 
 type LocalCluster struct {
 	destructor.MultiDestructor
+	OutputDir   string
 	Dnsmasq     *Dnsmasq
 	NTPServer   *ntp.Server
 	OmahaServer *omaha.TrivialServer
@@ -42,8 +43,8 @@ type LocalCluster struct {
 	nshandle    netns.NsHandle
 }
 
-func NewLocalCluster() (*LocalCluster, error) {
-	lc := &LocalCluster{}
+func NewLocalCluster(outputDir string) (*LocalCluster, error) {
+	lc := &LocalCluster{OutputDir: outputDir}
 
 	var err error
 	lc.nshandle, err = ns.Create()


### PR DESCRIPTION
kola will now create a temporary directory `_kola_temp` to dump tests
data to, such as machine configuration, journals, etc. To start off with
only QEMU is implemented and only ignition configurations are written.

For example after `kola run` all ignition configs used can be found at:

    _kola_temp/$test_name/$machine_id/ignition.json