### PR TITLE
cmd/plume: Use separate board list for each channel

### DIFF
--- a/cmd/plume/index.go
+++ b/cmd/plume/index.go
@@ -74,10 +74,16 @@ func runIndex(cmd *cobra.Command, args []string) {
 
 	if specBoard != "" {
 		boardOk := false
-		for _, board := range boards {
-			if specBoard == board {
-				boardOk = true
-				break
+	channelLoop:
+		for channel, spec := range specs {
+			if specChannel != "" && specChannel != channel {
+				continue
+			}
+			for _, board := range spec.Boards {
+				if specBoard == board {
+					boardOk = true
+					break channelLoop
+				}
 			}
 		}
 		if !boardOk {
@@ -134,7 +140,7 @@ func runIndex(cmd *cobra.Command, args []string) {
 			}
 
 			doIndex(bkt.Prefix(), false)
-			for _, board := range boards {
+			for _, board := range spec.Boards {
 				if specBoard != "" && specBoard != board {
 					continue
 				}

--- a/cmd/plume/specs.go
+++ b/cmd/plume/specs.go
@@ -59,6 +59,7 @@ type azureSpec struct {
 
 type channelSpec struct {
 	BaseURL      string // Copy from $BaseURL/$Board/$Version
+	Boards       []string
 	Destinations []storageSpec
 	GCE          gceSpec
 	Azure        azureSpec
@@ -68,12 +69,12 @@ var (
 	specBoard   string
 	specChannel string
 	specVersion string
-	boards      = []string{"amd64-usr", "arm64-usr"}
 	gceBoards   = []string{"amd64-usr"}
 	azureBoards = []string{"amd64-usr"}
 	specs       = map[string]channelSpec{
 		"alpha": channelSpec{
 			BaseURL: "gs://builds.release.core-os.net/alpha/boards",
+			Boards:  []string{"amd64-usr", "arm64-usr"},
 			Destinations: []storageSpec{storageSpec{
 				BaseURL:     "gs://alpha.release.core-os.net",
 				NamedPath:   "current",
@@ -121,6 +122,7 @@ var (
 		},
 		"beta": channelSpec{
 			BaseURL: "gs://builds.release.core-os.net/beta/boards",
+			Boards:  []string{"amd64-usr", "arm64-usr"},
 			Destinations: []storageSpec{storageSpec{
 				BaseURL:     "gs://beta.release.core-os.net",
 				NamedPath:   "current",
@@ -166,6 +168,7 @@ var (
 		},
 		"stable": channelSpec{
 			BaseURL: "gs://builds.release.core-os.net/stable/boards",
+			Boards:  []string{"amd64-usr"},
 			Destinations: []storageSpec{storageSpec{
 				BaseURL:     "gs://stable.release.core-os.net",
 				NamedPath:   "current",
@@ -231,14 +234,14 @@ func ChannelSpec() channelSpec {
 	}
 
 	boardOk := false
-	for _, board := range boards {
+	for _, board := range spec.Boards {
 		if specBoard == board {
 			boardOk = true
 			break
 		}
 	}
 	if !boardOk {
-		plog.Fatalf("Unknown board: %s", specBoard)
+		plog.Fatalf("Unknown board %q for channel %q", specBoard, specChannel)
 	}
 
 	gceOk := false


### PR DESCRIPTION
Avoid accidentally releasing arm64-usr to stable.