### PR TITLE
qemu: preserve config drives under _kola_temp output directory

### DIFF
--- a/platform/machine/qemu/machine.go
+++ b/platform/machine/qemu/machine.go
@@ -22,11 +22,10 @@ import (
 )
 
 type machine struct {
-	qc          *Cluster
-	id          string
-	qemu        exec.Cmd
-	configDrive *local.ConfigDrive
-	netif       *local.Interface
+	qc    *Cluster
+	id    string
+	qemu  exec.Cmd
+	netif *local.Interface
 }
 
 func (m *machine) ID() string {
@@ -55,13 +54,6 @@ func (m *machine) SSH(cmd string) ([]byte, error) {
 
 func (m *machine) Destroy() error {
 	err := m.qemu.Kill()
-
-	if m.configDrive != nil {
-		err2 := m.configDrive.Destroy()
-		if err == nil && err2 != nil {
-			err = err2
-		}
-	}
 
 	m.qc.DelMach(m)
 


### PR DESCRIPTION
Now in addition to preserving ignition.json, cloud-configs get saved too.