### PR TITLE
pluton: use bootkube's hackdir for configuration of host

### DIFF
--- a/cmd/pluton/pluton.go
+++ b/cmd/pluton/pluton.go
@@ -52,20 +52,16 @@ var (
 		Run:   runList,
 	}
 
-	bootkubeRepo       string
-	bootkubeTag        string
-	hostKubeletTag     string
-	conformanceRepo    string
-	conformanceVersion string
+	bootkubeRepo      string
+	bootkubeTag       string
+	bootkubeScriptDir string
 )
 
 func init() {
 
 	cmdRun.Flags().StringVar(&bootkubeRepo, "bootkubeRepo", "quay.io/coreos/bootkube", "")
 	cmdRun.Flags().StringVar(&bootkubeTag, "bootkubeTag", "v0.3.7", "")
-	cmdRun.Flags().StringVar(&hostKubeletTag, "hostKubeletTag", "v1.5.3_coreos.0", "")
-	cmdRun.Flags().StringVar(&conformanceRepo, "conformanceRepo", "github.com/coreos/kubernetes", "")
-	cmdRun.Flags().StringVar(&conformanceVersion, "conformanceVersion", "v1.5.3+coreos.0", "")
+	cmdRun.Flags().StringVar(&bootkubeScriptDir, "bootkubeScriptDir", "", "Make use of bootkube's node init scripts and kubelet service files. Leave blank to use default or pass in the hack/quickstart dir from the bootkube repo.")
 	root.AddCommand(cmdRun)
 	root.AddCommand(cmdList)
 }
@@ -96,9 +92,7 @@ func runRun(cmd *cobra.Command, args []string) {
 
 	kola.RegisterTestOption("BootkubeRepo", bootkubeRepo)
 	kola.RegisterTestOption("BootkubeTag", bootkubeTag)
-	kola.RegisterTestOption("HostKubeletTag", hostKubeletTag)
-	kola.RegisterTestOption("ConformanceRepo", conformanceRepo)
-	kola.RegisterTestOption("ConformanceVersion", conformanceVersion)
+	kola.RegisterTestOption("BootkubeScriptDir", bootkubeScriptDir)
 
 	err := kola.RunTests(pattern, kolaPlatform, outputDir)
 	if err != nil {

--- a/pluton/cluster.go
+++ b/pluton/cluster.go
@@ -32,14 +32,24 @@ import (
 type Cluster struct {
 	Masters []platform.Machine
 	Workers []platform.Machine
+	Info    Info
 
 	m Manager
 }
 
-func NewCluster(m Manager, masters, workers []platform.Machine) *Cluster {
+// Info contains information about how a Cluster is configured that may be
+// useful for some tests.
+type Info struct {
+	KubeletTag      string // e.g. v1.5.3_coreos.0
+	Version         string // e.g. v1.5.3+coreos.0
+	UpstreamVersion string // e.g. v1.5.3
+}
+
+func NewCluster(m Manager, masters, workers []platform.Machine, info Info) *Cluster {
 	return &Cluster{
 		Masters: masters,
 		Workers: workers,
+		Info:    info,
 		m:       m,
 	}
 }

--- a/pluton/spawn/bootkube.go
+++ b/pluton/spawn/bootkube.go
@@ -140,7 +140,7 @@ func renderNodeConfig(kubeletService string, isMaster, startEtcd bool) (string, 
 	}{
 		isMaster,
 		startEtcd,
-		kubeletService,
+		serviceToConfig(kubeletService),
 	}
 
 	buf := new(bytes.Buffer)
@@ -154,6 +154,22 @@ func renderNodeConfig(kubeletService string, isMaster, startEtcd bool) (string, 
 	}
 
 	return buf.String(), nil
+}
+
+// The service files we read in from the hack directory need to be indented and
+// have a bash variable substituted before being placed in the cloud-config.
+func serviceToConfig(s string) string {
+	const indent = "        " // 8 spaces to fit in cloud-config
+
+	lines := strings.Split(s, "\n")
+	for i := range lines {
+		lines[i] = indent + lines[i]
+	}
+
+	service := strings.Join(lines, "\n")
+	service = strings.Replace(service, "${COREOS_PRIVATE_IPV4}", "$private_ipv4", -1)
+
+	return service
 }
 
 func bootstrapMaster(m platform.Machine, imageRepo, imageTag string, selfHostEtcd bool) error {

--- a/pluton/spawn/nodeconfig.go
+++ b/pluton/spawn/nodeconfig.go
@@ -24,62 +24,75 @@ coreos:
   update:
     reboot-strategy: "off"`
 
-var defaultKubeletMasterService = `        [Service]
-        EnvironmentFile=/etc/environment
-        Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-        Environment=KUBELET_VERSION=v1.5.3_coreos.0
-        Environment="RKT_OPTS=--dns=host --volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni"
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
-        ExecStartPre=/bin/mkdir -p /var/lib/cni
-        ExecStart=/usr/lib/coreos/kubelet-wrapper \
-          --kubeconfig=/etc/kubernetes/kubeconfig \
-          --require-kubeconfig \
-          --cni-conf-dir=/etc/kubernetes/cni/net.d \
-          --network-plugin=cni \
-          --lock-file=/var/run/lock/kubelet.lock \
-          --exit-on-lock-contention \
-          --pod-manifest-path=/etc/kubernetes/manifests \
-          --hostname-override=$private_ipv4 \
-          --allow-privileged \
-          --node-labels=master=true \
-          --register-node=true \
-          --v=4 \
-          --cluster_dns=10.3.0.10 \
-          --cluster_domain=cluster.local
-        Restart=always
-        RestartSec=5
+var defaultKubeletMasterService = `[Service]
+Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
+Environment=KUBELET_IMAGE_TAG=v1.5.3_coreos.0
+Environment="RKT_RUN_ARGS=\
+--uuid-file-save=/var/run/kubelet-pod.uuid \
+--volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \
+--volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni"
+EnvironmentFile=/etc/environment
+ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
+ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
+ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
+ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
+ExecStartPre=/bin/mkdir -p /var/lib/cni
+ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
+ExecStart=/usr/lib/coreos/kubelet-wrapper \
+  --kubeconfig=/etc/kubernetes/kubeconfig \
+  --require-kubeconfig \
+  --client-ca-file=/etc/kubernetes/ca.crt \
+  --anonymous-auth=false \
+  --cni-conf-dir=/etc/kubernetes/cni/net.d \
+  --network-plugin=cni \
+  --lock-file=/var/run/lock/kubelet.lock \
+  --exit-on-lock-contention \
+  --allow-privileged \
+  --hostname-override=${COREOS_PRIVATE_IPV4} \
+  --node-labels=master=true \
+  --minimum-container-ttl-duration=3m0s \
+  --cluster_dns=10.3.0.10 \
+  --cluster_domain=cluster.local \
+  --config=/etc/kubernetes/manifests
 
-        [Install]
-        WantedBy=multi-user.target`
-var defaultKubeletWorkerService = `        [Service]
-        EnvironmentFile=/etc/environment
-        Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-        Environment=KUBELET_VERSION=v1.5.3_coreos.0
-        Environment="RKT_OPTS=--dns=host --volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni"
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
-        ExecStartPre=/bin/mkdir -p /var/lib/cni
-        ExecStart=/usr/lib/coreos/kubelet-wrapper \
-          --kubeconfig=/etc/kubernetes/kubeconfig \
-          --require-kubeconfig \
-          --cni-conf-dir=/etc/kubernetes/cni/net.d \
-          --network-plugin=cni \
-          --lock-file=/var/run/lock/kubelet.lock \
-          --exit-on-lock-contention \
-          --pod-manifest-path=/etc/kubernetes/manifests \
-          --hostname-override=$private_ipv4 \
-          --allow-privileged \
-          --register-node=true \
-          --v=4 \
-          --cluster_dns=10.3.0.10 \
-          --cluster_domain=cluster.local
-        Restart=always
-        RestartSec=5
+ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
+Restart=always
+RestartSec=5
 
-        [Install]
-        WantedBy=multi-user.target`
+[Install]
+WantedBy=multi-user.target`
+
+var defaultKubeletWorkerService = `[Service]
+Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
+Environment=KUBELET_IMAGE_TAG=v1.5.3_coreos.0
+Environment="RKT_RUN_ARGS=\
+--uuid-file-save=/var/run/kubelet-pod.uuid \
+--volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf \
+--volume var-lib-cni,kind=host,source=/var/lib/cni --mount volume=var-lib-cni,target=/var/lib/cni"
+EnvironmentFile=/etc/environment
+ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
+ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
+ExecStartPre=/bin/mkdir -p /var/lib/cni
+ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
+ExecStart=/usr/lib/coreos/kubelet-wrapper \
+  --kubeconfig=/etc/kubernetes/kubeconfig \
+  --require-kubeconfig \
+  --client-ca-file=/etc/kubernetes/ca.crt \
+  --anonymous-auth=false \
+  --cni-conf-dir=/etc/kubernetes/cni/net.d \
+  --network-plugin=cni \
+  --lock-file=/var/run/lock/kubelet.lock \
+  --exit-on-lock-contention \
+  --allow-privileged \
+  --hostname-override=${COREOS_PRIVATE_IPV4} \
+  --minimum-container-ttl-duration=3m0s \
+  --cluster_dns=10.3.0.10 \
+  --cluster_domain=cluster.local \
+  --config=/etc/kubernetes/manifests
+
+ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target`

--- a/pluton/tests/bootkube/conformance.go
+++ b/pluton/tests/bootkube/conformance.go
@@ -26,11 +26,5 @@ func conformanceBootkube(c cluster.TestCluster) error {
 		return err
 	}
 
-	// cmdline options
-	var (
-		repo    = c.Options["ConformanceRepo"]
-		version = c.Options["ConformanceVersion"]
-	)
-
-	return upstream.RunConformanceTests(pc, repo, version)
+	return upstream.RunConformanceTests(pc)
 }

--- a/pluton/tests/bootkube/scale.go
+++ b/pluton/tests/bootkube/scale.go
@@ -100,7 +100,7 @@ func resizeSelfHostedEtcd(c *pluton.Cluster, size int) error {
 		return nil
 	}
 
-	if err := util.Retry(10, 12*time.Second, podsReady); err != nil {
+	if err := util.Retry(15, 10*time.Second, podsReady); err != nil {
 		return err
 	}
 	return nil

--- a/pluton/upstream/conformance.go
+++ b/pluton/upstream/conformance.go
@@ -22,14 +22,15 @@ import (
 )
 
 // Runs conformance tests on a master node of a Cluster
-func RunConformanceTests(c *pluton.Cluster, k8sRepo, k8sVersion string) error {
+func RunConformanceTests(c *pluton.Cluster) error {
 	const (
 		kcPath  = "/etc/kubernetes/kubeconfig"
 		goImage = "docker://golang:1.7.4"
+		repo    = "github.com/coreos/kubernetes"
 	)
 
 	cmds := []string{
-		fmt.Sprintf("git clone https://%s /home/core/k8s", k8sRepo),
+		fmt.Sprintf("git clone https://%s /home/core/k8s", repo),
 		"mkdir /home/core/artifacts",
 	}
 	for _, cmd := range cmds {
@@ -54,7 +55,7 @@ func RunConformanceTests(c *pluton.Cluster, k8sRepo, k8sVersion string) error {
 		make all WHAT=test/e2e/e2e.test && \
 		KUBECONFIG=/kubeconfig KUBERNETES_PROVIDER=skeleton KUBERNETES_CONFORMANCE_TEST=Y go run hack/e2e.go \
  		-v --test -check_version_skew=false --test_args='--ginkgo.focus=\[Conformance\]'"`,
-		kcPath, goImage, k8sVersion)
+		kcPath, goImage, c.Info.Version)
 
 	// stream conformance output
 	client, err := c.Masters[0].SSHClient()


### PR DESCRIPTION
This makes pluton running on bootkube PRs less high-touch since we can input the hack/quickstart dir from bootkube along with the container. This PR only enables use of the kubelet service files from that directory for now. If no directory is specified we will use the default ones periodically synced with bootkube. 

Depends on: https://github.com/kubernetes-incubator/bootkube/pull/350 and a few more changes on my part here.

cc @marineam 