### PR TITLE
Migrate some logging from capnslog to harness.

### DIFF
--- a/kola/cluster/cluster.go
+++ b/kola/cluster/cluster.go
@@ -32,6 +32,13 @@ type TestCluster struct {
 	NativeFuncs []string
 }
 
+// Run runs f as a subtest and reports whether f succeeded.
+func (t *TestCluster) Run(name string, f func(c TestCluster)) bool {
+	return t.H.Run(name, func(h *harness.H) {
+		f(TestCluster{H: h, Cluster: t.Cluster})
+	})
+}
+
 // RunNative runs a registered NativeFunc on a remote machine
 func (t *TestCluster) RunNative(funcName string, m platform.Machine) error {
 	// scp and execute kolet on remote machine

--- a/kola/cluster/cluster.go
+++ b/kola/cluster/cluster.go
@@ -40,31 +40,30 @@ func (t *TestCluster) Run(name string, f func(c TestCluster)) bool {
 }
 
 // RunNative runs a registered NativeFunc on a remote machine
-func (t *TestCluster) RunNative(funcName string, m platform.Machine) error {
-	// scp and execute kolet on remote machine
-	client, err := m.SSHClient()
-	if err != nil {
-		return fmt.Errorf("kolet SSH client: %v", err)
-	}
+func (t *TestCluster) RunNative(funcName string, m platform.Machine) bool {
+	command := fmt.Sprintf("./kolet run %q %q", t.Name(), funcName)
+	return t.Run(funcName, func(c TestCluster) {
+		client, err := m.SSHClient()
+		if err != nil {
+			c.Fatalf("kolet SSH client: %v", err)
+		}
+		defer client.Close()
 
-	defer client.Close()
+		session, err := client.NewSession()
+		if err != nil {
+			c.Fatalf("kolet SSH session: %v", err)
+		}
+		defer session.Close()
 
-	session, err := client.NewSession()
-	if err != nil {
-		return fmt.Errorf("kolet SSH session: %v", err)
-	}
-
-	defer session.Close()
-
-	b, err := session.CombinedOutput(fmt.Sprintf("./kolet run %q %q", t.Name(), funcName))
-	b = bytes.TrimSpace(b)
-	if len(b) > 0 {
-		t.Logf("kolet:\n%s", b)
-	}
-	if err != nil {
-		return fmt.Errorf("kolet: %v", err)
-	}
-	return nil
+		b, err := session.CombinedOutput(command)
+		b = bytes.TrimSpace(b)
+		if len(b) > 0 {
+			t.Logf("kolet:\n%s", b)
+		}
+		if err != nil {
+			c.Errorf("kolet: %v", err)
+		}
+	})
 }
 
 // ListNativeFunctions returns a slice of function names that can be executed

--- a/kola/tests/coretest/testgroupglue.go
+++ b/kola/tests/coretest/testgroupglue.go
@@ -1,23 +1,15 @@
 package coretest
 
 import (
-	"github.com/coreos/pkg/capnslog"
-
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/tests/etcd"
 )
-
-var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "kola/tests/coretest")
 
 // run various native functions that only require a single machine
 func LocalTests(c cluster.TestCluster) error {
 	tests := c.ListNativeFunctions()
 	for _, name := range tests {
-		plog.Noticef("running %v...", name)
-		err := c.RunNative(name, c.Machines()[0])
-		if err != nil {
-			return err
-		}
+		c.RunNative(name, c.Machines()[0])
 	}
 	return nil
 }
@@ -31,11 +23,7 @@ func ClusterTests(c cluster.TestCluster) error {
 
 	tests := c.ListNativeFunctions()
 	for _, name := range tests {
-		plog.Noticef("running %v...", name)
-		err := c.RunNative(name, c.Machines()[0])
-		if err != nil {
-			return err
-		}
+		c.RunNative(name, c.Machines()[0])
 	}
 	return nil
 
@@ -45,11 +33,7 @@ func ClusterTests(c cluster.TestCluster) error {
 func InternetTests(c cluster.TestCluster) error {
 	tests := c.ListNativeFunctions()
 	for _, name := range tests {
-		plog.Noticef("running %v...", name)
-		err := c.RunNative(name, c.Machines()[0])
-		if err != nil {
-			return err
-		}
+		c.RunNative(name, c.Machines()[0])
 	}
 	return nil
 }

--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/coreos/go-semver/semver"
-	"github.com/coreos/pkg/capnslog"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/net/context"
 
@@ -32,10 +31,6 @@ import (
 	"github.com/coreos/mantle/lang/worker"
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/machine/qemu"
-)
-
-var (
-	plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "kola/tests/docker")
 )
 
 func init() {
@@ -133,7 +128,7 @@ func genDockerContainer(m platform.Machine, name string, binnames []string) erro
 func dockerResources(c cluster.TestCluster) error {
 	m := c.Machines()[0]
 
-	plog.Debug("creating sleep container")
+	c.Log("creating sleep container")
 
 	if err := genDockerContainer(m, "sleep", []string{"sleep"}); err != nil {
 		return err
@@ -171,7 +166,7 @@ func dockerResources(c cluster.TestCluster) error {
 		dCmd("--memory-swappiness=50"),
 		dCmd("--shm-size=1m"),
 	} {
-		plog.Debugf("Executing %q", dockerCmd)
+		c.Logf("Executing %q", dockerCmd)
 
 		// lol closures
 		cmd := dockerCmd
@@ -198,7 +193,7 @@ func dockerNetwork(c cluster.TestCluster) error {
 	machines := c.Machines()
 	src, dest := machines[0], machines[1]
 
-	plog.Debug("creating ncat containers")
+	c.Log("creating ncat containers")
 
 	if err := genDockerContainer(src, "ncat", []string{"ncat"}); err != nil {
 		return err
@@ -237,7 +232,6 @@ func dockerNetwork(c cluster.TestCluster) error {
 				return err
 			}
 
-			plog.Debug("waiting for server to be ready")
 			select {
 			case <-c.Done():
 				return fmt.Errorf("timeout waiting for server")

--- a/kola/tests/flannel/flannel.go
+++ b/kola/tests/flannel/flannel.go
@@ -23,8 +23,6 @@ import (
 	"net"
 	"strings"
 
-	"github.com/coreos/pkg/capnslog"
-
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/kola/tests/etcd"
@@ -32,7 +30,6 @@ import (
 )
 
 var (
-	plog        = capnslog.NewPackageLogger("github.com/coreos/mantle", "kola/tests/flannel")
 	flannelConf = `{
   "ignition": { "version": "2.0.0" },
   "systemd": {
@@ -111,7 +108,7 @@ func mach2bip(m platform.Machine, ifname string) (string, error) {
 }
 
 // ping sends icmp packets from machine a to b using the ping tool.
-func ping(a, b platform.Machine, ifname string) error {
+func ping(c cluster.TestCluster, a, b platform.Machine, ifname string) error {
 	srcip, err := mach2bip(a, ifname)
 	if err != nil {
 		return fmt.Errorf("failed to get docker bridge ip #1: %v", err)
@@ -128,7 +125,7 @@ func ping(a, b platform.Machine, ifname string) error {
 		return fmt.Errorf("bridge ips (%s %s) not in flannel network (%s)", srcip, dstip, ipnet)
 	}
 
-	plog.Infof("ping from %s(%s) to %s(%s)", a.ID(), srcip, b.ID(), dstip)
+	c.Logf("ping from %s(%s) to %s(%s)", a.ID(), srcip, b.ID(), dstip)
 
 	cmd := fmt.Sprintf("ping -c 10 -I %s %s", srcip, dstip)
 	out, err := a.SSH(cmd)
@@ -148,7 +145,7 @@ func udp(c cluster.TestCluster) error {
 		return fmt.Errorf("cluster health: %v", err)
 	}
 
-	return ping(machs[0], machs[2], "flannel0")
+	return ping(c, machs[0], machs[2], "flannel0")
 }
 
 // VXLAN tests that flannel can send packets using the vxlan backend.
@@ -160,5 +157,5 @@ func vxlan(c cluster.TestCluster) error {
 		return fmt.Errorf("cluster health: %v", err)
 	}
 
-	return ping(machs[0], machs[2], "flannel.1")
+	return ping(c, machs[0], machs[2], "flannel.1")
 }

--- a/kola/tests/misc/nfs.go
+++ b/kola/tests/misc/nfs.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/coreos/coreos-cloudinit/config"
-	"github.com/coreos/pkg/capnslog"
 
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
@@ -28,8 +27,6 @@ import (
 )
 
 var (
-	plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "kola/tests/misc")
-
 	nfsserverconf = config.CloudConfig{
 		CoreOS: config.CoreOS{
 			Units: []config.Unit{
@@ -96,7 +93,7 @@ func testNFS(c cluster.TestCluster, nfsversion int) error {
 
 	defer m1.Destroy()
 
-	plog.Info("NFS server booted.")
+	c.Log("NFS server booted.")
 
 	/* poke a file in /tmp */
 	tmp, err := m1.SSH("mktemp")
@@ -104,7 +101,7 @@ func testNFS(c cluster.TestCluster, nfsversion int) error {
 		return fmt.Errorf("Machine.SSH: %s", err)
 	}
 
-	plog.Infof("Test file %q created on server.", tmp)
+	c.Logf("Test file %q created on server.", tmp)
 
 	c2 := config.CloudConfig{
 		CoreOS: config.CoreOS{
@@ -126,9 +123,7 @@ func testNFS(c cluster.TestCluster, nfsversion int) error {
 
 	defer m2.Destroy()
 
-	plog.Info("NFS client booted.")
-
-	plog.Info("Waiting for NFS mount on client...")
+	c.Log("NFS client booted.")
 
 	checkmount := func() error {
 		status, err := m2.SSH("systemctl is-active mnt.mount")
@@ -136,7 +131,7 @@ func testNFS(c cluster.TestCluster, nfsversion int) error {
 			return fmt.Errorf("mnt.mount status is %q: %v", status, err)
 		}
 
-		plog.Info("Got NFS mount.")
+		c.Log("Got NFS mount.")
 		return nil
 	}
 


### PR DESCRIPTION
Ensures test logs are included in the orderly test output.