### PR TITLE
qemu: fix default PC BIOS image

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -31,7 +31,7 @@ var (
 	}
 
 	kolaDefaultBIOS = map[string]string{
-		"amd64-usr": "bios.bin",
+		"amd64-usr": "bios-256k.bin",
 		"arm64-usr": sdk.BuildRoot() + "/images/arm64-usr/latest/coreos_production_qemu_uefi_efi_code.fd",
 	}
 )

--- a/cmd/pluton/options.go
+++ b/cmd/pluton/options.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/coreos/mantle/kola"
 	"github.com/coreos/mantle/sdk"
@@ -33,7 +32,7 @@ var (
 
 	kolaDefaultBIOS = map[string]string{
 		"amd64-usr": "bios-256k.bin",
-		"arm64-usr": filepath.Join(sdk.BoardRoot("arm64-usr"), "/usr/share/edk2-armvirt/bios.bin"),
+		"arm64-usr": sdk.BuildRoot() + "/images/arm64-usr/latest/coreos_production_qemu_uefi_efi_code.fd",
 	}
 )
 

--- a/cmd/pluton/options.go
+++ b/cmd/pluton/options.go
@@ -32,7 +32,7 @@ var (
 	}
 
 	kolaDefaultBIOS = map[string]string{
-		"amd64-usr": "bios.bin",
+		"amd64-usr": "bios-256k.bin",
 		"arm64-usr": filepath.Join(sdk.BoardRoot("arm64-usr"), "/usr/share/edk2-armvirt/bios.bin"),
 	}
 )


### PR DESCRIPTION
Despite documentation to the contrary the default firmware for PC
virtual machines has been bios-256k.bin since QEMU 2.0. As of 2.8 the
older bios.bin has stopped working properly.