### PR TITLE
pluton: use new harness directly

### DIFF
--- a/platform/api/gcloud/compute.go
+++ b/platform/api/gcloud/compute.go
@@ -15,8 +15,8 @@
 package gcloud
 
 import (
+	"crypto/rand"
 	"fmt"
-	"math/rand"
 	"strings"
 	"time"
 
@@ -28,7 +28,9 @@ import (
 )
 
 func (a *API) vmname() string {
-	return fmt.Sprintf("%s-%x", a.options.BaseName, rand.Int63())
+	b := make([]byte, 10)
+	rand.Read(b)
+	return fmt.Sprintf("%s-%x", a.options.BaseName, b)
 }
 
 // Taken from: https://github.com/golang/build/blob/master/buildlet/gce.go

--- a/pluton/cluster.go
+++ b/pluton/cluster.go
@@ -20,19 +20,23 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/mantle/harness"
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/util"
 )
 
-// Cluster represents an interface to test kubernetes clusters The creation is
-// usually implemented by a function that builds the Cluster from a kola
-// TestCluster from the 'spawn' subpackage. Tests may be aware of the
-// implementor function since not all clusters are expected to have the same
-// components nor properties.
+// Cluster represents an interface to test kubernetes clusters. The harness
+// object is used for logging, exiting or skipping a test. Is nearly
+// identical to the Go test harness. The creation is usually implemented by a
+// function that builds the Cluster from a kola TestCluster from the 'spawn'
+// subpackage. Tests may be aware of the implementor function since not all
+// clusters are expected to have the same components nor properties.
 type Cluster struct {
 	Masters []platform.Machine
 	Workers []platform.Machine
 	Info    Info
+
+	*harness.H
 
 	m Manager
 }

--- a/pluton/harness/options.go
+++ b/pluton/harness/options.go
@@ -1,0 +1,38 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package harness
+
+import (
+	"github.com/coreos/mantle/platform"
+	"github.com/coreos/mantle/platform/api/gcloud"
+)
+
+// GlobalOptions are set in main and represent options that affect all tests
+// run in a single invocation of pluton.
+type GlobalOptions struct {
+	CloudPlatform   string // only GCE is supported currently
+	PlatformOptions platform.Options
+	GCEOptions      gcloud.Options
+
+	Parallel  int
+	OutputDir string
+
+	BootkubeRepo      string
+	BootkubeTag       string
+	BootkubeScriptDir string
+}
+
+// Glue variable for setting global options
+var Opts GlobalOptions

--- a/pluton/harness/register.go
+++ b/pluton/harness/register.go
@@ -1,0 +1,14 @@
+package harness
+
+import (
+	"github.com/coreos/mantle/harness"
+	"github.com/coreos/mantle/pluton"
+)
+
+var Tests harness.Tests
+
+func Register(test pluton.Test) {
+	Tests.Add(test.Name, func(h *harness.H) {
+		runTest(test, h)
+	})
+}

--- a/pluton/harness/run.go
+++ b/pluton/harness/run.go
@@ -1,0 +1,113 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package harness
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/coreos/mantle/harness"
+	"github.com/coreos/mantle/platform"
+	"github.com/coreos/mantle/platform/machine/gcloud"
+	"github.com/coreos/mantle/pluton"
+	"github.com/coreos/mantle/pluton/spawn"
+)
+
+// Call this from main after setting all the global options. Tests are filtered
+// by name based on the glob pattern given.
+func RunSuite(pattern string) {
+	Opts.GCEOptions.Options = &Opts.PlatformOptions
+
+	tests, err := filterTests(Tests, pattern)
+	if err != nil {
+		fmt.Printf("Error filtering glob pattern: %v", err)
+		os.Exit(1)
+
+	}
+
+	opts := harness.Options{
+		OutputDir: Opts.OutputDir,
+		Parallel:  Opts.Parallel,
+		Verbose:   true,
+	}
+	suite := harness.NewSuite(opts, tests)
+
+	if err := suite.Run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		fmt.Println("FAIL")
+		os.Exit(1)
+	}
+	fmt.Println("PASS")
+	os.Exit(0)
+}
+
+func filterTests(tests harness.Tests, pattern string) (harness.Tests, error) {
+	var filteredTests = make(harness.Tests)
+	for name, t := range tests {
+		match, err := filepath.Match(pattern, name)
+		if err != nil {
+			return nil, err
+		}
+		if !match {
+			continue
+		}
+		filteredTests[name] = t
+	}
+	return filteredTests, nil
+}
+
+// RunTest is called inside the closure passed into the harness. Currently only
+// GCE is supported, no reason this can't change
+func runTest(t pluton.Test, h *harness.H) {
+	h.Parallel()
+
+	var cloud platform.Cluster
+	var err error
+
+	switch Opts.CloudPlatform {
+	case "gce":
+		cloud, err = gcloud.NewCluster(&Opts.GCEOptions, h.OutputDir())
+	default:
+		err = fmt.Errorf("invalid cloud platform %v", Opts.CloudPlatform)
+	}
+
+	if err != nil {
+		h.Fatalf("Cluster failed: %v", err)
+	}
+	defer func() {
+		if err := cloud.Destroy(); err != nil {
+			h.Logf("cluster.Destroy(): %v", err)
+		}
+	}()
+
+	config := spawn.BootkubeConfig{
+		ImageRepo:      Opts.BootkubeRepo,
+		ImageTag:       Opts.BootkubeTag,
+		ScriptDir:      Opts.BootkubeScriptDir,
+		InitialWorkers: t.Options.InitialWorkers,
+		SelfHostEtcd:   t.Options.SelfHostEtcd,
+	}
+
+	c, err := spawn.MakeBootkubeCluster(cloud, config)
+	if err != nil {
+		h.Fatalf("creating cluster: %v", err)
+	}
+
+	// TODO(pb): evidence that harness and spawn should be the same package?
+	c.H = h
+
+	t.Run(c)
+}

--- a/pluton/harness/run.go
+++ b/pluton/harness/run.go
@@ -98,6 +98,7 @@ func runTest(t pluton.Test, h *harness.H) {
 		ImageTag:       Opts.BootkubeTag,
 		ScriptDir:      Opts.BootkubeScriptDir,
 		InitialWorkers: t.Options.InitialWorkers,
+		InitialMasters: t.Options.InitialMasters,
 		SelfHostEtcd:   t.Options.SelfHostEtcd,
 	}
 

--- a/pluton/test.go
+++ b/pluton/test.go
@@ -1,0 +1,36 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pluton
+
+// A Test defines a function that will test a running Cluster. The test is run
+// based on if its Name matches the glob pattern specified on the pluton
+// command line.
+type Test struct {
+	Name    string
+	Run     func(c *Cluster)
+	Options Options
+}
+
+// Options represent per-test options that control the initial creation of a
+// Cluster.  It is advised that all options are explicitly filled out for each
+// registered test. TODO(pb): If this is too verbose to declare per test we may
+// move to a default system but lose the nice struct declaration syntax.
+// Eventually, we may allow overriding global options such as bootkube versions
+// or cloud options.
+type Options struct {
+	SelfHostEtcd   bool
+	InitialWorkers int
+	InitialMasters int
+}

--- a/pluton/tests/bootkube/conformance.go
+++ b/pluton/tests/bootkube/conformance.go
@@ -15,25 +15,12 @@
 package bootkube
 
 import (
-	"github.com/coreos/mantle/kola/cluster"
-	"github.com/coreos/mantle/pluton/spawn"
+	"github.com/coreos/mantle/pluton"
 	"github.com/coreos/mantle/pluton/upstream"
 )
 
-func conformanceBootkube(c cluster.TestCluster) error {
-	pc, err := spawn.MakeBootkubeCluster(c, 4, false)
-	if err != nil {
-		return err
+func conformanceBootkube(c *pluton.Cluster) {
+	if err := upstream.RunConformanceTests(c); err != nil {
+		c.Fatal(err)
 	}
-
-	return upstream.RunConformanceTests(pc)
-}
-
-func conformanceSelfEtcdBootkube(c cluster.TestCluster) error {
-	pc, err := spawn.MakeBootkubeCluster(c, 4, true)
-	if err != nil {
-		return err
-	}
-
-	return upstream.RunConformanceTests(pc)
 }

--- a/pluton/tests/bootkube/registry.go
+++ b/pluton/tests/bootkube/registry.go
@@ -26,6 +26,7 @@ func init() {
 		Run:  smoke,
 		Options: pluton.Options{
 			SelfHostEtcd:   false,
+			InitialMasters: 1,
 			InitialWorkers: 1,
 		},
 	})
@@ -34,6 +35,7 @@ func init() {
 		Run:  rebootMaster,
 		Options: pluton.Options{
 			SelfHostEtcd:   false,
+			InitialMasters: 1,
 			InitialWorkers: 1,
 		},
 	})
@@ -43,6 +45,7 @@ func init() {
 		Run:  deleteAPIServer,
 		Options: pluton.Options{
 			SelfHostEtcd:   false,
+			InitialMasters: 1,
 			InitialWorkers: 1,
 		},
 	})
@@ -53,6 +56,7 @@ func init() {
 		Run:  smoke,
 		Options: pluton.Options{
 			SelfHostEtcd:   true,
+			InitialMasters: 1,
 			InitialWorkers: 1,
 		},
 	})
@@ -62,6 +66,7 @@ func init() {
 		Run:  etcdScale,
 		Options: pluton.Options{
 			SelfHostEtcd:   true,
+			InitialMasters: 1,
 			InitialWorkers: 1,
 		},
 	})
@@ -71,6 +76,7 @@ func init() {
 		Run:  rebootMaster,
 		Options: pluton.Options{
 			SelfHostEtcd:   false,
+			InitialMasters: 1,
 			InitialWorkers: 1,
 		},
 	})
@@ -80,6 +86,7 @@ func init() {
 		Run:  deleteAPIServer,
 		Options: pluton.Options{
 			SelfHostEtcd:   false,
+			InitialMasters: 1,
 			InitialWorkers: 1,
 		},
 	})
@@ -90,6 +97,7 @@ func init() {
 		Run:  conformanceBootkube,
 		Options: pluton.Options{
 			SelfHostEtcd:   false,
+			InitialMasters: 1,
 			InitialWorkers: 4,
 		},
 	})
@@ -98,6 +106,7 @@ func init() {
 		Run:  conformanceBootkube,
 		Options: pluton.Options{
 			SelfHostEtcd:   true,
+			InitialMasters: 1,
 			InitialWorkers: 4,
 		},
 	})

--- a/pluton/tests/bootkube/registry.go
+++ b/pluton/tests/bootkube/registry.go
@@ -17,68 +17,93 @@ package bootkube
 import (
 	"github.com/coreos/pkg/capnslog"
 
-	"github.com/coreos/mantle/kola/register"
+	"github.com/coreos/mantle/pluton"
+	"github.com/coreos/mantle/pluton/harness"
 )
 
 var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "pluton/tests/bootkube")
 
 func init() {
 	// main test suite run on every PR
-	register.Register(&register.Test{
-		Name:      "bootkube.smoke",
-		Run:       bootkubeSmoke,
-		Platforms: []string{"gce"},
+	harness.Register(pluton.Test{
+		Name: "bootkube.smoke",
+		Run:  smoke,
+		Options: pluton.Options{
+			SelfHostEtcd:   false,
+			InitialWorkers: 1,
+		},
+	})
+	harness.Register(pluton.Test{
+		Name: "bootkube.destruct.reboot",
+		Run:  rebootMaster,
+		Options: pluton.Options{
+			SelfHostEtcd:   false,
+			InitialWorkers: 1,
+		},
 	})
 
-	register.Register(&register.Test{
-		Name:      "bootkube.destruct.reboot",
-		Run:       rebootMaster,
-		Platforms: []string{"gce"},
-	})
-
-	register.Register(&register.Test{
-		Name:      "bootkube.destruct.delete",
-		Run:       deleteAPIServer,
-		Platforms: []string{"gce"},
+	harness.Register(pluton.Test{
+		Name: "bootkube.destruct.delete",
+		Run:  deleteAPIServer,
+		Options: pluton.Options{
+			SelfHostEtcd:   false,
+			InitialWorkers: 1,
+		},
 	})
 
 	// main self-hosted test suite run on every PR
-	register.Register(&register.Test{
-		Name:      "bootkube.selfetcd.smoke",
-		Run:       bootkubeSmokeEtcd,
-		Platforms: []string{"gce"},
+	harness.Register(pluton.Test{
+		Name: "bootkube.selfetcd.smoke",
+		Run:  smoke,
+		Options: pluton.Options{
+			SelfHostEtcd:   true,
+			InitialWorkers: 1,
+		},
 	})
 
-	register.Register(&register.Test{
-		Name:      "bootkube.selfetcd.destruct.reboot",
-		Run:       rebootMasterSelfEtcd,
-		Platforms: []string{"gce"},
+	harness.Register(pluton.Test{
+		Name: "bootkube.selfetcd.scale",
+		Run:  etcdScale,
+		Options: pluton.Options{
+			SelfHostEtcd:   true,
+			InitialWorkers: 1,
+		},
 	})
 
-	register.Register(&register.Test{
-		Name:      "bootkube.selfetcd.destruct.delete",
-		Run:       deleteAPIServerSelfEtcd,
-		Platforms: []string{"gce"},
+	harness.Register(pluton.Test{
+		Name: "bootkube.selfetcd.destruct.reboot",
+		Run:  rebootMaster,
+		Options: pluton.Options{
+			SelfHostEtcd:   false,
+			InitialWorkers: 1,
+		},
 	})
 
-	register.Register(&register.Test{
-		Name:      "bootkube.selfetcd.scale",
-		Run:       etcdScale,
-		Platforms: []string{"gce"},
+	harness.Register(pluton.Test{
+		Name: "bootkube.selfetcd.destruct.delete",
+		Run:  deleteAPIServer,
+		Options: pluton.Options{
+			SelfHostEtcd:   false,
+			InitialWorkers: 1,
+		},
 	})
-
-	// experimental self-hosted test suite run via `rktbot run etcd tests`
 
 	// conformance
-	register.Register(&register.Test{
-		Name:      "conformance.bootkube",
-		Run:       conformanceBootkube,
-		Platforms: []string{"gce"},
+	harness.Register(pluton.Test{
+		Name: "conformance.bootkube",
+		Run:  conformanceBootkube,
+		Options: pluton.Options{
+			SelfHostEtcd:   false,
+			InitialWorkers: 4,
+		},
 	})
-	register.Register(&register.Test{
-		Name:      "conformance.selfetcd.bootkube",
-		Run:       conformanceSelfEtcdBootkube,
-		Platforms: []string{"gce"},
+	harness.Register(pluton.Test{
+		Name: "conformance.selfetcd.bootkube",
+		Run:  conformanceBootkube,
+		Options: pluton.Options{
+			SelfHostEtcd:   true,
+			InitialWorkers: 4,
+		},
 	})
 
 }

--- a/pluton/tests/bootkube/registry.go
+++ b/pluton/tests/bootkube/registry.go
@@ -15,13 +15,9 @@
 package bootkube
 
 import (
-	"github.com/coreos/pkg/capnslog"
-
 	"github.com/coreos/mantle/pluton"
 	"github.com/coreos/mantle/pluton/harness"
 )
-
-var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "pluton/tests/bootkube")
 
 func init() {
 	// main test suite run on every PR

--- a/pluton/tests/bootkube/smoketest.go
+++ b/pluton/tests/bootkube/smoketest.go
@@ -67,7 +67,7 @@ func nginxCheck(c *pluton.Cluster) error {
 	deletePod := func() error {
 		_, err = c.Kubectl("delete deployment my-nginx")
 		if err != nil {
-			plog.Infof("unexpected kubectl failure deleting deployment: %v", err)
+			c.Logf("unexpected kubectl failure deleting deployment: %v", err)
 			return fmt.Errorf("delete deployment: %v", err)
 		}
 		return nil

--- a/pluton/tests/bootkube/smoketest.go
+++ b/pluton/tests/bootkube/smoketest.go
@@ -19,39 +19,16 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/pluton"
-	"github.com/coreos/mantle/pluton/spawn"
 	"github.com/coreos/mantle/util"
 )
 
-func bootkubeSmoke(c cluster.TestCluster) error {
-	// This should not return until cluster is ready
-	bc, err := spawn.MakeBootkubeCluster(c, 1, false)
-	if err != nil {
-		return err
-	}
-
+func smoke(c *pluton.Cluster) {
 	// run an nginx deployment and ping it
-	if err := nginxCheck(bc); err != nil {
-		return fmt.Errorf("nginxCheck: %s", err)
+	if err := nginxCheck(c); err != nil {
+		c.Fatalf("nginxCheck: %s", err)
 	}
 	// TODO add more basic or regression tests here
-	return nil
-}
-
-func bootkubeSmokeEtcd(c cluster.TestCluster) error {
-	// This should not return until cluster is ready
-	bc, err := spawn.MakeBootkubeCluster(c, 1, true)
-	if err != nil {
-		return err
-	}
-
-	// run an nginx deployment and ping it
-	if err := nginxCheck(bc); err != nil {
-		return fmt.Errorf("nginxCheck: %s", err)
-	}
-	return nil
 }
 
 func nginxCheck(c *pluton.Cluster) error {


### PR DESCRIPTION
Ready for review! New harness simplifies things so much for pluton considering that I no longer import anything from `kola/`.

Since we generally only run on GCE for bootkube testing I'm punting on support for other cloud platforms for now. It should take very little modification to pipe through something like all the AWS options and have things work, but, I'm mainly unsure of how I want to deal with the notion of a platform from a `pluton.Test` perspective.
