### PR TITLE
pluton: support NodeCheck becoming more flexible

### DIFF
--- a/pluton/spawn/bootkube.go
+++ b/pluton/spawn/bootkube.go
@@ -99,7 +99,7 @@ func MakeBootkubeCluster(c cluster.TestCluster, workerNodes int, selfHostEtcd bo
 	cluster := pluton.NewCluster(manager, []platform.Machine{master}, workers)
 
 	// check that all nodes appear in kubectl
-	if err := cluster.NodeCheck(20); err != nil {
+	if err := cluster.Ready(); err != nil {
 		return nil, fmt.Errorf("final node check: %v", err)
 	}
 

--- a/pluton/tests/bootkube/destructiontests.go
+++ b/pluton/tests/bootkube/destructiontests.go
@@ -47,7 +47,7 @@ func rebootMaster(tc cluster.TestCluster) error {
 			return fmt.Errorf("turning off selinux failed: %v", err)
 		}
 
-		if err := c.NodeCheck(25); err != nil {
+		if err := c.Ready(); err != nil {
 			return fmt.Errorf("nodeCheck: %s", err)
 		}
 	}
@@ -95,7 +95,7 @@ func deleteAPIServer(tc cluster.TestCluster) error {
 	}
 
 	// wait for apiserver to return
-	if err := c.NodeCheck(25); err != nil {
+	if err := c.Ready(); err != nil {
 		return fmt.Errorf("nodeCheck: %s", err)
 	}
 


### PR DESCRIPTION
In the future I'd like to this function to become more robust and based
on how the Cluster was setup and what things are expected to be there.
This just lays the groundwork interfacewise so future tests rely on it.
I also hardcode the timeout value to the highest one in use. I don't
think we need to expose it to test writers.