### PR TITLE
pluton/spawn: bump bootkube timeout

### DIFF
--- a/pluton/spawn/bootkube.go
+++ b/pluton/spawn/bootkube.go
@@ -204,7 +204,7 @@ func serviceToConfig(s string) string {
 }
 
 func bootstrapMaster(m platform.Machine, files *inputFiles, selfHostEtcd bool) error {
-	const startTimeout = time.Minute * 5 // stop bootkube start if it takes longer then this
+	const startTimeout = time.Minute * 10 // stop bootkube start if it takes longer then this
 
 	_, err := m.SSH("sudo setenforce 0")
 	if err != nil {


### PR DESCRIPTION
During the transition to using the hack/scripts directly I reduced the
bootkube timeout from 12 minutes to 5 by accident. Although bootkube is
normally much faster then 12 minutes (with container prefetching) the
timeout should not be this low.