### PR TITLE
kola: restore pause before cluster tear down

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -315,9 +315,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string) {
 	defer func() {
 		// give some time for the remote journal to be flushed so it can be read
 		// before we run the deferred machine destruction
-		if err != nil {
-			time.Sleep(2 * time.Second)
-		}
+		time.Sleep(2 * time.Second)
 	}()
 
 	// run test


### PR DESCRIPTION
Honestly I'm not sure how important this is and would be better
performed as some sort of flush mechanism in the journal recorder but
implementing flush would be a bit complicated so this stays for now.
It was broken by the conversion from returning errors to using
Error/Fatal methods rendering this `err` value always nil.