### PR TITLE
cmd/plume: Specify gp2 EBS volumes on 1451 and up

### DIFF
--- a/cmd/ore/aws/upload.go
+++ b/cmd/ore/aws/upload.go
@@ -224,7 +224,7 @@ func runUpload(cmd *cobra.Command, args []string) error {
 	}
 
 	// create AMIs and grant permissions
-	hvmID, err := API.CreateHVMImage(sourceSnapshot, amiName+"-hvm", uploadAMIDescription)
+	hvmID, err := API.CreateHVMImage(sourceSnapshot, amiName+"-hvm", uploadAMIDescription, aws.EC2VolumeTypeGP2)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "unable to create HVM image: %v\n", err)
 		os.Exit(1)
@@ -240,7 +240,7 @@ func runUpload(cmd *cobra.Command, args []string) error {
 
 	var pvID string
 	if uploadCreatePV {
-		pvImageID, err := API.CreatePVImage(sourceSnapshot, amiName, uploadAMIDescription)
+		pvImageID, err := API.CreatePVImage(sourceSnapshot, amiName, uploadAMIDescription, aws.EC2VolumeTypeGP2)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "unable to create PV image: %v\n", err)
 			os.Exit(1)

--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/management/storageservice"
 	"github.com/Microsoft/azure-vhd-utils-for-go/vhdcore/validator"
+	"github.com/coreos/go-semver/semver"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 	gs "google.golang.org/api/storage/v1"
@@ -341,12 +342,22 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imageName, 
 	}
 
 	plog.Printf("Creating AMIs from %v...", snapshot.SnapshotID)
-	hvmImageID, err := api.CreateHVMImage(snapshot.SnapshotID, imageName+"-hvm", imageDescription+" (HVM)")
+	volumeType := aws.EC2VolumeTypeGP2
+	parsedVersion, err := semver.NewVersion(specVersion)
+	if err != nil {
+		return nil, nil, fmt.Errorf("couldn't parse version %s: %v", specVersion, err)
+	}
+	if parsedVersion.LessThan(semver.Version{Major: 1451}) {
+		volumeType = aws.EC2VolumeTypeStandard
+		plog.Noticef("Using EBS Magnetic storage for version %v", specVersion)
+	}
+
+	hvmImageID, err := api.CreateHVMImage(snapshot.SnapshotID, imageName+"-hvm", imageDescription+" (HVM)", volumeType)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to create HVM image: %v", err)
 	}
 
-	pvImageID, err := api.CreatePVImage(snapshot.SnapshotID, imageName, imageDescription+" (PV)")
+	pvImageID, err := api.CreatePVImage(snapshot.SnapshotID, imageName, imageDescription+" (PV)", volumeType)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to create PV image: %v", err)
 	}

--- a/platform/api/aws/images.go
+++ b/platform/api/aws/images.go
@@ -43,6 +43,14 @@ const (
 	EC2ImageFormatVmdk                = ec2.DiskImageFormatVmdk
 )
 
+// TODO(bgilbert): remove after 1451 goes stable
+type EC2VolumeType string
+
+const (
+	EC2VolumeTypeStandard EC2VolumeType = "standard"
+	EC2VolumeTypeGP2      EC2VolumeType = "gp2"
+)
+
 // TODO, these can be derived at runtime
 // these are pv-grub-hd0_1.04-x86_64
 var akis = map[string]string{
@@ -344,15 +352,15 @@ func (a *API) CreateImportRole(bucket string) error {
 	return nil
 }
 
-func (a *API) CreateHVMImage(snapshotID string, name string, description string) (string, error) {
-	params := registerImageParams(snapshotID, name, description, "xvd", EC2ImageTypeHVM)
+func (a *API) CreateHVMImage(snapshotID string, name string, description string, volumeType EC2VolumeType) (string, error) {
+	params := registerImageParams(snapshotID, name, description, "xvd", EC2ImageTypeHVM, volumeType)
 	params.EnaSupport = aws.Bool(true)
 	params.SriovNetSupport = aws.String("simple")
 	return a.createImage(params)
 }
 
-func (a *API) CreatePVImage(snapshotID string, name string, description string) (string, error) {
-	params := registerImageParams(snapshotID, name, description, "sd", EC2ImageTypePV)
+func (a *API) CreatePVImage(snapshotID string, name string, description string, volumeType EC2VolumeType) (string, error) {
+	params := registerImageParams(snapshotID, name, description, "sd", EC2ImageTypePV, volumeType)
 	params.KernelId = aws.String(akis[a.opts.Region])
 	return a.createImage(params)
 }
@@ -384,7 +392,7 @@ func (a *API) createImage(params *ec2.RegisterImageInput) (string, error) {
 
 const diskSize = 8 // GB
 
-func registerImageParams(snapshotID, name, description string, diskBaseName string, imageType EC2ImageType) *ec2.RegisterImageInput {
+func registerImageParams(snapshotID, name, description string, diskBaseName string, imageType EC2ImageType, volumeType EC2VolumeType) *ec2.RegisterImageInput {
 	return &ec2.RegisterImageInput{
 		Name:               aws.String(name),
 		Description:        aws.String(description),
@@ -398,6 +406,7 @@ func registerImageParams(snapshotID, name, description string, diskBaseName stri
 					SnapshotId:          aws.String(snapshotID),
 					DeleteOnTermination: aws.Bool(true),
 					VolumeSize:          aws.Int64(diskSize),
+					VolumeType:          aws.String(string(volumeType)),
 				},
 			},
 			&ec2.BlockDeviceMapping{


### PR DESCRIPTION
The old setting was `standard`, which is a legacy type with worse performance (but half the cost). Update for current best practices.  The volume type can still be overridden by the user at launch time.

Unconditionally specify `gp2` in ore.

[Mailing list post](https://groups.google.com/d/msg/coreos-user/3TvZCD6taE4/qbZoMEMHBAAJ)