### PR TITLE
aws: default to HVM / t2 series

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -63,9 +63,9 @@ func init() {
 	sv(&kola.GCEOptions.JSONKeyFile, "gce-json-key", "", "use a service account's JSON key for authentication")
 
 	// aws-specific options
-	// CoreOS-alpha-845.0.0 on us-west-1
-	sv(&kola.AWSOptions.AMI, "aws-ami", "ami-55438011", "AWS AMI ID")
-	sv(&kola.AWSOptions.InstanceType, "aws-type", "t1.micro", "AWS instance type")
+	// Container Linux 1339.0.0 (alpha) on us-west-1
+	sv(&kola.AWSOptions.AMI, "aws-ami", "ami-17d48a77", "AWS AMI ID")
+	sv(&kola.AWSOptions.InstanceType, "aws-type", "t2.micro", "AWS instance type")
 	sv(&kola.AWSOptions.SecurityGroup, "aws-sg", "kola", "AWS security group name")
 }
 

--- a/platform/machine/aws/cluster.go
+++ b/platform/machine/aws/cluster.go
@@ -85,6 +85,9 @@ func (ac *cluster) NewMachine(userdata string) (platform.Machine, error) {
 	conf.CopyKeys(keys)
 
 	instances, err := ac.api.CreateInstances(ac.Name(), conf.String(), 1, true)
+	if err != nil {
+		return nil, err
+	}
 
 	mach := &machine{
 		cluster: ac,


### PR DESCRIPTION
And I tossed in an error check that lead to a panic if e.g. an HVM ami was specified but the PV-only t1.micro was defaulted.