### PR TITLE
kola/tests/etcd: remove etcd0 discovery test

### DIFF
--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -16,7 +16,6 @@ package etcd
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/coreos/pkg/capnslog"
 
@@ -27,37 +26,6 @@ import (
 var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "kola/tests/etcd")
 
 func init() {
-	// test etcd discovery with 0.4.7
-	register.Register(&register.Test{
-		Run:         Discovery,
-		Manual:      true,
-		ClusterSize: 3,
-		Name:        "coreos.etcd0.discovery",
-		/* TODO: https://github.com/coreos/bugs/issues/1815 */
-		UserData: `{
-  "ignition": { "version": "2.0.0" },
-  "systemd": {
-    "units": [
-      {
-        "name": "etcd.service",
-        "enable": true,
-        "dropins": [{
-          "name": "metadata.conf",
-          "contents": "[Unit]\nWants=coreos-metadata.service\nAfter=coreos-metadata.service\n\n[Service]\nEnvironmentFile=-/run/metadata/coreos\nExecStart=\nExecStart=/usr/bin/etcd --name=$name --discovery=$discovery --addr=$private_ipv4:2379 --peer-addr=$private_ipv4:2380"
-        }]
-      },
-      {
-        "name": "coreos-metadata.service",
-        "dropins": [{
-          "name": "qemu.conf",
-          "contents": "[Unit]\nConditionVirtualization=!qemu"
-        }]
-      }
-    ]
-  }
-}`,
-	})
-
 	// test etcd discovery with 2.0 with new cloud config
 	register.Register(&register.Test{
 		Run:         Discovery,
@@ -103,9 +71,7 @@ func Discovery(c cluster.TestCluster) error {
 		return fmt.Errorf("failed to set keys: %v", err)
 	}
 
-	var quorumRead bool
-	quorumRead = strings.Contains(c.Name, "etcd2")
-	if err = checkKeys(c, keyMap, quorumRead); err != nil {
+	if err = checkKeys(c, keyMap); err != nil {
 		return fmt.Errorf("failed to check keys: %v", err)
 	}
 

--- a/kola/tests/etcd/rolling.go
+++ b/kola/tests/etcd/rolling.go
@@ -88,7 +88,7 @@ func RollingUpgrade(cluster cluster.TestCluster) error {
 	for i, m := range cluster.Machines() {
 
 		// check current value set
-		if err := checkKeys(cluster, mapSet, true); err != nil {
+		if err := checkKeys(cluster, mapSet); err != nil {
 			return err
 		}
 
@@ -127,7 +127,7 @@ func RollingUpgrade(cluster cluster.TestCluster) error {
 	mapCopy(mapSet, tempSet)
 
 	// final check all values written correctly
-	if err := checkKeys(cluster, mapSet, true); err != nil {
+	if err := checkKeys(cluster, mapSet); err != nil {
 		return err
 	}
 

--- a/kola/tests/etcd/util.go
+++ b/kola/tests/etcd/util.go
@@ -116,15 +116,10 @@ func setKeys(cluster platform.Cluster, n int) (map[string]string, error) {
 
 // checkKeys tests that each node in the cluster has the full provided
 // key set in keyMap. Quorum get must be used.
-func checkKeys(cluster platform.Cluster, keyMap map[string]string, quorum bool) error {
+func checkKeys(cluster platform.Cluster, keyMap map[string]string) error {
 	for i, m := range cluster.Machines() {
 		for k, v := range keyMap {
-			var cmd string
-			if quorum {
-				cmd = fmt.Sprintf("curl -s http://127.0.0.1:2379/v2/keys/%v?quorum=true", k)
-			} else {
-				cmd = fmt.Sprintf("curl -s http://127.0.0.1:2379/v2/keys/%v", k)
-			}
+			cmd := fmt.Sprintf("curl -s http://127.0.0.1:2379/v2/keys/%v?quorum=true", k)
 
 			b, err := m.SSH(cmd)
 			if err != nil {


### PR DESCRIPTION
This test has been tagged as "Manual" since 2015, effectively meaning it
hasn't been run since then. Additionally the test has been broken since
the conversion to Ignition because etcd.service doesn't contain an
Install section so it is impossible to enable. There isn't much point to
keeping this dead/broken code around so just clean it out.