### PR TITLE
platform/aws: fix pre-flight check

### DIFF
--- a/platform/api/aws/api.go
+++ b/platform/api/aws/api.go
@@ -20,8 +20,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/coreos/pkg/capnslog"
 
 	"github.com/coreos/mantle/platform"
@@ -84,8 +84,8 @@ func New(opts *Options) (*API, error) {
 // PreflightCheck validates that the aws configuration provided has valid
 // credentials
 func (a *API) PreflightCheck() error {
-	iamClient := iam.New(a.session)
-	_, err := iamClient.GetUser(&iam.GetUserInput{})
+	stsClient := sts.New(a.session)
+	_, err := stsClient.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 
 	return err
 }


### PR DESCRIPTION
The original preflight check was meant to be the 'get my identity' call
that didn't require permissions. It turns out I was thinking about this
sts call, not the somewhat-similar iam call.