### PR TITLE
Use identical user data for all machines spawned together

### DIFF
--- a/cmd/kola/spawn.go
+++ b/cmd/kola/spawn.go
@@ -36,12 +36,11 @@ var (
 		Short:  "spawn a CoreOS instance",
 	}
 
-	spawnNodeCount      int
-	spawnProcessConfigs bool
-	spawnUserData       string
-	spawnShell          bool
-	spawnRemove         bool
-	spawnVerbose        bool
+	spawnNodeCount int
+	spawnUserData  string
+	spawnShell     bool
+	spawnRemove    bool
+	spawnVerbose   bool
 )
 
 func init() {
@@ -50,7 +49,6 @@ func init() {
 	cmdSpawn.Flags().BoolVarP(&spawnShell, "shell", "s", false, "spawn a shell in an instance before exiting")
 	cmdSpawn.Flags().BoolVarP(&spawnRemove, "remove", "r", true, "remove instances after shell exits")
 	cmdSpawn.Flags().BoolVarP(&spawnVerbose, "verbose", "v", false, "output information about spawned instances")
-	cmdSpawn.Flags().BoolVarP(&spawnProcessConfigs, "process-configs", "p", false, "process user-data as in standard test harnesses")
 	root.AddCommand(cmdSpawn)
 }
 
@@ -61,10 +59,6 @@ func runSpawn(cmd *cobra.Command, args []string) {
 
 	if spawnNodeCount <= 0 {
 		die("Cluster Failed: nodecount must be one or more")
-	}
-
-	if spawnProcessConfigs && spawnUserData == "" {
-		die("no userdata provided to process: -p is only meaningful with -u")
 	}
 
 	if spawnUserData != "" {
@@ -99,22 +93,9 @@ func runSpawn(cmd *cobra.Command, args []string) {
 		die("Cluster failed: %v", err)
 	}
 
-	var cfgs []string
-	if spawnProcessConfigs {
-		url, err := cluster.GetDiscoveryURL(spawnNodeCount)
-		if err != nil {
-			die("Failed to create discovery endpoint: %v", err)
-		}
-		cfgs = kola.MakeConfigs(url, userdata, spawnNodeCount)
-	} else {
-		for i := 0; i < spawnNodeCount; i++ {
-			cfgs = append(cfgs, userdata)
-		}
-	}
-
 	var someMach platform.Machine
 	for i := 0; i < spawnNodeCount; i++ {
-		mach, err := cluster.NewMachine(cfgs[i])
+		mach, err := cluster.NewMachine(userdata)
 		if err != nil {
 			die("Spawning instance failed: %v", err)
 		}

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -19,7 +19,6 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -270,16 +269,14 @@ func runTest(h *harness.H, t *register.Test, pltfrm string) {
 		}
 	}()
 
-	url, err := c.GetDiscoveryURL(t.ClusterSize)
-	if err != nil {
-		h.Fatalf("Failed to create discovery endpoint: %v", err)
-	}
-
-	cfgs := MakeConfigs(url, t.UserData, t.ClusterSize)
-
 	if t.ClusterSize > 0 {
-		_, err := platform.NewMachines(c, cfgs)
+		url, err := c.GetDiscoveryURL(t.ClusterSize)
 		if err != nil {
+			h.Fatalf("Failed to create discovery endpoint: %v", err)
+		}
+
+		cfg := strings.Replace(t.UserData, "$discovery", url, -1)
+		if _, err := platform.NewMachines(c, cfg, t.ClusterSize); err != nil {
 			h.Fatalf("Cluster failed starting machines: %v", err)
 		}
 	}
@@ -336,18 +333,6 @@ func scpKolet(c cluster.TestCluster, mArch string) {
 		}
 	}
 	c.Fatalf("Unable to locate kolet binary for %s", mArch)
-}
-
-// replaces $discovery with discover url in etcd cloud config and
-// replaces $name with a unique name
-func MakeConfigs(url, cfg string, csize int) []string {
-	cfg = strings.Replace(cfg, "$discovery", url, -1)
-
-	var cfgs []string
-	for i := 0; i < csize; i++ {
-		cfgs = append(cfgs, strings.Replace(cfg, "$name", "instance"+strconv.Itoa(i), -1))
-	}
-	return cfgs
 }
 
 // CleanOutputDir creates an empty directory, any existing data will be wiped!

--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -38,7 +38,7 @@ func init() {
         "enable": true,
         "dropins": [{
           "name": "metadata.conf",
-          "contents": "[Unit]\nWants=coreos-metadata.service\nAfter=coreos-metadata.service\n\n[Service]\nEnvironmentFile=-/run/metadata/coreos\nExecStart=\nExecStart=/usr/bin/etcd2 --name=$name --discovery=$discovery --advertise-client-urls=http://$private_ipv4:2379 --initial-advertise-peer-urls=http://$private_ipv4:2380 --listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001 --listen-peer-urls=http://$private_ipv4:2380,http://$private_ipv4:7001"
+          "contents": "[Unit]\nWants=coreos-metadata.service\nAfter=coreos-metadata.service\n\n[Service]\nEnvironmentFile=-/run/metadata/coreos\nExecStart=\nExecStart=/usr/bin/etcd2 --discovery=$discovery --advertise-client-urls=http://$private_ipv4:2379 --initial-advertise-peer-urls=http://$private_ipv4:2380 --listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001 --listen-peer-urls=http://$private_ipv4:2380,http://$private_ipv4:7001"
         }]
       },
       {

--- a/kola/tests/flannel/flannel.go
+++ b/kola/tests/flannel/flannel.go
@@ -39,7 +39,7 @@ var (
         "enable": true,
         "dropins": [{
           "name": "metadata.conf",
-          "contents": "[Unit]\nWants=coreos-metadata.service\nAfter=coreos-metadata.service\n\n[Service]\nEnvironmentFile=-/run/metadata/coreos\nExecStart=\nExecStart=/usr/bin/etcd2 --name=$name --discovery=$discovery --advertise-client-urls=http://$private_ipv4:2379 --initial-advertise-peer-urls=http://$private_ipv4:2380 --listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001 --listen-peer-urls=http://$private_ipv4:2380,http://$private_ipv4:7001"
+          "contents": "[Unit]\nWants=coreos-metadata.service\nAfter=coreos-metadata.service\n\n[Service]\nEnvironmentFile=-/run/metadata/coreos\nExecStart=\nExecStart=/usr/bin/etcd2 --discovery=$discovery --advertise-client-urls=http://$private_ipv4:2379 --initial-advertise-peer-urls=http://$private_ipv4:2380 --listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001 --listen-peer-urls=http://$private_ipv4:2380,http://$private_ipv4:7001"
         }]
       },
       {

--- a/kola/tests/kubernetes/setup.go
+++ b/kola/tests/kubernetes/setup.go
@@ -70,11 +70,7 @@ func setupCluster(c cluster.TestCluster, nodes int, version, runtime string) (*k
 	}
 
 	// create worker nodes
-	workerConfigs := make([]string, nodes)
-	for i := range workerConfigs {
-		workerConfigs[i] = "#cloud-config" // want default rather then blank
-	}
-	workers, err := platform.NewMachines(c, workerConfigs)
+	workers, err := platform.NewMachines(c, "#cloud-config", nodes)
 	if err != nil {
 		return nil, err
 	}

--- a/kola/tests/locksmith/locksmith.go
+++ b/kola/tests/locksmith/locksmith.go
@@ -45,7 +45,7 @@ func init() {
         "enable": true,
         "dropins": [{
           "name": "metadata.conf",
-          "contents": "[Unit]\nWants=coreos-metadata.service\nAfter=coreos-metadata.service\n\n[Service]\nEnvironmentFile=-/run/metadata/coreos\nExecStart=\nExecStart=/usr/bin/etcd2 --name=$name --discovery=$discovery --advertise-client-urls=http://$private_ipv4:2379 --initial-advertise-peer-urls=http://$private_ipv4:2380 --listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001 --listen-peer-urls=http://$private_ipv4:2380,http://$private_ipv4:7001"
+          "contents": "[Unit]\nWants=coreos-metadata.service\nAfter=coreos-metadata.service\n\n[Service]\nEnvironmentFile=-/run/metadata/coreos\nExecStart=\nExecStart=/usr/bin/etcd2 --discovery=$discovery --advertise-client-urls=http://$private_ipv4:2379 --initial-advertise-peer-urls=http://$private_ipv4:2380 --listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001 --listen-peer-urls=http://$private_ipv4:2380,http://$private_ipv4:7001"
         }]
       },
       {

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -183,26 +183,19 @@ func InstallFile(in io.Reader, m Machine, to string) error {
 	return nil
 }
 
-// NewMachines spawns len(userdatas) instances in cluster c, with
-// each instance passed the respective userdata.
-func NewMachines(c Cluster, userdatas []string) ([]Machine, error) {
+// NewMachines spawns n instances in cluster c, with
+// each instance passed the same userdata.
+func NewMachines(c Cluster, userdata string, n int) ([]Machine, error) {
 	var wg sync.WaitGroup
-
-	n := len(userdatas)
-
-	if n <= 0 {
-		return nil, fmt.Errorf("must provide one or more userdatas")
-	}
 
 	mchan := make(chan Machine, n)
 	errchan := make(chan error, n)
 
 	for i := 0; i < n; i++ {
-		ud := userdatas[i]
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			m, err := c.NewMachine(ud)
+			m, err := c.NewMachine(userdata)
 			if err != nil {
 				errchan <- err
 			}

--- a/pluton/spawn/bootkube.go
+++ b/pluton/spawn/bootkube.go
@@ -290,15 +290,6 @@ func (m *BootkubeManager) provisionNodes(masters, workers int) ([]platform.Machi
 		return nil, nil, err
 	}
 
-	configsM := make([]string, masters)
-	for i := range configsM {
-		configsM[i] = configM
-	}
-	configsW := make([]string, workers)
-	for i := range configsW {
-		configsW[i] = configW
-	}
-
 	// NewMachines already does parallelization but doesn't guarentee the
 	// order of the nodes returned which matters when we have heterogenious
 	// cloudconfigs here
@@ -309,16 +300,16 @@ func (m *BootkubeManager) provisionNodes(masters, workers int) ([]platform.Machi
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		if len(configsM) != 0 {
-			masterNodes, merror = platform.NewMachines(m, configsM)
+		if masters > 0 {
+			masterNodes, merror = platform.NewMachines(m, configM, masters)
 		} else {
 			masterNodes = []platform.Machine{}
 		}
 	}()
 	go func() {
 		defer wg.Done()
-		if len(configsW) != 0 {
-			workerNodes, werror = platform.NewMachines(m, configsW)
+		if workers > 0 {
+			workerNodes, werror = platform.NewMachines(m, configW, workers)
 		} else {
 			workerNodes = []platform.Machine{}
 		}


### PR DESCRIPTION
Remove an underutilized feature of `NewMachines` that allowed each machine to use a different config. Except for a few tests using the optional etcd `--name` argument this just resulted in boilerplate cruft to assemble lists of identical strings.