### PR TITLE
kola: Convert filesystem and verity tests to subtests

### DIFF
--- a/kola/tests/misc/files.go
+++ b/kola/tests/misc/files.go
@@ -24,41 +24,20 @@ import (
 
 func init() {
 	register.Register(&register.Test{
-		Run:         DeadLinks,
+		Run:         Filesystem,
 		ClusterSize: 1,
-		Name:        "coreos.filesystem.deadlinks",
+		Name:        "coreos.filesystem",
 		UserData:    `#cloud-config`,
 	})
-	register.Register(&register.Test{
-		Run:         SUIDFiles,
-		ClusterSize: 1,
-		Name:        "coreos.filesystem.suid",
-		UserData:    `#cloud-config`,
-	})
-	register.Register(&register.Test{
-		Run:         SGIDFiles,
-		ClusterSize: 1,
-		Name:        "coreos.filesystem.sgid",
-		UserData:    `#cloud-config`,
-	})
-	register.Register(&register.Test{
-		Run:         WritableFiles,
-		ClusterSize: 1,
-		Name:        "coreos.filesystem.writablefiles",
-		UserData:    `#cloud-config`,
-	})
-	register.Register(&register.Test{
-		Run:         WritableDirs,
-		ClusterSize: 1,
-		Name:        "coreos.filesystem.writabledirs",
-		UserData:    `#cloud-config`,
-	})
-	register.Register(&register.Test{
-		Run:         StickyDirs,
-		ClusterSize: 1,
-		Name:        "coreos.filesystem.stickydirs",
-		UserData:    `#cloud-config`,
-	})
+}
+
+func Filesystem(c cluster.TestCluster) {
+	c.Run("deadlinks", DeadLinks)
+	c.Run("suid", SUIDFiles)
+	c.Run("sgid", SGIDFiles)
+	c.Run("writablefiles", WritableFiles)
+	c.Run("writabledirs", WritableDirs)
+	c.Run("stickydirs", StickyDirs)
 }
 
 func sugidFiles(c cluster.TestCluster, validfiles []string, mode string) {

--- a/kola/tests/misc/verity.go
+++ b/kola/tests/misc/verity.go
@@ -27,17 +27,17 @@ import (
 
 func init() {
 	register.Register(&register.Test{
-		Run:         VerityVerify,
+		Run:         Verity,
 		ClusterSize: 1,
-		Name:        "coreos.verity.verify",
+		Name:        "coreos.verity",
 		UserData:    `#cloud-config`,
 	})
-	register.Register(&register.Test{
-		Run:         VerityCorruption,
-		ClusterSize: 1,
-		Name:        "coreos.verity.corruption",
-		UserData:    `#cloud-config`,
-	})
+}
+
+func Verity(c cluster.TestCluster) {
+	c.Run("verify", VerityVerify)
+	// modifies disk; must run last
+	c.Run("corruption", VerityCorruption)
 }
 
 // Verity verification tests.

--- a/util/retry.go
+++ b/util/retry.go
@@ -30,7 +30,9 @@ func Retry(attempts int, delay time.Duration, f func() error) error {
 			break
 		}
 
-		time.Sleep(delay)
+		if i < attempts-1 {
+			time.Sleep(delay)
+		}
 	}
 
 	return err


### PR DESCRIPTION
Unrelatedly, skip the last sleep in util.Retry().