### PR TITLE
pluton/spawn: avoid failed locksmith unit

### DIFF
--- a/pluton/spawn/nodeconfig.go
+++ b/pluton/spawn/nodeconfig.go
@@ -3,9 +3,11 @@ package spawn
 var nodeTmpl = `#cloud-config
 coreos:
   units: 
-    - name: kubelet.service
+    - name: "update-engine.service"
+      mask: true
+    - name: "locksmithd.service"
+      mask: true
+    - name: "kubelet.service"
       enable: false
       content: | 
-{{.KubeletService}}
-  update:
-    reboot-strategy: "off"`
+{{.KubeletService}}`


### PR DESCRIPTION
Occasionally when running the conformance test locksmith would fail. This should avoid that possibility all together.