### PR TITLE
pluton: get kubectl from image

### DIFF
--- a/pluton/cluster.go
+++ b/pluton/cluster.go
@@ -44,10 +44,9 @@ type Cluster struct {
 // Info contains information about how a Cluster is configured that may be
 // useful for some tests.
 type Info struct {
-	KubeletTag      string // e.g. v1.5.3_coreos.0
-	Version         string // e.g. v1.5.3+coreos.0
-	UpstreamVersion string // e.g. v1.5.3
-	ImageRepo       string // e.g. quay.io/coreos/hyperkube
+	KubeletTag string // e.g. v1.5.3_coreos.0
+	Version    string // e.g. v1.5.3+coreos.0
+	ImageRepo  string // e.g. quay.io/coreos/hyperkube
 }
 
 func NewCluster(m Manager, masters, workers []platform.Machine, info Info) *Cluster {

--- a/pluton/spawn/bootkube.go
+++ b/pluton/spawn/bootkube.go
@@ -339,13 +339,13 @@ func (m *BootkubeManager) provisionNodes(masters, workers int) ([]platform.Machi
 			plog.Infof("Warning: unable to transfer client cert to worker: %v", err)
 		}
 
-		if err := installKubectl(node, m.info); err != nil {
-			return nil, nil, err
-		}
-
 		// disable selinux
 		_, err = node.SSH("sudo setenforce 0")
 		if err != nil {
+			return nil, nil, err
+		}
+
+		if err := installKubectl(node, m.info); err != nil {
 			return nil, nil, err
 		}
 


### PR DESCRIPTION
By getting kubectl from the hyperkube image we can simplify a lot of the crusty version handling we had to start hacking around. Should have done this this way from the start. Maybe kubectl used to not be in hyperkube?

cc @diegs 