### PR TITLE
kola/tests/locksmith: ignore a stray racy reboot error

### DIFF
--- a/kola/tests/locksmith/locksmith.go
+++ b/kola/tests/locksmith/locksmith.go
@@ -17,6 +17,7 @@ package locksmith
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -138,6 +139,8 @@ func locksmithCluster(c cluster.TestCluster) error {
 			output, err := m.SSH(cmd)
 			if _, ok := err.(*ssh.ExitMissingError); ok {
 				err = nil // A terminated session is perfectly normal during reboot.
+			} else if err == io.EOF {
+				err = nil // Sometimes copying command output returns EOF here.
 			}
 			if err != nil {
 				return fmt.Errorf("failed to run %q: output: %q status: %q", cmd, output, err)


### PR DESCRIPTION
There is still a race condition in the locksmith reboot test that is not as common as the last one, but suddenly got more annoying since I made kola failures fail the whole OS build again.  It appears to be an EOF from the Go SSH library's `Wait` function copying output, but since it fails rarely and randomly, this is just a shot in the dark.