### PR TITLE
Add support for dumping machine user-data and journal to GCE

### DIFF
--- a/cmd/kola/bootchart.go
+++ b/cmd/kola/bootchart.go
@@ -66,9 +66,9 @@ func runBootchart(cmd *cobra.Command, args []string) {
 	if kolaPlatform == "qemu" {
 		cluster, err = qemu.NewCluster(&kola.QEMUOptions, outputDir)
 	} else if kolaPlatform == "gce" {
-		cluster, err = gcloud.NewCluster(&kola.GCEOptions)
+		cluster, err = gcloud.NewCluster(&kola.GCEOptions, outputDir)
 	} else if kolaPlatform == "aws" {
-		cluster, err = aws.NewCluster(&kola.AWSOptions)
+		cluster, err = aws.NewCluster(&kola.AWSOptions, outputDir)
 	} else {
 		fmt.Fprintf(os.Stderr, "Invalid platform: %v", kolaPlatform)
 	}

--- a/cmd/kola/spawn.go
+++ b/cmd/kola/spawn.go
@@ -88,9 +88,9 @@ func runSpawn(cmd *cobra.Command, args []string) {
 	case "qemu":
 		cluster, err = qemu.NewCluster(&kola.QEMUOptions, outputDir)
 	case "gce":
-		cluster, err = gcloud.NewCluster(&kola.GCEOptions)
+		cluster, err = gcloud.NewCluster(&kola.GCEOptions, outputDir)
 	case "aws":
-		cluster, err = aws.NewCluster(&kola.AWSOptions)
+		cluster, err = aws.NewCluster(&kola.AWSOptions, outputDir)
 	default:
 		err = fmt.Errorf("invalid platform %q", kolaPlatform)
 	}

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -313,9 +313,9 @@ func getClusterSemver(pltfrm, outputDir string) (*semver.Version, error) {
 	case "qemu":
 		cluster, err = qemu.NewCluster(&QEMUOptions, testDir)
 	case "gce":
-		cluster, err = gcloud.NewCluster(&GCEOptions)
+		cluster, err = gcloud.NewCluster(&GCEOptions, testDir)
 	case "aws":
-		cluster, err = aws.NewCluster(&AWSOptions)
+		cluster, err = aws.NewCluster(&AWSOptions, testDir)
 	default:
 		err = fmt.Errorf("invalid platform %q", pltfrm)
 	}
@@ -366,9 +366,9 @@ func RunTest(t *register.Test, pltfrm, outputDir string) (err error) {
 	case "qemu":
 		c, err = qemu.NewCluster(&QEMUOptions, testDir)
 	case "gce":
-		c, err = gcloud.NewCluster(&GCEOptions)
+		c, err = gcloud.NewCluster(&GCEOptions, testDir)
 	case "aws":
-		c, err = aws.NewCluster(&AWSOptions)
+		c, err = aws.NewCluster(&AWSOptions, testDir)
 	default:
 		err = fmt.Errorf("invalid platform %q", pltfrm)
 	}

--- a/platform/base.go
+++ b/platform/base.go
@@ -37,13 +37,14 @@ type BaseCluster struct {
 	machmap  map[string]Machine
 
 	name string
+	dir  string
 }
 
-func NewBaseCluster(basename string) (*BaseCluster, error) {
-	return NewBaseClusterWithDialer(basename, network.NewRetryDialer())
+func NewBaseCluster(basename, outputDir string) (*BaseCluster, error) {
+	return NewBaseClusterWithDialer(basename, outputDir, network.NewRetryDialer())
 }
 
-func NewBaseClusterWithDialer(basename string, dialer network.Dialer) (*BaseCluster, error) {
+func NewBaseClusterWithDialer(basename, outputDir string, dialer network.Dialer) (*BaseCluster, error) {
 	agent, err := network.NewSSHAgent(dialer)
 	if err != nil {
 		return nil, err
@@ -53,6 +54,7 @@ func NewBaseClusterWithDialer(basename string, dialer network.Dialer) (*BaseClus
 		agent:   agent,
 		machmap: make(map[string]Machine),
 		name:    fmt.Sprintf("%s-%s", basename, uuid.NewV4()),
+		dir:     outputDir,
 	}
 
 	return bc, nil
@@ -158,4 +160,8 @@ func (bc *BaseCluster) GetDiscoveryURL(size int) (string, error) {
 
 func (bc *BaseCluster) Name() string {
 	return bc.name
+}
+
+func (bc *BaseCluster) OutputDir() string {
+	return bc.dir
 }

--- a/platform/local/cluster.go
+++ b/platform/local/cluster.go
@@ -37,7 +37,6 @@ import (
 type LocalCluster struct {
 	destructor.MultiDestructor
 	*platform.BaseCluster
-	OutputDir   string
 	Dnsmasq     *Dnsmasq
 	NTPServer   *ntp.Server
 	OmahaServer *omaha.TrivialServer
@@ -46,7 +45,7 @@ type LocalCluster struct {
 }
 
 func NewLocalCluster(basename, outputDir string) (*LocalCluster, error) {
-	lc := &LocalCluster{OutputDir: outputDir}
+	lc := &LocalCluster{}
 
 	var err error
 	lc.nshandle, err = ns.Create()
@@ -56,7 +55,7 @@ func NewLocalCluster(basename, outputDir string) (*LocalCluster, error) {
 	lc.AddCloser(&lc.nshandle)
 
 	nsdialer := network.NewNsDialer(lc.nshandle)
-	lc.BaseCluster, err = platform.NewBaseClusterWithDialer(basename, nsdialer)
+	lc.BaseCluster, err = platform.NewBaseClusterWithDialer(basename, outputDir, nsdialer)
 	if err != nil {
 		lc.Destroy()
 		return nil, err

--- a/platform/local/cluster.go
+++ b/platform/local/cluster.go
@@ -29,12 +29,14 @@ import (
 	"github.com/coreos/mantle/network"
 	"github.com/coreos/mantle/network/ntp"
 	"github.com/coreos/mantle/network/omaha"
+	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/system/exec"
 	"github.com/coreos/mantle/system/ns"
 )
 
 type LocalCluster struct {
 	destructor.MultiDestructor
+	*platform.BaseCluster
 	OutputDir   string
 	Dnsmasq     *Dnsmasq
 	NTPServer   *ntp.Server
@@ -43,7 +45,7 @@ type LocalCluster struct {
 	nshandle    netns.NsHandle
 }
 
-func NewLocalCluster(outputDir string) (*LocalCluster, error) {
+func NewLocalCluster(basename, outputDir string) (*LocalCluster, error) {
 	lc := &LocalCluster{OutputDir: outputDir}
 
 	var err error
@@ -53,9 +55,18 @@ func NewLocalCluster(outputDir string) (*LocalCluster, error) {
 	}
 	lc.AddCloser(&lc.nshandle)
 
+	nsdialer := network.NewNsDialer(lc.nshandle)
+	lc.BaseCluster, err = platform.NewBaseClusterWithDialer(basename, nsdialer)
+	if err != nil {
+		lc.Destroy()
+		return nil, err
+	}
+	lc.AddDestructor(lc.BaseCluster)
+
 	// dnsmasq and etcd much be launched in the new namespace
 	nsExit, err := ns.Enter(lc.nshandle)
 	if err != nil {
+		lc.Destroy()
 		return nil, err
 	}
 	defer nsExit()
@@ -166,4 +177,8 @@ func (lc *LocalCluster) NewTap(bridge string) (*TunTap, error) {
 
 func (lc *LocalCluster) GetNsHandle() netns.NsHandle {
 	return lc.nshandle
+}
+
+func (lc *LocalCluster) Destroy() error {
+	return lc.MultiDestructor.Destroy()
 }

--- a/platform/machine/aws/cluster.go
+++ b/platform/machine/aws/cluster.go
@@ -34,13 +34,13 @@ type cluster struct {
 // NewCluster will consume the environment variables $AWS_REGION,
 // $AWS_ACCESS_KEY_ID, and $AWS_SECRET_ACCESS_KEY to determine the region to
 // spawn instances in and the credentials to use to authenticate.
-func NewCluster(opts *aws.Options) (platform.Cluster, error) {
+func NewCluster(opts *aws.Options, outputDir string) (platform.Cluster, error) {
 	api, err := aws.New(opts)
 	if err != nil {
 		return nil, err
 	}
 
-	bc, err := platform.NewBaseCluster(opts.BaseName)
+	bc, err := platform.NewBaseCluster(opts.BaseName, outputDir)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/machine/gcloud/cluster.go
+++ b/platform/machine/gcloud/cluster.go
@@ -28,13 +28,13 @@ type cluster struct {
 	api *gcloud.API
 }
 
-func NewCluster(opts *gcloud.Options) (platform.Cluster, error) {
+func NewCluster(opts *gcloud.Options, outputDir string) (platform.Cluster, error) {
 	api, err := gcloud.New(opts)
 	if err != nil {
 		return nil, err
 	}
 
-	bc, err := platform.NewBaseCluster(opts.BaseName)
+	bc, err := platform.NewBaseCluster(opts.BaseName, outputDir)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/machine/gcloud/cluster.go
+++ b/platform/machine/gcloud/cluster.go
@@ -16,6 +16,9 @@
 package gcloud
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/coreos/mantle/platform"
@@ -79,6 +82,28 @@ func (gc *cluster) NewMachine(userdata string) (platform.Machine, error) {
 		name:  instance.Name,
 		intIP: intip,
 		extIP: extip,
+	}
+
+	dir := filepath.Join(gc.OutputDir(), gm.ID())
+	if err := os.Mkdir(dir, 0777); err != nil {
+		gm.Destroy()
+		return nil, err
+	}
+
+	confPath := filepath.Join(dir, "user-data")
+	if err := conf.WriteFile(confPath); err != nil {
+		gm.Destroy()
+		return nil, err
+	}
+
+	if gm.journal, err = platform.NewJournal(dir); err != nil {
+		gm.Destroy()
+		return nil, err
+	}
+
+	if err := gm.journal.Start(context.TODO(), gm); err != nil {
+		gm.Destroy()
+		return nil, err
 	}
 
 	if err := platform.CheckMachine(gm); err != nil {

--- a/platform/machine/gcloud/machine.go
+++ b/platform/machine/gcloud/machine.go
@@ -1,16 +1,19 @@
 package gcloud
 
 import (
+	"context"
+
 	"golang.org/x/crypto/ssh"
 
 	"github.com/coreos/mantle/platform"
 )
 
 type machine struct {
-	gc    *cluster
-	name  string
-	intIP string
-	extIP string
+	gc      *cluster
+	name    string
+	intIP   string
+	extIP   string
+	journal *platform.Journal
 }
 
 func (gm *machine) ID() string {
@@ -38,12 +41,30 @@ func (gm *machine) SSH(cmd string) ([]byte, error) {
 }
 
 func (m *machine) Reboot() error {
-	return platform.Reboot(m)
+	if err := platform.StartReboot(m); err != nil {
+		return err
+	}
+	if err := m.journal.Start(context.TODO(), m); err != nil {
+		return err
+	}
+	if err := platform.CheckMachine(m); err != nil {
+		return err
+	}
+	if err := platform.EnableSelinux(m); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (gm *machine) Destroy() error {
 	if err := gm.gc.api.TerminateInstance(gm.name); err != nil {
 		return err
+	}
+
+	if gm.journal != nil {
+		if err := gm.journal.Destroy(); err != nil {
+			return err
+		}
 	}
 
 	gm.gc.DelMach(gm)

--- a/platform/machine/qemu/cluster.go
+++ b/platform/machine/qemu/cluster.go
@@ -75,7 +75,7 @@ func NewCluster(conf *Options, outputDir string) (platform.Cluster, error) {
 func (qc *Cluster) NewMachine(cfg string) (platform.Machine, error) {
 	id := uuid.NewV4()
 
-	dir := filepath.Join(qc.OutputDir, id.String())
+	dir := filepath.Join(qc.OutputDir(), id.String())
 	if err := os.Mkdir(dir, 0777); err != nil {
 		return nil, err
 	}

--- a/platform/machine/qemu/cluster.go
+++ b/platform/machine/qemu/cluster.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/satori/go.uuid"
 
-	"github.com/coreos/mantle/network"
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/conf"
 	"github.com/coreos/mantle/platform/local"
@@ -51,7 +50,6 @@ type Options struct {
 // XXX: must be exported so that certain QEMU tests can access struct members
 // through type assertions.
 type Cluster struct {
-	*platform.BaseCluster
 	conf *Options
 
 	mu sync.Mutex
@@ -61,32 +59,17 @@ type Cluster struct {
 // NewCluster creates a Cluster instance, suitable for running virtual
 // machines in QEMU.
 func NewCluster(conf *Options, outputDir string) (platform.Cluster, error) {
-	lc, err := local.NewLocalCluster(outputDir)
-	if err != nil {
-		return nil, err
-	}
-
-	nsdialer := network.NewNsDialer(lc.GetNsHandle())
-	bc, err := platform.NewBaseClusterWithDialer(conf.BaseName, nsdialer)
+	lc, err := local.NewLocalCluster(conf.BaseName, outputDir)
 	if err != nil {
 		return nil, err
 	}
 
 	qc := &Cluster{
-		BaseCluster:  bc,
 		conf:         conf,
 		LocalCluster: lc,
 	}
 
 	return qc, nil
-}
-
-func (qc *Cluster) Destroy() error {
-	if err := qc.BaseCluster.Destroy(); err != nil {
-		return err
-	}
-
-	return qc.LocalCluster.Destroy()
 }
 
 func (qc *Cluster) NewMachine(cfg string) (platform.Machine, error) {
@@ -235,11 +218,6 @@ func (qc *Cluster) NewMachine(cfg string) (platform.Machine, error) {
 	qc.AddMach(qm)
 
 	return qm, nil
-}
-
-// overrides BaseCluster.GetDiscoveryURL
-func (qc *Cluster) GetDiscoveryURL(size int) (string, error) {
-	return qc.LocalCluster.GetDiscoveryURL(size)
 }
 
 // The virtio device name differs between machine types but otherwise


### PR DESCRIPTION
One slight catch about this scheme that I've found: if you are switching between platforms between runs of kola you'll need to manually remove the _kola_temp directory after QEMU runs since they run as root while GCE and others can be run as your normal user.