### PR TITLE
pluton/tests/bootkube: self-hosted etcd only scales to master nodes

### DIFF
--- a/pluton/tests/bootkube/scale.go
+++ b/pluton/tests/bootkube/scale.go
@@ -142,8 +142,7 @@ func checkEtcdPodDistribution(c *pluton.Cluster, etcdClusterSize int) error {
 
 	for k, _ := range nodeSet {
 		if _, ok := masterSet[k]; !ok {
-			// Just warn instead of erroring until/if supported
-			plog.Infof("detected self-hosted etcd pod running on non-master node %v %v", masterSet, nodeSet)
+			return fmt.Errorf("detected self-hosted etcd pod running on non-master node %v %v", masterSet, nodeSet)
 		}
 	}
 

--- a/pluton/tests/bootkube/scale.go
+++ b/pluton/tests/bootkube/scale.go
@@ -100,8 +100,8 @@ func resizeSelfHostedEtcd(c *pluton.Cluster, size int) error {
 		return nil
 	}
 
-	if err := util.Retry(15, 10*time.Second, podsReady); err != nil {
-		return err
+	if err := util.Retry(20, 10*time.Second, podsReady); err != nil {
+		return fmt.Errorf("Waited 200 seconds for etcd to scale: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
cc @xiang90 @hongchaodeng

We can enable this now because of https://github.com/kubernetes-incubator/bootkube/pull/359