### PR TITLE
platform/aws: add missing errcheck

### DIFF
--- a/platform/machine/aws/cluster.go
+++ b/platform/machine/aws/cluster.go
@@ -85,6 +85,9 @@ func (ac *cluster) NewMachine(userdata string) (platform.Machine, error) {
 	conf.CopyKeys(keys)
 
 	instances, err := ac.api.CreateInstances(ac.Name(), conf.String(), 1, true)
+	if err != nil {
+		return nil, err
+	}
 
 	mach := &machine{
 		cluster: ac,


### PR DESCRIPTION
This would lead to a panic rather than a useful error message