### PR TITLE
kola: restore parallel test execution

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -16,6 +16,7 @@ package kola
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -178,8 +179,14 @@ func RunTests(pattern, pltfrm, outputDir string) error {
 	for _, test := range tests {
 		test := test // for the closure
 		run := func(h *harness.H) {
+			h.Parallel()
+
 			// don't go too fast, in case we're talking to a rate limiting api like AWS EC2.
-			time.Sleep(2 * time.Second)
+			// FIXME(marineam): API requests must do their own
+			// backoff due to rate limiting, this is unreliable.
+			max := int64(2 * time.Second)
+			splay := time.Duration(rand.Int63n(max))
+			time.Sleep(splay)
 
 			err := RunTest(test, pltfrm, outputDir)
 			if _, ok := err.(skip.Skip); ok {


### PR DESCRIPTION
Missed this 2f417db9. As in `testing` H.Parallel must be called to
enable parallel execution. Switch from a plain two seconds to a random
delay between zero and two seconds for rate limiting since all Parallel
calls will always unblock at the same time.