### PR TITLE
pluton/spawn: don't use rkt-fly on bootkube start

### DIFF
--- a/pluton/spawn/bootkube.go
+++ b/pluton/spawn/bootkube.go
@@ -203,9 +203,10 @@ func bootstrapMaster(m platform.Machine, imageRepo, imageTag string, selfHostEtc
 		// start kubelet
 		"sudo systemctl -q enable --now kubelet",
 
-		// start bootkube (rkt fly makes stderr/stdout seperation work)
+		// start bootkube
+		// TODO(pb): separate stdin/stdout
 		fmt.Sprintf(`sudo /usr/bin/rkt run \
-                --stage1-name=coreos.com/rkt/stage1-fly:1.25.0 \
+		--net=host \
         	--volume home,kind=host,source=/home/core \
         	--mount volume=home,target=/core \
         	--volume manifests,kind=host,source=/etc/kubernetes/manifests \


### PR DESCRIPTION
This was causing my bootkube PR for 1.6 updates to fail. Its unclear why, but removing rkt-fly stopped bootkube from nearly immediately exiting. 

It was one of the last remaining differences between how I setup bootkube and the scripts from the in-repo hack-dir. I added the rkt-fly so I could separate stdout from stdin in rkt, there is probably another way to accomplish this.