### PR TITLE
harness: add an example for how to customize test suites

### DIFF
--- a/harness/_example/doc.go
+++ b/harness/_example/doc.go
@@ -1,0 +1,31 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This example program illustrates how to create a custom test suite
+// based on the harness package. main.go contains the test suite glue
+// while tests.go contains example tests.
+//
+// The custom test suite adds a feature to give individual tests some
+// data that can be overridden in the environment. When executed:
+//
+//	./example  -v
+//	=== RUN   LogIt
+//	--- PASS: LogIt (0.00s)
+//	        tests.go:27: Got "something"
+//	=== RUN   SkipIt
+//	--- SKIP: SkipIt (0.00s)
+//	        main.go:40: Missing "TEST_DATA_else" in environment.
+//	PASS
+//
+package main

--- a/harness/_example/main.go
+++ b/harness/_example/main.go
@@ -1,0 +1,76 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/coreos/mantle/harness"
+)
+
+type X struct {
+	*harness.H
+	defaults map[string]string
+}
+
+func (x *X) Option(key string) string {
+	env := "TEST_DATA_" + key
+	if value := os.Getenv(env); value != "" {
+		return value
+	}
+
+	if value, ok := x.defaults[key]; ok {
+		return value
+	}
+
+	x.Skipf("Missing %q in environment.", env)
+	return ""
+}
+
+type Test struct {
+	Name     string
+	Run      func(x *X)
+	Defaults map[string]string
+}
+
+var tests harness.Tests
+
+func Register(test Test) {
+	// copy map to prevent surprises
+	defaults := make(map[string]string)
+	for k, v := range test.Defaults {
+		defaults[k] = v
+	}
+
+	tests.Add(test.Name, func(h *harness.H) {
+		test.Run(&X{H: h, defaults: defaults})
+	})
+}
+
+func main() {
+	opts := harness.Options{OutputDir: "_x_temp"}
+	opts.FlagSet("", flag.ExitOnError).Parse(os.Args[1:])
+
+	suite := harness.NewSuite(opts, tests)
+	if err := suite.Run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		fmt.Println("FAIL")
+		os.Exit(1)
+	}
+	fmt.Println("PASS")
+	os.Exit(0)
+}

--- a/harness/_example/tests.go
+++ b/harness/_example/tests.go
@@ -1,0 +1,39 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+func init() {
+	defaults := map[string]string{
+		"something": "something",
+	}
+
+	Register(Test{
+		Name:     "LogIt",
+		Defaults: defaults,
+		Run: func(x *X) {
+			s := x.Option("something")
+			x.Logf("Got %q", s)
+		},
+	})
+
+	Register(Test{
+		Name:     "SkipIt",
+		Defaults: defaults,
+		Run: func(x *X) {
+			s := x.Option("else")
+			x.Errorf("Got %q", s)
+		},
+	})
+}


### PR DESCRIPTION
Slowly porting kola to the new harness package is a little tricky so I
wanted a clear/concise example of how harness can be used to illustrate
what I'm trying to do.