### PR TITLE
Add an option to cork to verify the manifest tag

### DIFF
--- a/cmd/cork/create.go
+++ b/cmd/cork/create.go
@@ -241,6 +241,12 @@ func updateRepo() {
 		plog.Fatalf("repo init failed: %v", err)
 	}
 
+	if sigVerify {
+		if err := sdk.RepoVerifyTag(manifestBranch); err != nil {
+			plog.Fatalf("repo tag verification failed: %v", err)
+		}
+	}
+
 	if err := sdk.RepoSync(chrootName); err != nil {
 		plog.Fatalf("repo sync failed: %v", err)
 	}

--- a/cmd/cork/create.go
+++ b/cmd/cork/create.go
@@ -42,6 +42,7 @@ var (
 	manifestName   string
 	manifestBranch string
 	repoVerify     bool
+	sigVerify      bool
 
 	// only for `create` command
 	allowReplace bool
@@ -109,6 +110,8 @@ func init() {
 		"verify", false, "Check repo tree and release manifest match")
 	creationFlags.StringVar(&verifyKeyFile,
 		"verify-key", "", "PGP public key to be used in verifing download signatures.  Defaults to CoreOS Buildbot (0412 7D0B FABE C887 1FFB  2CCE 50E0 8855 93D2 DCB4)")
+	creationFlags.BoolVar(&sigVerify,
+		"verify-signature", false, "Verify the manifest Git tag with GPG")
 
 	root.AddCommand(setupCmd)
 
@@ -192,10 +195,15 @@ func runCreate(cmd *cobra.Command, args []string) {
 	if sdkVersion == "" {
 		plog.Noticef("Detecting SDK version")
 
+		getRemoteVersions := sdk.VersionsFromRemoteRepo
+		if sigVerify {
+			getRemoteVersions = sdk.VersionsFromSignedRemoteRepo
+		}
+
 		if ver, err := sdk.VersionsFromManifest(); err == nil {
 			sdkVersion = ver.SDKVersion
 			plog.Noticef("Found SDK version %s from local repo", sdkVersion)
-		} else if ver, err := sdk.VersionsFromRemoteRepo(manifestURL, manifestBranch); err == nil {
+		} else if ver, err := getRemoteVersions(manifestURL, manifestBranch); err == nil {
 			sdkVersion = ver.SDKVersion
 			plog.Noticef("Found SDK version %s from remote repo", sdkVersion)
 		} else {
@@ -288,7 +296,11 @@ func runUpdate(cmd *cobra.Command, args []string) {
 
 	if sdkVersion == "" || newVersion == "" {
 		plog.Notice("Detecting versions in remote repo")
-		ver, err := sdk.VersionsFromRemoteRepo(manifestURL, manifestBranch)
+		getRemoteVersions := sdk.VersionsFromRemoteRepo
+		if sigVerify {
+			getRemoteVersions = sdk.VersionsFromSignedRemoteRepo
+		}
+		ver, err := getRemoteVersions(manifestURL, manifestBranch)
 		if err != nil {
 			plog.Fatalf("Reading from remote repo failed: %v", err)
 		}

--- a/sdk/repo.go
+++ b/sdk/repo.go
@@ -20,6 +20,9 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/coreos/mantle/system/exec"
 )
 
 const (
@@ -131,6 +134,17 @@ func RepoInit(chroot, url, branch, name string) error {
 		"--manifest-url", url,
 		"--manifest-branch", branch,
 		"--manifest-name", name)
+}
+
+func RepoVerifyTag(branch string) error {
+	manifestRepoDir := ".repo/manifests"
+	if strings.HasPrefix(branch, "refs/tags/") {
+		branch = strings.TrimPrefix(branch, "refs/tags/")
+	}
+
+	tag := exec.Command("git", "-C", manifestRepoDir, "tag", "-v", branch)
+	tag.Stderr = os.Stderr
+	return tag.Run()
 }
 
 func RepoSync(chroot string) error {


### PR DESCRIPTION
This should verify the manifest tag signature before anything attempts to use the repo's contents.

After a quick look over the source, `repo` doesn't appear to run anything out of the repository in its `init` subcommand, so it should be safe to run `repo init`, `git tag -v`, then `repo sync` since the `repo init` is analogous to `git clone`.

The manifest repo was cloned in another place to read its version numbers, so this PR verifies it there as well before returning the versions.