### PR TITLE
Fix up some kola test output

### DIFF
--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -393,9 +393,9 @@ func dockerUserns(c cluster.TestCluster) {
 	if err != nil {
 		c.Fatalf("could not run sleep: %v", err)
 	}
-	uid_map, err := m.SSH(`until [[ "$(/usr/bin/docker inspect -f {{.State.Running}} sleepy)" == "true" ]]; do sleep 0.1; done;
-	                pid=$(docker inspect -f {{.State.Pid}} sleepy); 
-									cat /proc/$pid/uid_map; docker kill sleepy &>/dev/null`)
+	uid_map, err := m.SSH(`until [[ "$(docker inspect -f {{.State.Running}} sleepy)" == "true" ]]; do sleep 0.1; done;
+		pid=$(docker inspect -f {{.State.Pid}} sleepy);
+		cat /proc/$pid/uid_map; docker kill sleepy &>/dev/null`)
 	if err != nil {
 		c.Fatalf("could not read uid mapping: %v", err)
 	}

--- a/kola/tests/fleet/fleet.go
+++ b/kola/tests/fleet/fleet.go
@@ -160,6 +160,6 @@ func Proxy(c cluster.TestCluster) {
 	}
 
 	if !bytes.Equal(status, []byte("active")) {
-		c.Fatalf("unit not active: %v", status)
+		c.Fatalf("unit not active: %s", status)
 	}
 }

--- a/kola/tests/locksmith/locksmith.go
+++ b/kola/tests/locksmith/locksmith.go
@@ -164,7 +164,7 @@ func locksmithTLS(c cluster.TestCluster) {
 	lCmd := "sudo locksmithctl --endpoint https://localhost:2379 --etcd-cafile /etc/ssl/etcd/ca-etcd-cert.pem --etcd-certfile /etc/ssl/etcd/locksmith-cert.pem --etcd-keyfile /etc/ssl/etcd/locksmith-key.pem "
 
 	// First verify etcd has a valid TLS connection ready
-	output, err := m.SSH("openssl s_client -showcerts -verify_return_error -verify_ip 127.0.0.1 -verify_hostname localhost -connect localhost:2379 0</dev/null 2>/dev/null")
+	output, err := m.SSH("openssl s_client -showcerts -verify_return_error -verify_ip 127.0.0.1 -verify_hostname localhost -connect localhost:2379 0</dev/null 2>&1")
 	if err != nil || !bytes.Contains(output, []byte("Verify return code: 0")) {
 		c.Fatalf("openssl s_client: %q: %v", output, err)
 	}

--- a/kola/tests/misc/files.go
+++ b/kola/tests/misc/files.go
@@ -140,7 +140,7 @@ func WritableFiles(c cluster.TestCluster) {
 	}
 
 	if string(output) != "" {
-		c.Fatalf("Unknown writable files found: %v", output)
+		c.Fatalf("Unknown writable files found: %s", output)
 	}
 }
 
@@ -153,7 +153,7 @@ func WritableDirs(c cluster.TestCluster) {
 	}
 
 	if string(output) != "" {
-		c.Fatalf("Unknown writable directories found: %v", output)
+		c.Fatalf("Unknown writable directories found: %s", output)
 	}
 }
 
@@ -185,6 +185,6 @@ func StickyDirs(c cluster.TestCluster) {
 	}
 
 	if string(output) != "" {
-		c.Fatalf("Unknown sticky directories found: %v", output)
+		c.Fatalf("Unknown sticky directories found: %s", output)
 	}
 }


### PR DESCRIPTION
This also includes fixing some command output being displayed as byte arrays.  (And dropping the absolute path wasn't required; it's just so it's possible to test without wrapper scripts.)