### PR TITLE
kolet: fix everything

### DIFF
--- a/cmd/kolet/kolet.go
+++ b/cmd/kolet/kolet.go
@@ -24,22 +24,29 @@ import (
 	"github.com/coreos/mantle/kola/register"
 
 	// Register any tests that we may wish to execute in kolet.
-	_ "github.com/coreos/mantle/kola"
+	_ "github.com/coreos/mantle/kola/registry"
 )
 
 var (
 	plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "kolet")
 
 	root = &cobra.Command{
-		Use:   "kolet",
+		Use:   "kolet run [test] [func]",
 		Short: "Native code runner for kola",
+		Run:   run,
 	}
 
 	cmdRun = &cobra.Command{
-		Use:   "run",
+		Use:   "run [test] [func]",
 		Short: "Run a given test's native function",
+		Run:   run,
 	}
 )
+
+func run(cmd *cobra.Command, args []string) {
+	cmd.Usage()
+	os.Exit(2)
+}
 
 func main() {
 	for testName, testObj := range register.Tests {
@@ -47,7 +54,8 @@ func main() {
 			continue
 		}
 		testCmd := &cobra.Command{
-			Use: testName,
+			Use: testName + " [func]",
+			Run: run,
 		}
 		for nativeName := range testObj.NativeFuncs {
 			nativeFunc := testObj.NativeFuncs[nativeName]
@@ -73,9 +81,4 @@ func main() {
 	root.AddCommand(cmdRun)
 
 	cli.Execute(root)
-
-	// nativeRun always exits so if we are here it we probably just
-	// dumped usage/help info and stopped. Must exit with non-zero
-	// to prevent bugs from creating false-positives in kola.
-	os.Exit(2)
 }

--- a/kola/cluster/cluster.go
+++ b/kola/cluster/cluster.go
@@ -15,6 +15,7 @@
 package cluster
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -49,8 +50,12 @@ func (t *TestCluster) RunNative(funcName string, m platform.Machine) error {
 	defer session.Close()
 
 	b, err := session.CombinedOutput(fmt.Sprintf("./kolet run %q %q", t.Name(), funcName))
+	b = bytes.TrimSpace(b)
+	if len(b) > 0 {
+		t.Logf("kolet:\n%s", b)
+	}
 	if err != nil {
-		return fmt.Errorf("%s", b) // return function std output, not the exit status
+		return fmt.Errorf("kolet: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
When kolet was converted to use cobra subcommands in c56732e4 the final
`os.Exit(2)` fallback never served its purpose because `cli.Execute()`
always exits the program. This was made worse by the fact that cobra
does not consider running a command without a `Run` method to be an
error, simply printing the `Short` description and returning. When test
registration was working this wasn't noticed because cobra would raise
an error if you did not provide a valid subcommand. In commit 3a073663
test registration in kolet broke because the import line was not
updated. So for the past few months all kolet based tests merely checked
that kolet could execute and print the `Short` description from the run
command. This was further made impossible to notice because the output
of kolet is never reported unless it exits with a non-zero value. We
probably could have noticed the kolet breakage in one case but fe34b448
worked around the issue by removing the kolet usage instead of finding
the root cause.

On the up side, we never really lost much test coverage because all of
the remaining kolet tests came from coretest which we still use in the
old AMI test script that we are still working on replacing.