### PR TITLE
kola/tests/fleet: show the unit status in the error

### DIFF
--- a/kola/tests/fleet/fleet.go
+++ b/kola/tests/fleet/fleet.go
@@ -161,7 +161,7 @@ func Proxy(c cluster.TestCluster) error {
 	}
 
 	if !bytes.Equal(status, []byte("active")) {
-		return fmt.Errorf("unit not active")
+		return fmt.Errorf("unit not active: %v", status)
 	}
 
 	return nil


### PR DESCRIPTION
There was another race failure that caused one of the recent OS builds to fail.  The journal from this test ends abruptly after `fleetd` says it completed the `StartUnit` task, regardless of if the test fails or not.  There isn't anything in the journal from the `hello.service` unit or any transient unit.

So, rather than just wrap this in a `Retry` function, I'd like to at least try to see if the unit actually failed, or if it is still in some preparatory state (since the fleet `active` value is directly taken from the systemd state).  The `fleetctl start` source looks like it should be blocking until non-`Global` services get an `active` systemd state, but this should hopefully verify that if the failure happens again.