### PR TITLE
pluton: prefetch and cache containers

### DIFF
--- a/pluton/harness/run.go
+++ b/pluton/harness/run.go
@@ -59,7 +59,11 @@ func RunSuite(pattern string) {
 			os.Exit(1)
 		}
 
-		cloud, err = gcloud.NewCluster(&Opts.GCEOptions, bastionDir)
+		// override machine size for bastion
+		bastionOpts := Opts.GCEOptions
+		bastionOpts.MachineType = "n1-standard-4"
+
+		cloud, err = gcloud.NewCluster(&bastionOpts, bastionDir)
 		if err != nil {
 			fmt.Printf("setting up bastion cluster: %v\n", err)
 			os.Exit(1)
@@ -72,6 +76,7 @@ func RunSuite(pattern string) {
 			cloud.Destroy()
 			os.Exit(1)
 		}
+
 	default:
 		fmt.Printf("invalid cloud platform %v\n", Opts.CloudPlatform)
 		os.Exit(1)

--- a/pluton/spawn/containercache/sshcache.go
+++ b/pluton/spawn/containercache/sshcache.go
@@ -1,0 +1,211 @@
+package containercache
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/coreos/mantle/platform"
+	"github.com/coreos/mantle/util"
+)
+
+const (
+	cacheDir          = "/home/core/containercache"
+	downloadRetries   = 3
+	downloadRetryWait = 15 * time.Second
+)
+
+var once sync.Once
+
+type ImageName struct {
+	Name   string
+	Engine string // docker or rkt
+}
+
+// StartBastionOnce will populate a bastion machine with the given containers
+// for rkt and docker. Since its best to run this only once per test suite, the
+// bastion machine should be in a separate platform.Cluster then the one used
+// in the test so it can be available for all tests in a given run. This
+// function is guarded with a sync.Once, so only the first within a test suite
+// it will have it run.
+func StartBastionOnce(bastion platform.Machine, names []ImageName) error {
+	var err error
+
+	f := func() {
+		err = startBastion(bastion, names)
+	}
+	once.Do(f)
+
+	return err
+}
+
+// Load all containers cached by the bastion node into the docker and rkt store
+// of the given machines.
+func Load(bastion platform.Machine, machines []platform.Machine) error {
+	if len(machines) < 0 {
+		return nil
+	}
+
+	// error if bastion is not setup
+	if err := StartBastionOnce(nil, nil); err != nil {
+		return fmt.Errorf("Must call StartBastionOnce before Load")
+	}
+
+	if err := copyPublicKeys(bastion, machines); err != nil {
+		return fmt.Errorf("copying public keys: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	var errors []error
+
+	wg.Add(len(machines))
+
+	for _, m := range machines {
+		go func(m platform.Machine) {
+			defer wg.Done()
+
+			if err := transferContainers(bastion, m); err != nil {
+				errors = append(errors, err)
+			}
+		}(m)
+	}
+	wg.Wait()
+
+	if len(errors) != 0 {
+		return fmt.Errorf("%s", errors)
+	}
+
+	return nil
+}
+
+func startBastion(bastion platform.Machine, names []ImageName) error {
+	if bastion == nil {
+		return fmt.Errorf("error starting containercache: bastion is nil")
+	}
+
+	// generate key-pair
+	out, err := bastion.SSH(`ssh-keygen -t ed25519 -N "" -f ./.ssh/bastion.key`)
+	if err != nil {
+		return fmt.Errorf("%v: %s", err, out)
+	}
+
+	//fetch rkt and docker images and retry on failures
+	//TODO: log failures via harness logs along with stderr
+	for _, name := range names {
+		switch name.Engine {
+		case "rkt":
+			rktFetch := func() error {
+				out, err := bastion.SSH(fmt.Sprintf("sudo rkt fetch %s --trust-keys-from-https", name.Name))
+				if err != nil {
+					return fmt.Errorf("%v: %s", err, out)
+				}
+				return nil
+			}
+			if err := util.Retry(downloadRetries, downloadRetryWait, rktFetch); err != nil {
+				return fmt.Errorf("pulling rkt container %v: %v", name, err)
+			}
+		case "docker":
+			dockerFetch := func() error {
+				out, err := bastion.SSH(fmt.Sprintf("docker pull %s", name.Name))
+				if err != nil {
+					return fmt.Errorf("%v: %s", err, out)
+				}
+				return nil
+			}
+			if err := util.Retry(downloadRetries, downloadRetryWait, dockerFetch); err != nil {
+				return fmt.Errorf("pulling docker container %v: %v", name, err)
+			}
+		default:
+			return fmt.Errorf("invalid container name Engine must either be 'rkt' or 'docker' got %v", name.Engine)
+		}
+	}
+
+	// extract containers to known location for Load to pick up later
+	err = extract(bastion, names)
+	if err != nil {
+		return fmt.Errorf("error extracting containers: %v", err)
+	}
+
+	return nil
+}
+
+// Extract existing containers to fs
+func extract(bastion platform.Machine, names []ImageName) error {
+	out, err := bastion.SSH(fmt.Sprintf("mkdir %v", cacheDir))
+	if err != nil {
+		return fmt.Errorf("creating cache dir: %v -- %s", err, out)
+	}
+
+	for _, name := range names {
+		switch name.Engine {
+		case "rkt":
+			out, err = bastion.SSH(fmt.Sprintf("sudo rkt image export %v %v/%v.aci", name.Name, cacheDir, strings.Replace(name.Name, "/", ".", -1)))
+			if err != nil {
+				return fmt.Errorf("rkt image export: %v -- %s", err, out)
+			}
+		case "docker":
+			out, err = bastion.SSH(fmt.Sprintf("docker save %v -o %v/%v.tar", name.Name, cacheDir, strings.Replace(name.Name, "/", ".", -1)))
+			if err != nil {
+				return fmt.Errorf("docker save: %v -- %s", err, out)
+			}
+		default:
+			return fmt.Errorf("invalid container name Engine must either be 'rkt' or 'docker' got %v", name.Engine)
+		}
+	}
+
+	out, err = bastion.SSH("sudo chown -R core " + cacheDir)
+	if err != nil {
+		return fmt.Errorf("%v: %s", err, out)
+	}
+
+	return nil
+}
+
+func copyPublicKeys(bastion platform.Machine, machines []platform.Machine) error {
+	for _, m := range machines {
+		err := platform.TransferFile(bastion, "/home/core/.ssh/bastion.key.pub", m, "/home/core/bastion.key.pub")
+		if err != nil {
+			return err
+		}
+
+		out, err := m.SSH("update-ssh-keys -a bastion /home/core/bastion.key.pub")
+		if err != nil {
+			return fmt.Errorf("%v: %s", err, out)
+		}
+	}
+
+	return nil
+}
+
+func transferContainers(bastion, dst platform.Machine) error {
+	scpCmd := fmt.Sprintf("sudo scp -rqB -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /home/core/.ssh/bastion.key %v core@%v:%v", cacheDir, dst.PrivateIP(), cacheDir)
+	out, err := bastion.SSH(scpCmd)
+	if err != nil {
+		return fmt.Errorf("scp'ing container : %v -- %s", err, out)
+	}
+
+	// get file list to import
+	out, err = dst.SSH(fmt.Sprintf("ls -m %v", cacheDir))
+	if err != nil {
+		return fmt.Errorf("ls -m : %v -- %s", err, out)
+	}
+	var files []string
+	for _, s := range strings.Split(string(out), ",") {
+		files = append(files, filepath.Join(cacheDir, strings.TrimSpace(s)))
+	}
+
+	// fetch/import files
+	for _, f := range files {
+		if strings.HasSuffix(f, "aci") {
+			dst.SSH(fmt.Sprintf("sudo rkt fetch file://%v --insecure-options=image", f))
+		} else if strings.HasSuffix(f, "tar") {
+			dst.SSH(fmt.Sprintf("docker load -i %v", f))
+		} else {
+			return fmt.Errorf("can't import file: %v", f)
+		}
+	}
+	return nil
+
+}

--- a/pluton/tests/bootkube/registry.go
+++ b/pluton/tests/bootkube/registry.go
@@ -62,16 +62,6 @@ func init() {
 	})
 
 	harness.Register(pluton.Test{
-		Name: "bootkube.selfetcd.scale",
-		Run:  etcdScale,
-		Options: pluton.Options{
-			SelfHostEtcd:   true,
-			InitialMasters: 1,
-			InitialWorkers: 1,
-		},
-	})
-
-	harness.Register(pluton.Test{
 		Name: "bootkube.selfetcd.destruct.reboot",
 		Run:  rebootMaster,
 		Options: pluton.Options{
@@ -86,6 +76,17 @@ func init() {
 		Run:  deleteAPIServer,
 		Options: pluton.Options{
 			SelfHostEtcd:   false,
+			InitialMasters: 1,
+			InitialWorkers: 1,
+		},
+	})
+
+	// failing/experimental tests
+	harness.Register(pluton.Test{
+		Name: "experimental.selfetcd.scale",
+		Run:  etcdScale,
+		Options: pluton.Options{
+			SelfHostEtcd:   true,
 			InitialMasters: 1,
 			InitialWorkers: 1,
 		},


### PR DESCRIPTION
cc @aaronlevy @marineam 
This sets up a bastion node per test suite that prefetches a given list of containers and extracts them into archives on disk. Once this is done the tests run in parallel and before setting up bootkube, it pulls the container archives and extracts them into the store.

This actually slows down tests runs a bit for a variety of reasons (extra extraction steps, copying containers around on disk, and all nodes having to pull container archives from one machine), but it does allow us to run 7 tests in parallel again. Regardless, this is about stability and isolating as much of the internet downloads to the beginning of a test. Scp'ing around the files isn't the most efficient, but its relatively simple and should be reliable.

One disadvantage is that we have to maintain the list of containers to prefetch and keep them at the right version. At the least, our largest container, hyperkube, infers the tag. Its not fatal if we cache the wrong container, it just means  some internet variance could make it back into the test. In the future, maybe this list is defined along side the tests inside the bootkube repo after the tests migrate there.

You might notice the use of sync.Once is a little odd. The reason is because its important that the spawn package calls the initial `StartBastionOnce` because that package is aware of which containers to prefetch and the pluton harness shouldn't be. sync.Once is the simplest way to ensure that only the first caller causes the bastion to prefetch the images while all subsequent callers are blocked until the first call is complete.

  I also plan to come back around and have more timing profiles logged through the mantle harness, but that depends on first integrating such logging into the spawn package.