### PR TITLE
kola/docker: add userns test

### DIFF
--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -66,9 +66,12 @@ func init() {
 
 // make a docker container out of binaries on the host
 func genDockerContainer(m platform.Machine, name string, binnames []string) error {
-	genScript := "b=$(which %s) ; tar -hc $b $(ldd $b | grep -o /lib'[^ ]*' | sort -u) | docker import - %s"
+	cmd := `tmpdir=$(mktemp -d); cd $tmpdir; echo -e "FROM scratch\nCOPY . /" > Dockerfile;
+	        b=$(which %s); libs=$(ldd $b | grep -o /lib'[^ ]*' | sort -u);
+	        rsync -av --relative --copy-links $b $libs ./;
+	        docker build -t %s .`
 
-	if output, err := m.SSH(fmt.Sprintf(genScript, strings.Join(binnames, " "), name)); err != nil {
+	if output, err := m.SSH(fmt.Sprintf(cmd, strings.Join(binnames, " "), name)); err != nil {
 		return fmt.Errorf("failed to make %s container: output: %q status: %q", name, output, err)
 	}
 


### PR DESCRIPTION
This includes turning on selinux, running a userns container, and double
checking uid mapping happened as far as proc can tell.

This misses coverage of `--userns-remap=default` doing its implicit-user-creation stuff, but that feature works on fewer total versions and is far less important (since using userns without it is well documented in multiple places)