### PR TITLE
kola/docker: add regression test for 1785

### DIFF
--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -102,9 +102,9 @@ func init() {
 // make a docker container out of binaries on the host
 func genDockerContainer(m platform.Machine, name string, binnames []string) error {
 	cmd := `tmpdir=$(mktemp -d); cd $tmpdir; echo -e "FROM scratch\nCOPY . /" > Dockerfile;
-	        b=$(which %s); libs=$(ldd $b | grep -o /lib'[^ ]*' | sort -u);
-	        rsync -av --relative --copy-links $b $libs ./;
-	        docker build -t %s .`
+	        b=$(which %s); libs=$(sudo ldd $b | grep -o /lib'[^ ]*' | sort -u);
+	        sudo rsync -av --relative --copy-links $b $libs ./;
+	        sudo docker build -t %s .`
 
 	if output, err := m.SSH(fmt.Sprintf(cmd, strings.Join(binnames, " "), name)); err != nil {
 		return fmt.Errorf("failed to make %s container: output: %q status: %q", name, output, err)

--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -97,6 +97,12 @@ func init() {
 		UserData:   `{"ignition":{"version":"2.0.0","config":{}},"storage":{"files":[{"filesystem":"root","path":"/etc/subuid","contents":{"source":"data:,dockremap%3A100000%3A65536","verification":{}},"user":{},"group":{}},{"filesystem":"root","path":"/etc/subgid","contents":{"source":"data:,dockremap%3A100000%3A65536","verification":{}},"user":{},"group":{}}]},"systemd":{"units":[{"name":"docker.service","enable":true,"dropins":[{"name":"10-uesrns.conf","contents":"[Service]\nEnvironment=DOCKER_OPTS=--userns-remap=dockremap"}]}]},"networkd":{},"passwd":{"users":[{"name":"dockremap","create":{}}]}}`,
 		MinVersion: semver.Version{Major: 1192},
 	})
+	register.Register(&register.Test{
+		Run:         dockerNetworksReliably,
+		ClusterSize: 1,
+		Name:        "docker.networks-reliably",
+		MinVersion:  semver.Version{Major: 1192},
+	})
 }
 
 // make a docker container out of binaries on the host
@@ -317,6 +323,23 @@ func dockerUserns(c cluster.TestCluster) error {
 	}
 	if mapParts[0] != "0" && mapParts[1] != "100000" {
 		return fmt.Errorf("unexpected userns mapping values: %v", string(uid_map))
+	}
+
+	return nil
+}
+
+// Regression test for https://github.com/coreos/bugs/issues/1785
+// Also, hopefully will catch any similar issues
+func dockerNetworksReliably(c cluster.TestCluster) error {
+	m := c.Machines()[0]
+
+	if err := genDockerContainer(m, "ping", []string{"sh", "ping"}); err != nil {
+		return err
+	}
+
+	output, err := m.SSH(`seq 1 100 | xargs -i -n 1 -P 20 docker run ping sh -c 'out=$(ping -c 1 172.17.0.1 -w 1); if [[ "$?" != 0 ]]; then echo "{} FAIL"; echo "$out"; exit 1; else echo "{} PASS"; fi'`)
+	if err != nil {
+		return fmt.Errorf("could not run 100 containers pinging the bridge: %v: %q", err, string(output))
 	}
 
 	return nil


### PR DESCRIPTION
This test fairly reliably fails for 1235-8 and has passed 2/2 times for 1235-6.

It takes a little under 2 minutes to run, so not too bad.

cc @dm0- 