### PR TITLE
kola/tests: make coreos-metadata.service depend on coreos.oem.id

### DIFF
--- a/kola/tests/coretest/core.go
+++ b/kola/tests/coretest/core.go
@@ -74,7 +74,7 @@ func init() {
         "name": "coreos-metadata.service",
         "dropins": [{
           "name": "qemu.conf",
-          "contents": "[Unit]\nConditionVirtualization=!kvm\nConditionVirtualization=!qemu"
+          "contents": "[Unit]\nConditionKernelCommandLine=coreos.oem.id"
         }]
       }
     ]

--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -47,7 +47,7 @@ func init() {
         "name": "coreos-metadata.service",
         "dropins": [{
           "name": "qemu.conf",
-          "contents": "[Unit]\nConditionVirtualization=!kvm\nConditionVirtualization=!qemu"
+          "contents": "[Unit]\nConditionKernelCommandLine=coreos.oem.id"
         }]
       }
     ]

--- a/kola/tests/flannel/flannel.go
+++ b/kola/tests/flannel/flannel.go
@@ -68,7 +68,7 @@ var (
         "name": "coreos-metadata.service",
         "dropins": [{
           "name": "qemu.conf",
-          "contents": "[Unit]\nConditionVirtualization=!kvm\nConditionVirtualization=!qemu"
+          "contents": "[Unit]\nConditionKernelCommandLine=coreos.oem.id"
         }]
       }
     ]

--- a/kola/tests/fleet/fleet.go
+++ b/kola/tests/fleet/fleet.go
@@ -51,7 +51,7 @@ var (
         "name": "coreos-metadata.service",
         "dropins": [{
           "name": "qemu.conf",
-          "contents": "[Unit]\nConditionVirtualization=!kvm\nConditionVirtualization=!qemu"
+          "contents": "[Unit]\nConditionKernelCommandLine=coreos.oem.id"
         }]
       }
     ]
@@ -86,7 +86,7 @@ var (
         "name": "coreos-metadata.service",
         "dropins": [{
           "name": "qemu.conf",
-          "contents": "[Unit]\nConditionVirtualization=!kvm\nConditionVirtualization=!qemu"
+          "contents": "[Unit]\nConditionKernelCommandLine=coreos.oem.id"
         }]
       }
     ]

--- a/kola/tests/locksmith/locksmith.go
+++ b/kola/tests/locksmith/locksmith.go
@@ -51,7 +51,7 @@ func init() {
         "name": "coreos-metadata.service",
         "dropins": [{
           "name": "qemu.conf",
-          "contents": "[Unit]\nConditionVirtualization=!kvm\nConditionVirtualization=!qemu"
+          "contents": "[Unit]\nConditionKernelCommandLine=coreos.oem.id"
         }]
       }
     ]


### PR DESCRIPTION
The service conditions were previously based on virt-type values, but since systemd v233, "kvm" is returned where "qemu" used to be.  Excluding based on "ConditionVirtualization=kvm" is not feasible
since "kvm" is the detected virt-type for several platforms that do utilize the metadata service.  Since these platforms all require setting coreos.oem.id on the kernel command-line, and QEMU tests run on the base image without that value set, make the service depend on its existence.