### PR TITLE
aws: Default to us-west-2 everywhere, and t2.small

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -73,7 +73,7 @@ func init() {
 	// Container Linux 1339.0.0 (alpha) on us-west-1
 	sv(&kola.AWSOptions.Region, "aws-region", defaultRegion, "AWS region")
 	sv(&kola.AWSOptions.AMI, "aws-ami", "ami-17d48a77", "AWS AMI ID")
-	sv(&kola.AWSOptions.InstanceType, "aws-type", "t2.micro", "AWS instance type")
+	sv(&kola.AWSOptions.InstanceType, "aws-type", "t2.small", "AWS instance type")
 	sv(&kola.AWSOptions.SecurityGroup, "aws-sg", "kola", "AWS security group name")
 }
 

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -68,11 +68,11 @@ func init() {
 	// aws-specific options
 	defaultRegion := os.Getenv("AWS_REGION")
 	if defaultRegion == "" {
-		defaultRegion = "us-west-1"
+		defaultRegion = "us-west-2"
 	}
-	// Container Linux 1339.0.0 (alpha) on us-west-1
+	// Container Linux 1430.0.0 (alpha) on us-west-2
 	sv(&kola.AWSOptions.Region, "aws-region", defaultRegion, "AWS region")
-	sv(&kola.AWSOptions.AMI, "aws-ami", "ami-17d48a77", "AWS AMI ID")
+	sv(&kola.AWSOptions.AMI, "aws-ami", "ami-b1620fd1", "AWS AMI ID")
 	sv(&kola.AWSOptions.InstanceType, "aws-type", "t2.small", "AWS instance type")
 	sv(&kola.AWSOptions.SecurityGroup, "aws-sg", "kola", "AWS security group name")
 }

--- a/cmd/ore/aws/aws.go
+++ b/cmd/ore/aws/aws.go
@@ -44,7 +44,7 @@ var (
 func init() {
 	defaultRegion := os.Getenv("AWS_REGION")
 	if defaultRegion == "" {
-		defaultRegion = "us-east-1"
+		defaultRegion = "us-west-2"
 	}
 
 	AWS.PersistentFlags().StringVar(&credentialsFile, "credentials-file", "", "AWS credentials file")

--- a/cmd/ore/aws/upload.go
+++ b/cmd/ore/aws/upload.go
@@ -37,7 +37,7 @@ Supported source formats are VMDK (as created with ./image_to_vm --format=ami_vm
 
 After a successful run, the final line of output will be a line of JSON describing the relevant resources.
 `,
-		Example: `  ore aws upload --region=us-west-2 \
+		Example: `  ore aws upload --region=us-east-1 \
 	  --ami-name="CoreOS-stable-1234.5.6" \
 	  --ami-description="CoreOS stable 1234.5.6" \
 	  --file="/home/.../coreos_production_ami_vmdk_image.vmdk"`,


### PR DESCRIPTION
It's too easy to leak instances when we have three different default regions.