### PR TITLE
platform/api/gcloud: slight increase default gce node root disk size

### DIFF
--- a/platform/api/gcloud/compute.go
+++ b/platform/api/gcloud/compute.go
@@ -69,6 +69,7 @@ func (a *API) mkinstance(userdata, name string, keys []*agent.Key) *compute.Inst
 					DiskName:    name,
 					SourceImage: a.options.Image,
 					DiskType:    "/zones/" + a.options.Zone + "/diskTypes/" + a.options.DiskType,
+					DiskSizeGb:  12,
 				},
 			},
 		},


### PR DESCRIPTION
I had a buggy cluster that kept running out of disk space so I had bumped this locally. Even with out the pod gc bug, a cluster that is running self-hosted etcd already gets somewhat close to running out of disk space. Lets give ourselves a slightly larger margin. 