### PR TITLE
pluton/tests/bootkube: incorrect self-hosted-etcd test options

### DIFF
--- a/pluton/tests/bootkube/registry.go
+++ b/pluton/tests/bootkube/registry.go
@@ -62,26 +62,26 @@ func init() {
 	})
 
 	harness.Register(pluton.Test{
-		Name: "bootkube.selfetcd.destruct.reboot",
-		Run:  rebootMaster,
-		Options: pluton.Options{
-			SelfHostEtcd:   false,
-			InitialMasters: 1,
-			InitialWorkers: 1,
-		},
-	})
-
-	harness.Register(pluton.Test{
 		Name: "bootkube.selfetcd.destruct.delete",
 		Run:  deleteAPIServer,
 		Options: pluton.Options{
-			SelfHostEtcd:   false,
+			SelfHostEtcd:   true,
 			InitialMasters: 1,
 			InitialWorkers: 1,
 		},
 	})
 
 	// failing/experimental tests
+	harness.Register(pluton.Test{
+		Name: "experimental.selfetcd.destruct.reboot",
+		Run:  rebootMaster,
+		Options: pluton.Options{
+			SelfHostEtcd:   true,
+			InitialMasters: 1,
+			InitialWorkers: 1,
+		},
+	})
+
 	harness.Register(pluton.Test{
 		Name: "experimental.selfetcd.scale",
 		Run:  etcdScale,


### PR DESCRIPTION
cc @hongchaodeng self-hosted etcd reboot and api-server deletion tests weren't actually running correctly because they weren't using self-hosted-etcd. Looks like this must have been messed up in a refactor somewhere.