### PR TITLE
kola/tests: exclude coreos-metadata from kvm systems

### DIFF
--- a/kola/tests/coretest/core.go
+++ b/kola/tests/coretest/core.go
@@ -50,7 +50,6 @@ func init() {
 			"EtcdUpdateValue":    TestEtcdUpdateValue,
 			"FleetctlRunService": TestFleetctlRunService,
 		},
-		/* TODO: https://github.com/coreos/bugs/issues/1815 */
 		UserData: `{
   "ignition": { "version": "2.0.0" },
   "systemd": {
@@ -75,7 +74,7 @@ func init() {
         "name": "coreos-metadata.service",
         "dropins": [{
           "name": "qemu.conf",
-          "contents": "[Unit]\nConditionVirtualization=!qemu"
+          "contents": "[Unit]\nConditionVirtualization=!kvm\nConditionVirtualization=!qemu"
         }]
       }
     ]

--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -31,7 +31,6 @@ func init() {
 		Run:         Discovery,
 		ClusterSize: 3,
 		Name:        "coreos.etcd2.discovery",
-		/* TODO: https://github.com/coreos/bugs/issues/1815 */
 		UserData: `{
   "ignition": { "version": "2.0.0" },
   "systemd": {
@@ -48,7 +47,7 @@ func init() {
         "name": "coreos-metadata.service",
         "dropins": [{
           "name": "qemu.conf",
-          "contents": "[Unit]\nConditionVirtualization=!qemu"
+          "contents": "[Unit]\nConditionVirtualization=!kvm\nConditionVirtualization=!qemu"
         }]
       }
     ]

--- a/kola/tests/flannel/flannel.go
+++ b/kola/tests/flannel/flannel.go
@@ -32,8 +32,7 @@ import (
 )
 
 var (
-	plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "kola/tests/flannel")
-	/* TODO: https://github.com/coreos/bugs/issues/1815 */
+	plog        = capnslog.NewPackageLogger("github.com/coreos/mantle", "kola/tests/flannel")
 	flannelConf = `{
   "ignition": { "version": "2.0.0" },
   "systemd": {
@@ -69,7 +68,7 @@ var (
         "name": "coreos-metadata.service",
         "dropins": [{
           "name": "qemu.conf",
-          "contents": "[Unit]\nConditionVirtualization=!qemu"
+          "contents": "[Unit]\nConditionVirtualization=!kvm\nConditionVirtualization=!qemu"
         }]
       }
     ]

--- a/kola/tests/fleet/fleet.go
+++ b/kola/tests/fleet/fleet.go
@@ -27,7 +27,6 @@ import (
 )
 
 var (
-	/* TODO: https://github.com/coreos/bugs/issues/1815 */
 	masterconf = `{
   "ignition": { "version": "2.0.0" },
   "systemd": {
@@ -52,7 +51,7 @@ var (
         "name": "coreos-metadata.service",
         "dropins": [{
           "name": "qemu.conf",
-          "contents": "[Unit]\nConditionVirtualization=!qemu"
+          "contents": "[Unit]\nConditionVirtualization=!kvm\nConditionVirtualization=!qemu"
         }]
       }
     ]
@@ -67,7 +66,6 @@ var (
   }
 }`
 
-	/* TODO: https://github.com/coreos/bugs/issues/1815 */
 	proxyconf = `{
   "ignition": { "version": "2.0.0" },
   "systemd": {
@@ -88,7 +86,7 @@ var (
         "name": "coreos-metadata.service",
         "dropins": [{
           "name": "qemu.conf",
-          "contents": "[Unit]\nConditionVirtualization=!qemu"
+          "contents": "[Unit]\nConditionVirtualization=!kvm\nConditionVirtualization=!qemu"
         }]
       }
     ]

--- a/kola/tests/locksmith/locksmith.go
+++ b/kola/tests/locksmith/locksmith.go
@@ -51,7 +51,7 @@ func init() {
         "name": "coreos-metadata.service",
         "dropins": [{
           "name": "qemu.conf",
-          "contents": "[Unit]\nConditionVirtualization=!qemu"
+          "contents": "[Unit]\nConditionVirtualization=!kvm\nConditionVirtualization=!qemu"
         }]
       }
     ]


### PR DESCRIPTION
Apparently `kvm` is the intended value, and this was written for broken versions of systemd.  See the history of `virt.c`: https://github.com/systemd/systemd/commits/master/src/basic/virt.c