### PR TITLE
journal: convert formatter to an interface

### DIFF
--- a/network/journal/format.go
+++ b/network/journal/format.go
@@ -23,26 +23,31 @@ import (
 	"unicode/utf8"
 )
 
-// ShortWriter writes journal entries in a format similar to journalctl's
-// "short-precise" format, excluding hostname for conciseness.
-type ShortWriter struct {
+type Formatter interface {
+	SetTimezone(tz *time.Location)
+	WriteEntry(entry Entry) error
+}
+
+type shortWriter struct {
 	w  io.Writer
 	tz *time.Location
 }
 
-func NewShortWriter(w io.Writer) *ShortWriter {
-	return &ShortWriter{
+// ShortWriter writes journal entries in a format similar to journalctl's
+// "short-precise" format, excluding hostname for conciseness.
+func ShortWriter(w io.Writer) Formatter {
+	return &shortWriter{
 		w:  w,
 		tz: time.Local,
 	}
 }
 
 // SetTimezone updates the time location. The default is local time.
-func (s *ShortWriter) SetTimezone(tz *time.Location) {
+func (s *shortWriter) SetTimezone(tz *time.Location) {
 	s.tz = tz
 }
 
-func (s *ShortWriter) WriteEntry(entry Entry) error {
+func (s *shortWriter) WriteEntry(entry Entry) error {
 	realtime := entry.Realtime()
 	message, ok := entry[FIELD_MESSAGE]
 	if realtime.IsZero() || !ok {

--- a/network/journal/format_test.go
+++ b/network/journal/format_test.go
@@ -136,7 +136,7 @@ func TestFormatShort(t *testing.T) {
 	}} {
 		t.Run(testcase.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			w := NewShortWriter(&buf)
+			w := ShortWriter(&buf)
 			w.SetTimezone(time.UTC) // Needed for consistent test results.
 			if err := w.WriteEntry(testcase.entry); err != nil {
 				t.Error(err)


### PR DESCRIPTION
There is only one formatter right now but an interface feels more
appropriate for this.