### PR TITLE
Mockssh: A basic ssh server/client for testing

### DIFF
--- a/lang/bufpipe/fixed_buffer.go
+++ b/lang/bufpipe/fixed_buffer.go
@@ -1,0 +1,60 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package http2
+
+import (
+	"errors"
+)
+
+// fixedBuffer is an io.ReadWriter backed by a fixed size buffer.
+// It never allocates, but moves old data as new data is written.
+type fixedBuffer struct {
+	buf  []byte
+	r, w int
+}
+
+var (
+	errReadEmpty = errors.New("read from empty fixedBuffer")
+	errWriteFull = errors.New("write on full fixedBuffer")
+)
+
+// Read copies bytes from the buffer into p.
+// It is an error to read when no data is available.
+func (b *fixedBuffer) Read(p []byte) (n int, err error) {
+	if b.r == b.w {
+		return 0, errReadEmpty
+	}
+	n = copy(p, b.buf[b.r:b.w])
+	b.r += n
+	if b.r == b.w {
+		b.r = 0
+		b.w = 0
+	}
+	return n, nil
+}
+
+// Len returns the number of bytes of the unread portion of the buffer.
+func (b *fixedBuffer) Len() int {
+	return b.w - b.r
+}
+
+// Write copies bytes from p into the buffer.
+// It is an error to write more data than the buffer can hold.
+func (b *fixedBuffer) Write(p []byte) (n int, err error) {
+	// Slide existing data to beginning.
+	if b.r > 0 && len(p) > len(b.buf)-b.w {
+		copy(b.buf, b.buf[b.r:b.w])
+		b.w -= b.r
+		b.r = 0
+	}
+
+	// Write new data.
+	n = copy(b.buf[b.w:], p)
+	b.w += n
+	if n < len(p) {
+		err = errWriteFull
+	}
+	return n, err
+}

--- a/lang/bufpipe/fixed_buffer.go
+++ b/lang/bufpipe/fixed_buffer.go
@@ -1,8 +1,10 @@
 // Copyright 2014 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+// Licensed under the same terms as Go itself:
+// https://github.com/golang/go/blob/master/LICENSE
 
-package http2
+package bufpipe
 
 import (
 	"errors"

--- a/lang/bufpipe/fixed_buffer_test.go
+++ b/lang/bufpipe/fixed_buffer_test.go
@@ -1,0 +1,128 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package http2
+
+import (
+	"reflect"
+	"testing"
+)
+
+var bufferReadTests = []struct {
+	buf      fixedBuffer
+	read, wn int
+	werr     error
+	wp       []byte
+	wbuf     fixedBuffer
+}{
+	{
+		fixedBuffer{[]byte{'a', 0}, 0, 1},
+		5, 1, nil, []byte{'a'},
+		fixedBuffer{[]byte{'a', 0}, 0, 0},
+	},
+	{
+		fixedBuffer{[]byte{0, 'a'}, 1, 2},
+		5, 1, nil, []byte{'a'},
+		fixedBuffer{[]byte{0, 'a'}, 0, 0},
+	},
+	{
+		fixedBuffer{[]byte{'a', 'b'}, 0, 2},
+		1, 1, nil, []byte{'a'},
+		fixedBuffer{[]byte{'a', 'b'}, 1, 2},
+	},
+	{
+		fixedBuffer{[]byte{}, 0, 0},
+		5, 0, errReadEmpty, []byte{},
+		fixedBuffer{[]byte{}, 0, 0},
+	},
+}
+
+func TestBufferRead(t *testing.T) {
+	for i, tt := range bufferReadTests {
+		read := make([]byte, tt.read)
+		n, err := tt.buf.Read(read)
+		if n != tt.wn {
+			t.Errorf("#%d: wn = %d want %d", i, n, tt.wn)
+			continue
+		}
+		if err != tt.werr {
+			t.Errorf("#%d: werr = %v want %v", i, err, tt.werr)
+			continue
+		}
+		read = read[:n]
+		if !reflect.DeepEqual(read, tt.wp) {
+			t.Errorf("#%d: read = %+v want %+v", i, read, tt.wp)
+		}
+		if !reflect.DeepEqual(tt.buf, tt.wbuf) {
+			t.Errorf("#%d: buf = %+v want %+v", i, tt.buf, tt.wbuf)
+		}
+	}
+}
+
+var bufferWriteTests = []struct {
+	buf       fixedBuffer
+	write, wn int
+	werr      error
+	wbuf      fixedBuffer
+}{
+	{
+		buf: fixedBuffer{
+			buf: []byte{},
+		},
+		wbuf: fixedBuffer{
+			buf: []byte{},
+		},
+	},
+	{
+		buf: fixedBuffer{
+			buf: []byte{1, 'a'},
+		},
+		write: 1,
+		wn:    1,
+		wbuf: fixedBuffer{
+			buf: []byte{0, 'a'},
+			w:   1,
+		},
+	},
+	{
+		buf: fixedBuffer{
+			buf: []byte{'a', 1},
+			r:   1,
+			w:   1,
+		},
+		write: 2,
+		wn:    2,
+		wbuf: fixedBuffer{
+			buf: []byte{0, 0},
+			w:   2,
+		},
+	},
+	{
+		buf: fixedBuffer{
+			buf: []byte{},
+		},
+		write: 5,
+		werr:  errWriteFull,
+		wbuf: fixedBuffer{
+			buf: []byte{},
+		},
+	},
+}
+
+func TestBufferWrite(t *testing.T) {
+	for i, tt := range bufferWriteTests {
+		n, err := tt.buf.Write(make([]byte, tt.write))
+		if n != tt.wn {
+			t.Errorf("#%d: wrote %d bytes; want %d", i, n, tt.wn)
+			continue
+		}
+		if err != tt.werr {
+			t.Errorf("#%d: error = %v; want %v", i, err, tt.werr)
+			continue
+		}
+		if !reflect.DeepEqual(tt.buf, tt.wbuf) {
+			t.Errorf("#%d: buf = %+v; want %+v", i, tt.buf, tt.wbuf)
+		}
+	}
+}

--- a/lang/bufpipe/fixed_buffer_test.go
+++ b/lang/bufpipe/fixed_buffer_test.go
@@ -1,8 +1,10 @@
 // Copyright 2014 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+// Licensed under the same terms as Go itself:
+// https://github.com/golang/go/blob/master/LICENSE
 
-package http2
+package bufpipe
 
 import (
 	"reflect"

--- a/lang/bufpipe/pipe.go
+++ b/lang/bufpipe/pipe.go
@@ -1,0 +1,198 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Pipe adapter to connect code expecting an io.Reader
+// with code expecting an io.Writer.
+
+package io
+
+import (
+	"errors"
+	"sync"
+)
+
+// ErrClosedPipe is the error used for read or write operations on a closed pipe.
+var ErrClosedPipe = errors.New("io: read/write on closed pipe")
+
+// A pipe is the shared pipe structure underlying PipeReader and PipeWriter.
+type pipe struct {
+	rl    sync.Mutex // gates readers one at a time
+	wl    sync.Mutex // gates writers one at a time
+	l     sync.Mutex // protects remaining fields
+	data  []byte     // data remaining in pending write
+	rwait sync.Cond  // waiting reader
+	wwait sync.Cond  // waiting writer
+	rerr  error      // if reader closed, error to give writes
+	werr  error      // if writer closed, error to give reads
+}
+
+func (p *pipe) read(b []byte) (n int, err error) {
+	// One reader at a time.
+	p.rl.Lock()
+	defer p.rl.Unlock()
+
+	p.l.Lock()
+	defer p.l.Unlock()
+	for {
+		if p.rerr != nil {
+			return 0, ErrClosedPipe
+		}
+		if p.data != nil {
+			break
+		}
+		if p.werr != nil {
+			return 0, p.werr
+		}
+		p.rwait.Wait()
+	}
+	n = copy(b, p.data)
+	p.data = p.data[n:]
+	if len(p.data) == 0 {
+		p.data = nil
+		p.wwait.Signal()
+	}
+	return
+}
+
+var zero [0]byte
+
+func (p *pipe) write(b []byte) (n int, err error) {
+	// pipe uses nil to mean not available
+	if b == nil {
+		b = zero[:]
+	}
+
+	// One writer at a time.
+	p.wl.Lock()
+	defer p.wl.Unlock()
+
+	p.l.Lock()
+	defer p.l.Unlock()
+	if p.werr != nil {
+		err = ErrClosedPipe
+		return
+	}
+	p.data = b
+	p.rwait.Signal()
+	for {
+		if p.data == nil {
+			break
+		}
+		if p.rerr != nil {
+			err = p.rerr
+			break
+		}
+		if p.werr != nil {
+			err = ErrClosedPipe
+			break
+		}
+		p.wwait.Wait()
+	}
+	n = len(b) - len(p.data)
+	p.data = nil // in case of rerr or werr
+	return
+}
+
+func (p *pipe) rclose(err error) {
+	if err == nil {
+		err = ErrClosedPipe
+	}
+	p.l.Lock()
+	defer p.l.Unlock()
+	p.rerr = err
+	p.rwait.Signal()
+	p.wwait.Signal()
+}
+
+func (p *pipe) wclose(err error) {
+	if err == nil {
+		err = EOF
+	}
+	p.l.Lock()
+	defer p.l.Unlock()
+	p.werr = err
+	p.rwait.Signal()
+	p.wwait.Signal()
+}
+
+// A PipeReader is the read half of a pipe.
+type PipeReader struct {
+	p *pipe
+}
+
+// Read implements the standard Read interface:
+// it reads data from the pipe, blocking until a writer
+// arrives or the write end is closed.
+// If the write end is closed with an error, that error is
+// returned as err; otherwise err is EOF.
+func (r *PipeReader) Read(data []byte) (n int, err error) {
+	return r.p.read(data)
+}
+
+// Close closes the reader; subsequent writes to the
+// write half of the pipe will return the error ErrClosedPipe.
+func (r *PipeReader) Close() error {
+	return r.CloseWithError(nil)
+}
+
+// CloseWithError closes the reader; subsequent writes
+// to the write half of the pipe will return the error err.
+func (r *PipeReader) CloseWithError(err error) error {
+	r.p.rclose(err)
+	return nil
+}
+
+// A PipeWriter is the write half of a pipe.
+type PipeWriter struct {
+	p *pipe
+}
+
+// Write implements the standard Write interface:
+// it writes data to the pipe, blocking until one or more readers
+// have consumed all the data or the read end is closed.
+// If the read end is closed with an error, that err is
+// returned as err; otherwise err is ErrClosedPipe.
+func (w *PipeWriter) Write(data []byte) (n int, err error) {
+	return w.p.write(data)
+}
+
+// Close closes the writer; subsequent reads from the
+// read half of the pipe will return no bytes and EOF.
+func (w *PipeWriter) Close() error {
+	return w.CloseWithError(nil)
+}
+
+// CloseWithError closes the writer; subsequent reads from the
+// read half of the pipe will return no bytes and the error err,
+// or EOF if err is nil.
+//
+// CloseWithError always returns nil.
+func (w *PipeWriter) CloseWithError(err error) error {
+	w.p.wclose(err)
+	return nil
+}
+
+// Pipe creates a synchronous in-memory pipe.
+// It can be used to connect code expecting an io.Reader
+// with code expecting an io.Writer.
+//
+// Reads and Writes on the pipe are matched one to one
+// except when multiple Reads are needed to consume a single Write.
+// That is, each Write to the PipeWriter blocks until it has satisfied
+// one or more Reads from the PipeReader that fully consume
+// the written data.
+// The data is copied directly from the Write to the corresponding
+// Read (or Reads); there is no internal buffering.
+//
+// It is safe to call Read and Write in parallel with each other or with Close.
+// Parallel calls to Read and parallel calls to Write are also safe:
+// the individual calls will be gated sequentially.
+func Pipe() (*PipeReader, *PipeWriter) {
+	p := new(pipe)
+	p.rwait.L = &p.l
+	p.wwait.L = &p.l
+	r := &PipeReader{p}
+	w := &PipeWriter{p}
+	return r, w
+}

--- a/lang/bufpipe/pipe_test.go
+++ b/lang/bufpipe/pipe_test.go
@@ -1,0 +1,314 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package io_test
+
+import (
+	"fmt"
+	. "io"
+	"testing"
+	"time"
+)
+
+func checkWrite(t *testing.T, w Writer, data []byte, c chan int) {
+	n, err := w.Write(data)
+	if err != nil {
+		t.Errorf("write: %v", err)
+	}
+	if n != len(data) {
+		t.Errorf("short write: %d != %d", n, len(data))
+	}
+	c <- 0
+}
+
+// Test a single read/write pair.
+func TestPipe1(t *testing.T) {
+	c := make(chan int)
+	r, w := Pipe()
+	var buf = make([]byte, 64)
+	go checkWrite(t, w, []byte("hello, world"), c)
+	n, err := r.Read(buf)
+	if err != nil {
+		t.Errorf("read: %v", err)
+	} else if n != 12 || string(buf[0:12]) != "hello, world" {
+		t.Errorf("bad read: got %q", buf[0:n])
+	}
+	<-c
+	r.Close()
+	w.Close()
+}
+
+func reader(t *testing.T, r Reader, c chan int) {
+	var buf = make([]byte, 64)
+	for {
+		n, err := r.Read(buf)
+		if err == EOF {
+			c <- 0
+			break
+		}
+		if err != nil {
+			t.Errorf("read: %v", err)
+		}
+		c <- n
+	}
+}
+
+// Test a sequence of read/write pairs.
+func TestPipe2(t *testing.T) {
+	c := make(chan int)
+	r, w := Pipe()
+	go reader(t, r, c)
+	var buf = make([]byte, 64)
+	for i := 0; i < 5; i++ {
+		p := buf[0 : 5+i*10]
+		n, err := w.Write(p)
+		if n != len(p) {
+			t.Errorf("wrote %d, got %d", len(p), n)
+		}
+		if err != nil {
+			t.Errorf("write: %v", err)
+		}
+		nn := <-c
+		if nn != n {
+			t.Errorf("wrote %d, read got %d", n, nn)
+		}
+	}
+	w.Close()
+	nn := <-c
+	if nn != 0 {
+		t.Errorf("final read got %d", nn)
+	}
+}
+
+type pipeReturn struct {
+	n   int
+	err error
+}
+
+// Test a large write that requires multiple reads to satisfy.
+func writer(w WriteCloser, buf []byte, c chan pipeReturn) {
+	n, err := w.Write(buf)
+	w.Close()
+	c <- pipeReturn{n, err}
+}
+
+func TestPipe3(t *testing.T) {
+	c := make(chan pipeReturn)
+	r, w := Pipe()
+	var wdat = make([]byte, 128)
+	for i := 0; i < len(wdat); i++ {
+		wdat[i] = byte(i)
+	}
+	go writer(w, wdat, c)
+	var rdat = make([]byte, 1024)
+	tot := 0
+	for n := 1; n <= 256; n *= 2 {
+		nn, err := r.Read(rdat[tot : tot+n])
+		if err != nil && err != EOF {
+			t.Fatalf("read: %v", err)
+		}
+
+		// only final two reads should be short - 1 byte, then 0
+		expect := n
+		if n == 128 {
+			expect = 1
+		} else if n == 256 {
+			expect = 0
+			if err != EOF {
+				t.Fatalf("read at end: %v", err)
+			}
+		}
+		if nn != expect {
+			t.Fatalf("read %d, expected %d, got %d", n, expect, nn)
+		}
+		tot += nn
+	}
+	pr := <-c
+	if pr.n != 128 || pr.err != nil {
+		t.Fatalf("write 128: %d, %v", pr.n, pr.err)
+	}
+	if tot != 128 {
+		t.Fatalf("total read %d != 128", tot)
+	}
+	for i := 0; i < 128; i++ {
+		if rdat[i] != byte(i) {
+			t.Fatalf("rdat[%d] = %d", i, rdat[i])
+		}
+	}
+}
+
+// Test read after/before writer close.
+
+type closer interface {
+	CloseWithError(error) error
+	Close() error
+}
+
+type pipeTest struct {
+	async          bool
+	err            error
+	closeWithError bool
+}
+
+func (p pipeTest) String() string {
+	return fmt.Sprintf("async=%v err=%v closeWithError=%v", p.async, p.err, p.closeWithError)
+}
+
+var pipeTests = []pipeTest{
+	{true, nil, false},
+	{true, nil, true},
+	{true, ErrShortWrite, true},
+	{false, nil, false},
+	{false, nil, true},
+	{false, ErrShortWrite, true},
+}
+
+func delayClose(t *testing.T, cl closer, ch chan int, tt pipeTest) {
+	time.Sleep(1 * time.Millisecond)
+	var err error
+	if tt.closeWithError {
+		err = cl.CloseWithError(tt.err)
+	} else {
+		err = cl.Close()
+	}
+	if err != nil {
+		t.Errorf("delayClose: %v", err)
+	}
+	ch <- 0
+}
+
+func TestPipeReadClose(t *testing.T) {
+	for _, tt := range pipeTests {
+		c := make(chan int, 1)
+		r, w := Pipe()
+		if tt.async {
+			go delayClose(t, w, c, tt)
+		} else {
+			delayClose(t, w, c, tt)
+		}
+		var buf = make([]byte, 64)
+		n, err := r.Read(buf)
+		<-c
+		want := tt.err
+		if want == nil {
+			want = EOF
+		}
+		if err != want {
+			t.Errorf("read from closed pipe: %v want %v", err, want)
+		}
+		if n != 0 {
+			t.Errorf("read on closed pipe returned %d", n)
+		}
+		if err = r.Close(); err != nil {
+			t.Errorf("r.Close: %v", err)
+		}
+	}
+}
+
+// Test close on Read side during Read.
+func TestPipeReadClose2(t *testing.T) {
+	c := make(chan int, 1)
+	r, _ := Pipe()
+	go delayClose(t, r, c, pipeTest{})
+	n, err := r.Read(make([]byte, 64))
+	<-c
+	if n != 0 || err != ErrClosedPipe {
+		t.Errorf("read from closed pipe: %v, %v want %v, %v", n, err, 0, ErrClosedPipe)
+	}
+}
+
+// Test write after/before reader close.
+
+func TestPipeWriteClose(t *testing.T) {
+	for _, tt := range pipeTests {
+		c := make(chan int, 1)
+		r, w := Pipe()
+		if tt.async {
+			go delayClose(t, r, c, tt)
+		} else {
+			delayClose(t, r, c, tt)
+		}
+		n, err := WriteString(w, "hello, world")
+		<-c
+		expect := tt.err
+		if expect == nil {
+			expect = ErrClosedPipe
+		}
+		if err != expect {
+			t.Errorf("write on closed pipe: %v want %v", err, expect)
+		}
+		if n != 0 {
+			t.Errorf("write on closed pipe returned %d", n)
+		}
+		if err = w.Close(); err != nil {
+			t.Errorf("w.Close: %v", err)
+		}
+	}
+}
+
+// Test close on Write side during Write.
+func TestPipeWriteClose2(t *testing.T) {
+	c := make(chan int, 1)
+	_, w := Pipe()
+	go delayClose(t, w, c, pipeTest{})
+	n, err := w.Write(make([]byte, 64))
+	<-c
+	if n != 0 || err != ErrClosedPipe {
+		t.Errorf("write to closed pipe: %v, %v want %v, %v", n, err, 0, ErrClosedPipe)
+	}
+}
+
+func TestWriteEmpty(t *testing.T) {
+	r, w := Pipe()
+	go func() {
+		w.Write([]byte{})
+		w.Close()
+	}()
+	var b [2]byte
+	ReadFull(r, b[0:2])
+	r.Close()
+}
+
+func TestWriteNil(t *testing.T) {
+	r, w := Pipe()
+	go func() {
+		w.Write(nil)
+		w.Close()
+	}()
+	var b [2]byte
+	ReadFull(r, b[0:2])
+	r.Close()
+}
+
+func TestWriteAfterWriterClose(t *testing.T) {
+	r, w := Pipe()
+
+	done := make(chan bool)
+	var writeErr error
+	go func() {
+		_, err := w.Write([]byte("hello"))
+		if err != nil {
+			t.Errorf("got error: %q; expected none", err)
+		}
+		w.Close()
+		_, writeErr = w.Write([]byte("world"))
+		done <- true
+	}()
+
+	buf := make([]byte, 100)
+	var result string
+	n, err := ReadFull(r, buf)
+	if err != nil && err != ErrUnexpectedEOF {
+		t.Fatalf("got: %q; want: %q", err, ErrUnexpectedEOF)
+	}
+	result = string(buf[0:n])
+	<-done
+
+	if result != "hello" {
+		t.Errorf("got: %q; want: %q", result, "hello")
+	}
+	if writeErr != ErrClosedPipe {
+		t.Errorf("got: %q; want: %q", writeErr, ErrClosedPipe)
+	}
+}

--- a/network/bufnet/pipe.go
+++ b/network/bufnet/pipe.go
@@ -1,0 +1,67 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package net
+
+import (
+	"errors"
+	"io"
+	"time"
+)
+
+// Pipe creates a synchronous, in-memory, full duplex
+// network connection; both ends implement the Conn interface.
+// Reads on one end are matched with writes on the other,
+// copying data directly between the two; there is no internal
+// buffering.
+func Pipe() (Conn, Conn) {
+	r1, w1 := io.Pipe()
+	r2, w2 := io.Pipe()
+
+	return &pipe{r1, w2}, &pipe{r2, w1}
+}
+
+type pipe struct {
+	*io.PipeReader
+	*io.PipeWriter
+}
+
+type pipeAddr int
+
+func (pipeAddr) Network() string {
+	return "pipe"
+}
+
+func (pipeAddr) String() string {
+	return "pipe"
+}
+
+func (p *pipe) Close() error {
+	err := p.PipeReader.Close()
+	err1 := p.PipeWriter.Close()
+	if err == nil {
+		err = err1
+	}
+	return err
+}
+
+func (p *pipe) LocalAddr() Addr {
+	return pipeAddr(0)
+}
+
+func (p *pipe) RemoteAddr() Addr {
+	return pipeAddr(0)
+}
+
+func (p *pipe) SetDeadline(t time.Time) error {
+	return &OpError{Op: "set", Net: "pipe", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
+}
+
+func (p *pipe) SetReadDeadline(t time.Time) error {
+	return &OpError{Op: "set", Net: "pipe", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
+}
+
+func (p *pipe) SetWriteDeadline(t time.Time) error {
+	return &OpError{Op: "set", Net: "pipe", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
+}

--- a/network/bufnet/pipe.go
+++ b/network/bufnet/pipe.go
@@ -1,12 +1,15 @@
 // Copyright 2010 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+// Licensed under the same terms as Go itself:
+// https://github.com/golang/go/blob/master/LICENSE
 
-package net
+package bufnet
 
 import (
 	"errors"
 	"io"
+	"net"
 	"time"
 )
 
@@ -15,7 +18,7 @@ import (
 // Reads on one end are matched with writes on the other,
 // copying data directly between the two; there is no internal
 // buffering.
-func Pipe() (Conn, Conn) {
+func Pipe() (net.Conn, net.Conn) {
 	r1, w1 := io.Pipe()
 	r2, w2 := io.Pipe()
 
@@ -46,22 +49,22 @@ func (p *pipe) Close() error {
 	return err
 }
 
-func (p *pipe) LocalAddr() Addr {
+func (p *pipe) LocalAddr() net.Addr {
 	return pipeAddr(0)
 }
 
-func (p *pipe) RemoteAddr() Addr {
+func (p *pipe) RemoteAddr() net.Addr {
 	return pipeAddr(0)
 }
 
 func (p *pipe) SetDeadline(t time.Time) error {
-	return &OpError{Op: "set", Net: "pipe", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
+	return &net.OpError{Op: "set", Net: "pipe", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
 }
 
 func (p *pipe) SetReadDeadline(t time.Time) error {
-	return &OpError{Op: "set", Net: "pipe", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
+	return &net.OpError{Op: "set", Net: "pipe", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
 }
 
 func (p *pipe) SetWriteDeadline(t time.Time) error {
-	return &OpError{Op: "set", Net: "pipe", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
+	return &net.OpError{Op: "set", Net: "pipe", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
 }

--- a/network/bufnet/pipe_test.go
+++ b/network/bufnet/pipe_test.go
@@ -1,0 +1,55 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package net
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func checkPipeWrite(t *testing.T, w io.Writer, data []byte, c chan int) {
+	n, err := w.Write(data)
+	if err != nil {
+		t.Error(err)
+	}
+	if n != len(data) {
+		t.Errorf("short write: %d != %d", n, len(data))
+	}
+	c <- 0
+}
+
+func checkPipeRead(t *testing.T, r io.Reader, data []byte, wantErr error) {
+	buf := make([]byte, len(data)+10)
+	n, err := r.Read(buf)
+	if err != wantErr {
+		t.Error(err)
+		return
+	}
+	if n != len(data) || !bytes.Equal(buf[0:n], data) {
+		t.Errorf("bad read: got %q", buf[0:n])
+		return
+	}
+}
+
+// TestPipe tests a simple read/write/close sequence.
+// Assumes that the underlying io.Pipe implementation
+// is solid and we're just testing the net wrapping.
+func TestPipe(t *testing.T) {
+	c := make(chan int)
+	cli, srv := Pipe()
+	go checkPipeWrite(t, cli, []byte("hello, world"), c)
+	checkPipeRead(t, srv, []byte("hello, world"), nil)
+	<-c
+	go checkPipeWrite(t, srv, []byte("line 2"), c)
+	checkPipeRead(t, cli, []byte("line 2"), nil)
+	<-c
+	go checkPipeWrite(t, cli, []byte("a third line"), c)
+	checkPipeRead(t, srv, []byte("a third line"), nil)
+	<-c
+	go srv.Close()
+	checkPipeRead(t, cli, nil, io.EOF)
+	cli.Close()
+}

--- a/network/bufnet/pipe_test.go
+++ b/network/bufnet/pipe_test.go
@@ -1,8 +1,10 @@
 // Copyright 2010 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+// Licensed under the same terms as Go itself:
+// https://github.com/golang/go/blob/master/LICENSE
 
-package net
+package bufnet
 
 import (
 	"bytes"

--- a/network/mockssh/mockssh.go
+++ b/network/mockssh/mockssh.go
@@ -1,0 +1,206 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// mockssh implements a basic ssh server for use in unit tests.
+//
+// Command execution in the server is implemented by a user provided handler
+// function rather than executing a real shell.
+//
+// Some inspiration is taken from but not based on:
+// https://godoc.org/github.com/gliderlabs/ssh
+package mockssh
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/coreos/mantle/network/bufnet"
+)
+
+const (
+	pipeBufferSize = 8192
+)
+
+var (
+	mockServerPrivateKey ssh.Signer
+)
+
+func init() {
+	var err error
+	mockServerPrivateKey, err = ssh.ParsePrivateKey([]byte(`
+-----BEGIN RSA PRIVATE KEY-----
+MIICXgIBAAKBgQC+6EsrBSr0Ik+ADcR17zjYK9+RcO+AYFA6IN/wYl0lV8Os/Md8
+amVUnC3FGhvK4hQwvQVEQpoxcT4DoHZh6Fs4uStixFZSCWLGbYwb8qsRkMJl/ZkZ
+kgY/ZUOQSHqoNsIkVajoVPOK8gb9pFcDW0WHcIDHa6L+IoZH7nfUmG5/9QIDAQAB
+AoGBALxhwPr8qHwr90MnUrwFiZRXBtAgH1YQtFoH4rL0fXHB/wcOkVMGMmOhkdCz
+iMVU/hNyEmZfSoSLeGRfzTGj9Y541nfcbFcCwpen8mfLk4JyVsHr1J9T/c0i9yot
+NtZFU6Imsw6judu4ohzLrI6hYdvSTUzJvrUe4jKQ8uv/O4JBAkEA6ON3ZnxlwtvC
+rcTBes/8bHLjrvQk371HraRH9xN29XSII11igPYDGRsrO8+5fTcVi/gYI6GIo/pU
+amRoMgwm7QJBANHaS9VJwSWHyfO5AjNHzOQM7M5SUf9KVTUdgCXi+H0cBPZdlZaF
+FviXHnH114tiSlKDmwJicrmWW0Pk0c1A1CkCQGoWZGe9NyXisfYycOifIh/M3kbu
+VHXPZX2GHnpA1anOoc1qVtrkNlkTdUhTwe12UExogaaJiRMZj6a/gm959akCQQCo
+KXsdRsYNMhwmPzpBJ6dLlAPrbdIhdkqDjslTEue3Mc3UMrgdbzcyK78M6Uk5e6E9
+MBL2PTfb+l3WMTXiebHJAkEApUjV9xL1i+7EidI3hOgTZxk5Ti6eXpZdjQIN3OGn
+uCeD0x31tIEl6p5wYaspSAOZJh8/jz4qMbLOUjmhRUzIJg==
+-----END RSA PRIVATE KEY-----
+`))
+	if err != nil {
+		panic(err)
+	}
+}
+
+// SessionHandler is a user provided function that processes/executes
+// the command given to it in the given Session. Before finishing the
+// handler must call session.Close or session.Exit.
+type SessionHandler func(session *Session)
+
+// Session represents the server side execution of the client's ssh.Session.
+type Session struct {
+	Exec   string   // Command to execute.
+	Env    []string // Environment values provided by the client.
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+
+	channel ssh.Channel
+}
+
+// Exit sends the given command exit status and closes the session.
+func (s *Session) Exit(code int) error {
+	status := struct{ Status uint32 }{uint32(code)}
+	payload := ssh.Marshal(&status)
+
+	_, err := s.channel.SendRequest("exit-status", false, payload)
+	if err != nil {
+		return err
+	}
+
+	return s.channel.Close()
+}
+
+// Close ends the session without sending an exit status.
+func (s *Session) Close() error {
+	return s.channel.Close()
+}
+
+// NewMockClient starts a ssh server backed by the given handler and
+// returns a client that is connected to it.
+func NewMockClient(handler SessionHandler) *ssh.Client {
+	config := ssh.ClientConfig{
+		User: "mock",
+		Auth: []ssh.AuthMethod{
+			ssh.Password(""),
+		},
+	}
+
+	pipe := startMockServer(handler)
+	conn, chans, reqs, err := ssh.NewClientConn(pipe, "mock", &config)
+	if err != nil {
+		panic(err)
+	}
+
+	return ssh.NewClient(conn, chans, reqs)
+}
+
+type mockServer struct {
+	config  ssh.ServerConfig
+	handler SessionHandler
+	server  *ssh.ServerConn
+}
+
+func startMockServer(handler SessionHandler) net.Conn {
+	m := mockServer{
+		config: ssh.ServerConfig{
+			PasswordCallback: func(c ssh.ConnMetadata, pass []byte) (*ssh.Permissions, error) {
+				return nil, nil
+			},
+		},
+		handler: handler,
+	}
+	m.config.AddHostKey(mockServerPrivateKey)
+
+	sPipe, cPipe := bufnet.FixedPipe(pipeBufferSize)
+	go m.handleServerConn(sPipe)
+	return cPipe
+}
+
+func (m *mockServer) handleServerConn(conn net.Conn) {
+	serverConn, chans, reqs, err := ssh.NewServerConn(conn, &m.config)
+	if err != nil {
+		log.Printf("mockssh: server handshake failed: %v", err)
+		return
+	}
+	m.server = serverConn
+
+	// reqs must be serviced but are not important to us.
+	go ssh.DiscardRequests(reqs)
+
+	for newChannel := range chans {
+		go m.handleServerChannel(newChannel)
+	}
+}
+
+func (m *mockServer) handleServerChannel(newChannel ssh.NewChannel) {
+	if newChannel.ChannelType() != "session" {
+		newChannel.Reject(ssh.UnknownChannelType, "unknown channel type")
+		return
+	}
+
+	channel, requests, err := newChannel.Accept()
+	if err != nil {
+		log.Printf("mockssh: accepting channel failed: %v", err)
+		return
+	}
+
+	session := &Session{
+		Stdin:   channel,
+		Stdout:  channel,
+		Stderr:  channel.Stderr(),
+		channel: channel,
+	}
+
+	// shell and pty requests are not implemented.
+	for req := range requests {
+		if session == nil {
+			req.Reply(false, nil)
+		}
+		switch req.Type {
+		case "exec":
+			v := struct{ Value string }{}
+			if err := ssh.Unmarshal(req.Payload, &v); err != nil {
+				req.Reply(false, nil)
+			} else {
+				session.Exec = v.Value
+				req.Reply(true, nil)
+				go m.handler(session)
+			}
+			session = nil
+		case "env":
+			kv := struct{ Key, Value string }{}
+			if err := ssh.Unmarshal(req.Payload, &kv); err != nil {
+				req.Reply(false, nil)
+			} else {
+				env := fmt.Sprintf("%s=%s", kv.Key, kv.Value)
+				session.Env = append(session.Env, env)
+				req.Reply(true, nil)
+			}
+		default:
+			req.Reply(false, nil)
+		}
+	}
+}

--- a/network/mockssh/mockssh_test.go
+++ b/network/mockssh/mockssh_test.go
@@ -1,0 +1,228 @@
+// Copyright 2017 CoreOS, Inc.
+// Copyright 2014 The Go Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mockssh
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func TestExitStatusZero(t *testing.T) {
+	client := NewMockClient(func(s *Session) {
+		s.Exit(0)
+	})
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := session.Run(""); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExitStatusNonzero(t *testing.T) {
+	client := NewMockClient(func(s *Session) {
+		s.Exit(42)
+	})
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = session.Run("")
+	if ex, ok := err.(*ssh.ExitError); !ok {
+		t.Fatalf("unexpected error: %v", err)
+	} else if ex.ExitStatus() != 42 {
+		t.Fatalf("unexpected exit: %v", err)
+	}
+}
+
+func TestExitStatusMissing(t *testing.T) {
+	client := NewMockClient(func(s *Session) {
+		s.Close()
+	})
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = session.Run("")
+	if _, ok := err.(*ssh.ExitMissingError); !ok {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCat(t *testing.T) {
+	client := NewMockClient(func(s *Session) {
+		if _, err := io.Copy(s.Stdout, s.Stdin); err != nil {
+			t.Error(err)
+		}
+		s.Exit(0)
+	})
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const data = "hello world\n"
+	session.Stdin = strings.NewReader("hello world\n")
+
+	out, err := session.Output("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != data {
+		t.Fatalf("unexpected output: %q; wanted %q", out, data)
+	}
+}
+
+func TestStderr(t *testing.T) {
+	client := NewMockClient(func(s *Session) {
+		io.WriteString(s.Stdout, "Stdout")
+		io.WriteString(s.Stderr, "Stderr")
+		s.Exit(0)
+	})
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	session.Stdout = &stdout
+	session.Stderr = &stderr
+
+	if err := session.Run(""); err != nil {
+		t.Fatal(err)
+	}
+
+	if stdout.String() != "Stdout" {
+		t.Errorf("got %q wanted %q", stdout.String(), "Stdout")
+	}
+	if stderr.String() != "Stderr" {
+		t.Errorf("got %q wanted %q", stderr.String(), "Stderr")
+	}
+}
+
+func TestExec(t *testing.T) {
+	const cmd = "test command"
+	client := NewMockClient(func(s *Session) {
+		if s.Exec != cmd {
+			t.Errorf("got %q wanted %q", s.Exec, cmd)
+		}
+		s.Exit(0)
+	})
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := session.Run(cmd); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnv(t *testing.T) {
+	expect := []string{"VAR1=VALUE1", "VAR2=VALUE2"}
+	client := NewMockClient(func(s *Session) {
+		if !reflect.DeepEqual(s.Env, expect) {
+			t.Errorf("got %v wanted %v", s.Env, expect)
+		}
+		s.Exit(0)
+	})
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := session.Setenv("VAR1", "VALUE1"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := session.Setenv("VAR2", "VALUE2"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := session.Run(""); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// shell is not implemented, confirm it fails.
+func TestShell(t *testing.T) {
+	client := NewMockClient(func(s *Session) {
+		t.Errorf("executed shell")
+		s.Exit(0)
+	})
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := session.Shell(); err == nil {
+		t.Fatal("shell succeeded")
+	}
+}
+
+// The server code spawns a lot of goroutines and all of them need to
+// gracefully terminate when the client is closed.
+func TestMain(m *testing.M) {
+	g0 := runtime.NumGoroutine()
+
+	code := m.Run()
+	if code != 0 {
+		os.Exit(code)
+	}
+
+	// Check that there are no goroutines left behind.
+	t0 := time.Now()
+	stacks := make([]byte, 1<<20)
+	for {
+		g1 := runtime.NumGoroutine()
+		if g1 == g0 {
+			return
+		}
+		stacks = stacks[:runtime.Stack(stacks, true)]
+		time.Sleep(50 * time.Millisecond)
+		if time.Since(t0) > 2*time.Second {
+			fmt.Fprintf(os.Stderr, "Unexpected leftover goroutines detected: %v -> %v\n%s\n", g0, g1, stacks)
+			os.Exit(1)
+		}
+	}
+}


### PR DESCRIPTION
The interesting piece of code here is a simple ssh server: command execution is performed by a `SessionHandler` function which is given a `Session` struct that is the mirror of the client's session. Each server has only one handler and one client and is terminated when the client is closed.

The rest of this code is copy/pasted from `io`, `net`, and `golang.org/x/net/http2` with minor tweaks to implement a buffered versions of `io.Pipe` and `net.Pipe` because connecting the Go ssh server and client to each other without a buffer just results in a deadlock.

Alternatively instead of copying all of that code, sockets created by `socketpair(2)` could be used to use in-kernel buffering just like TCP does but there is no way to create `net.UnixConn` objects from the unix sockets returned by `socketpair(2)` so that option would still require a pile of copy/pasted code.

Or I could have used a listening socket like a normal server but I only wanted a single connection so having a listening socket hanging around seemed inappropriate and opens the possibility of fd leak bugs in shutdown/cleanup code that just don't need to be there in the first place.