### PR TITLE
Make gangue downloads cleaner

### DIFF
--- a/cmd/gangue/gangue.go
+++ b/cmd/gangue/gangue.go
@@ -41,8 +41,8 @@ var (
 		Run:   run,
 	}
 
-	gpgKeyFile, jsonKeyFile string
-	serviceAuth, verify     bool
+	gpgKeyFile, jsonKeyFile      string
+	keepSig, serviceAuth, verify bool
 )
 
 func init() {
@@ -53,6 +53,7 @@ func init() {
 	sv(&jsonKeyFile, "json-key", "", "use a service account's JSON key for authentication")
 	bv(&verify, "verify", true, "use GPG verification")
 	sv(&gpgKeyFile, "verify-key", "", "PGP public key file to verify signatures, or blank for the default key built into the program")
+	bv(&keepSig, "keep-sig", false, "keep the detached signature file on disk when successful")
 	root.AddCommand(get)
 }
 
@@ -127,6 +128,9 @@ func run(cmd *cobra.Command, args []string) {
 	// Download the file and verify it (unless disabled)
 	if verify {
 		err = sdk.UpdateSignedFile(output, source, client, gpgKeyFile)
+		if err == nil && !keepSig {
+			err = os.Remove(output + ".sig")
+		}
 	} else {
 		err = sdk.UpdateFile(output, source, client)
 	}

--- a/sdk/download.go
+++ b/sdk/download.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -263,17 +262,11 @@ func UpdateFile(file, url string, client *http.Client) error {
 		return err
 	}
 
-	t, err := ioutil.TempFile(filepath.Dir(file), "sdkUpdateCheck")
-	if err != nil {
-		return err
-	}
-	t.Close()
-	tempFile := t.Name()
-	defer os.Remove(tempFile)
-
+	tempFile := file + ".part"
 	if err := DownloadFile(tempFile, url, client); err != nil {
 		return fmt.Errorf("%s: %s", url, err)
 	}
+	defer os.Remove(tempFile)
 
 	equal, err := cmpFileBytes(file, tempFile)
 	if os.IsExist(err) { // file may not exist, that is ok


### PR DESCRIPTION
After building with signed bootstrap packages, some new issues arose because the toolchain packages are downloaded into the same directory as built packages.

- The `sdk.UpdateSignedFile` function leaves detached signatures in place, which may be desired in most cases, but since the scripts upload packages by the directory, they would sign the leftover signatures while uploading them.

- The `sdk.UpdateFile` function doesn't respect `umask` since it creates the file with `ioutil.TempFile`, which uses mode `0600`.  This can cause read failures when `emerge` downloads the binary packages as root, then other parts of the SDK scripts try to read them as an unprivileged user.  The change here just uses `ioutil.TempFile` to generate the file name and lets the download function write the file, but this will affect all commands using `sdk.UpdateFile`, so I'm not sure about it.