### PR TITLE
kola: Add independent tests of SSH key injection via Ignition and platform

### DIFF
--- a/cmd/kola/bootchart.go
+++ b/cmd/kola/bootchart.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/coreos/mantle/kola"
+	"github.com/coreos/mantle/platform"
 )
 
 var cmdBootchart = &cobra.Command{
@@ -55,7 +56,9 @@ func runBootchart(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	cluster, err := kola.NewCluster(kolaPlatform, outputDir)
+	cluster, err := kola.NewCluster(kolaPlatform, &platform.RuntimeConfig{
+		OutputDir: outputDir,
+	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Cluster failed: %v\n", err)
 		os.Exit(1)

--- a/cmd/kola/qemu.go
+++ b/cmd/kola/qemu.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/coreos/mantle/kola"
+	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/machine/qemu"
 )
 
@@ -53,7 +54,9 @@ func runQemu(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	cluster, err := qemu.NewCluster(&kola.QEMUOptions, outputDir)
+	cluster, err := qemu.NewCluster(&kola.QEMUOptions, &platform.RuntimeConfig{
+		OutputDir: outputDir,
+	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Cluster failed: %v\n", err)
 		os.Exit(1)

--- a/cmd/kola/spawn.go
+++ b/cmd/kola/spawn.go
@@ -80,7 +80,9 @@ func doSpawn(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Setup failed: %v", err)
 	}
 
-	cluster, err := kola.NewCluster(kolaPlatform, outputDir)
+	cluster, err := kola.NewCluster(kolaPlatform, &platform.RuntimeConfig{
+		OutputDir: outputDir,
+	})
 	if err != nil {
 		return fmt.Errorf("Cluster failed: %v", err)
 	}

--- a/cmd/kola/updatepayload.go
+++ b/cmd/kola/updatepayload.go
@@ -136,7 +136,9 @@ func runUpdateTest() error {
 		os.Exit(1)
 	}
 
-	cluster, err := qemu.NewCluster(&kola.QEMUOptions, outputDir)
+	cluster, err := qemu.NewCluster(&kola.QEMUOptions, &platform.RuntimeConfig{
+		OutputDir: outputDir,
+	})
 	if err != nil {
 		return fmt.Errorf("new cluster: %v", err)
 	}

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -271,6 +271,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string) {
 	conf := &platform.RuntimeConfig{
 		OutputDir:          h.OutputDir(),
 		NoSSHKeyInUserData: t.HasFlag(register.NoSSHKeyInUserData),
+		NoSSHKeyInMetadata: t.HasFlag(register.NoSSHKeyInMetadata),
 	}
 	c, err := NewCluster(pltfrm, conf)
 	if err != nil {

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -269,7 +269,8 @@ func runTest(h *harness.H, t *register.Test, pltfrm string) {
 	time.Sleep(splay)
 
 	conf := &platform.RuntimeConfig{
-		OutputDir: h.OutputDir(),
+		OutputDir:          h.OutputDir(),
+		NoSSHKeyInUserData: t.HasFlag(register.NoSSHKeyInUserData),
 	}
 	c, err := NewCluster(pltfrm, conf)
 	if err != nil {

--- a/kola/register/register.go
+++ b/kola/register/register.go
@@ -27,7 +27,7 @@ import (
 // statically declare state of the platform.TestCluster before the test
 // function is run.
 type Test struct {
-	Name             string // should be uppercase and unique
+	Name             string // should be unique
 	Run              func(cluster.TestCluster)
 	NativeFuncs      map[string]func() error
 	UserData         string

--- a/kola/register/register.go
+++ b/kola/register/register.go
@@ -22,6 +22,12 @@ import (
 	"github.com/coreos/mantle/kola/cluster"
 )
 
+type Flag int
+
+const (
+	NoSSHKeyInUserData Flag = iota // don't inject SSH key into Ignition/cloud-config
+)
+
 // Test provides the main test abstraction for kola. The run function is
 // the actual testing function while the other fields provide ways to
 // statically declare state of the platform.TestCluster before the test
@@ -35,6 +41,7 @@ type Test struct {
 	Platforms        []string // whitelist of platforms to run test against -- defaults to all
 	ExcludePlatforms []string // blacklist of platforms to ignore -- defaults to none
 	Architectures    []string // whitelist of machine architectures supported -- defaults to all
+	Flags            []Flag   // special-case options for this test
 
 	// MinVersion prevents the test from executing on CoreOS machines
 	// less than MinVersion. This will be ignored if the name fully
@@ -64,4 +71,13 @@ func Register(t *Test) {
 	}
 
 	Tests[t.Name] = t
+}
+
+func (t *Test) HasFlag(flag Flag) bool {
+	for _, f := range t.Flags {
+		if f == flag {
+			return true
+		}
+	}
+	return false
 }

--- a/kola/register/register.go
+++ b/kola/register/register.go
@@ -26,6 +26,7 @@ type Flag int
 
 const (
 	NoSSHKeyInUserData Flag = iota // don't inject SSH key into Ignition/cloud-config
+	NoSSHKeyInMetadata             // don't add SSH key to platform metadata
 )
 
 // Test provides the main test abstraction for kola. The run function is

--- a/kola/tests/ignition/v2/empty.go
+++ b/kola/tests/ignition/v2/empty.go
@@ -19,15 +19,24 @@ import (
 	"github.com/coreos/mantle/kola/register"
 )
 
-// Tests for https://github.com/coreos/bugs/issues/1184
-// This test requires the kola key to be passed to the instance via cloud
+// These tests require the kola key to be passed to the instance via cloud
 // provider metadata since it will not be injected into the config.
 func init() {
+	// Tests for https://github.com/coreos/bugs/issues/1184
 	register.Register(&register.Test{
 		Name:             "coreos.ignition.v2.empty",
 		Run:              empty,
 		ClusterSize:      1,
 		ExcludePlatforms: []string{"qemu"},
+	})
+	// Tests for https://github.com/coreos/bugs/issues/1981
+	register.Register(&register.Test{
+		Name:             "coreos.ignition.v2.noop",
+		Run:              empty,
+		ClusterSize:      1,
+		ExcludePlatforms: []string{"qemu"},
+		Flags:            []register.Flag{register.NoSSHKeyInUserData},
+		UserData:         `{"ignition":{"version":"2.0.0"}}`,
 	})
 }
 

--- a/kola/tests/ignition/v2/ssh.go
+++ b/kola/tests/ignition/v2/ssh.go
@@ -1,0 +1,32 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ignition
+
+import (
+	"github.com/coreos/mantle/kola/register"
+)
+
+func init() {
+	// verify that SSH key injection works correctly through Ignition,
+	// without injecting via platform metadata
+	register.Register(&register.Test{
+		Name:             "coreos.ignition.v2.ssh.key",
+		Run:              empty,
+		ClusterSize:      1,
+		ExcludePlatforms: []string{"qemu"}, // redundant on qemu
+		Flags:            []register.Flag{register.NoSSHKeyInMetadata},
+		UserData:         `{"ignition":{"version":"2.0.0"}}`,
+	})
+}

--- a/platform/base.go
+++ b/platform/base.go
@@ -202,3 +202,7 @@ func (bc *BaseCluster) Name() string {
 func (bc *BaseCluster) OutputDir() string {
 	return bc.conf.OutputDir
 }
+
+func (bc *BaseCluster) Conf() RuntimeConfig {
+	return *bc.conf
+}

--- a/platform/base.go
+++ b/platform/base.go
@@ -142,12 +142,14 @@ func (bc *BaseCluster) MangleUserData(userdata string, ignitionVars map[string]s
 		return nil, err
 	}
 
-	keys, err := bc.Keys()
-	if err != nil {
-		return nil, err
-	}
+	if !bc.conf.NoSSHKeyInUserData {
+		keys, err := bc.Keys()
+		if err != nil {
+			return nil, err
+		}
 
-	conf.CopyKeys(keys)
+		conf.CopyKeys(keys)
+	}
 
 	return conf, nil
 }

--- a/platform/base.go
+++ b/platform/base.go
@@ -41,14 +41,14 @@ type BaseCluster struct {
 	machmap  map[string]Machine
 
 	name string
-	dir  string
+	conf *RuntimeConfig
 }
 
-func NewBaseCluster(basename, outputDir string) (*BaseCluster, error) {
-	return NewBaseClusterWithDialer(basename, outputDir, network.NewRetryDialer())
+func NewBaseCluster(basename string, conf *RuntimeConfig) (*BaseCluster, error) {
+	return NewBaseClusterWithDialer(basename, conf, network.NewRetryDialer())
 }
 
-func NewBaseClusterWithDialer(basename, outputDir string, dialer network.Dialer) (*BaseCluster, error) {
+func NewBaseClusterWithDialer(basename string, conf *RuntimeConfig, dialer network.Dialer) (*BaseCluster, error) {
 	agent, err := network.NewSSHAgent(dialer)
 	if err != nil {
 		return nil, err
@@ -58,7 +58,7 @@ func NewBaseClusterWithDialer(basename, outputDir string, dialer network.Dialer)
 		agent:   agent,
 		machmap: make(map[string]Machine),
 		name:    fmt.Sprintf("%s-%s", basename, uuid.NewV4()),
-		dir:     outputDir,
+		conf:    conf,
 	}
 
 	return bc, nil
@@ -198,5 +198,5 @@ func (bc *BaseCluster) Name() string {
 }
 
 func (bc *BaseCluster) OutputDir() string {
-	return bc.dir
+	return bc.conf.OutputDir
 }

--- a/platform/base.go
+++ b/platform/base.go
@@ -199,10 +199,6 @@ func (bc *BaseCluster) Name() string {
 	return bc.name
 }
 
-func (bc *BaseCluster) OutputDir() string {
-	return bc.conf.OutputDir
-}
-
 func (bc *BaseCluster) Conf() RuntimeConfig {
 	return *bc.conf
 }

--- a/platform/local/cluster.go
+++ b/platform/local/cluster.go
@@ -44,7 +44,7 @@ type LocalCluster struct {
 	nshandle    netns.NsHandle
 }
 
-func NewLocalCluster(basename, outputDir string) (*LocalCluster, error) {
+func NewLocalCluster(basename string, conf *platform.RuntimeConfig) (*LocalCluster, error) {
 	lc := &LocalCluster{}
 
 	var err error
@@ -55,7 +55,7 @@ func NewLocalCluster(basename, outputDir string) (*LocalCluster, error) {
 	lc.AddCloser(&lc.nshandle)
 
 	nsdialer := network.NewNsDialer(lc.nshandle)
-	lc.BaseCluster, err = platform.NewBaseClusterWithDialer(basename, outputDir, nsdialer)
+	lc.BaseCluster, err = platform.NewBaseClusterWithDialer(basename, conf, nsdialer)
 	if err != nil {
 		lc.Destroy()
 		return nil, err

--- a/platform/machine/aws/cluster.go
+++ b/platform/machine/aws/cluster.go
@@ -88,7 +88,7 @@ func (ac *cluster) NewMachine(userdata string) (platform.Machine, error) {
 		mach:    instances[0],
 	}
 
-	dir := filepath.Join(ac.OutputDir(), mach.ID())
+	dir := filepath.Join(ac.Conf().OutputDir, mach.ID())
 	if err := os.Mkdir(dir, 0777); err != nil {
 		mach.Destroy()
 		return nil, err

--- a/platform/machine/aws/cluster.go
+++ b/platform/machine/aws/cluster.go
@@ -35,13 +35,13 @@ type cluster struct {
 // NewCluster will consume the environment variables $AWS_REGION,
 // $AWS_ACCESS_KEY_ID, and $AWS_SECRET_ACCESS_KEY to determine the region to
 // spawn instances in and the credentials to use to authenticate.
-func NewCluster(opts *aws.Options, outputDir string) (platform.Cluster, error) {
+func NewCluster(opts *aws.Options, conf *platform.RuntimeConfig) (platform.Cluster, error) {
 	api, err := aws.New(opts)
 	if err != nil {
 		return nil, err
 	}
 
-	bc, err := platform.NewBaseCluster(opts.BaseName, outputDir)
+	bc, err := platform.NewBaseCluster(opts.BaseName, conf)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/machine/gcloud/cluster.go
+++ b/platform/machine/gcloud/cluster.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"golang.org/x/crypto/ssh/agent"
+
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/api/gcloud"
 )
@@ -58,9 +60,12 @@ func (gc *cluster) NewMachine(userdata string) (platform.Machine, error) {
 		return nil, err
 	}
 
-	keys, err := gc.Keys()
-	if err != nil {
-		return nil, err
+	var keys []*agent.Key
+	if !gc.Conf().NoSSHKeyInMetadata {
+		keys, err = gc.Keys()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	instance, err := gc.api.CreateInstance(conf.String(), keys)

--- a/platform/machine/gcloud/cluster.go
+++ b/platform/machine/gcloud/cluster.go
@@ -82,7 +82,7 @@ func (gc *cluster) NewMachine(userdata string) (platform.Machine, error) {
 		extIP: extip,
 	}
 
-	dir := filepath.Join(gc.OutputDir(), gm.ID())
+	dir := filepath.Join(gc.Conf().OutputDir, gm.ID())
 	if err := os.Mkdir(dir, 0777); err != nil {
 		gm.Destroy()
 		return nil, err

--- a/platform/machine/gcloud/cluster.go
+++ b/platform/machine/gcloud/cluster.go
@@ -29,13 +29,13 @@ type cluster struct {
 	api *gcloud.API
 }
 
-func NewCluster(opts *gcloud.Options, outputDir string) (platform.Cluster, error) {
+func NewCluster(opts *gcloud.Options, conf *platform.RuntimeConfig) (platform.Cluster, error) {
 	api, err := gcloud.New(opts)
 	if err != nil {
 		return nil, err
 	}
 
-	bc, err := platform.NewBaseCluster(opts.BaseName, outputDir)
+	bc, err := platform.NewBaseCluster(opts.BaseName, conf)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/machine/qemu/cluster.go
+++ b/platform/machine/qemu/cluster.go
@@ -62,8 +62,8 @@ var (
 
 // NewCluster creates a Cluster instance, suitable for running virtual
 // machines in QEMU.
-func NewCluster(conf *Options, outputDir string) (platform.Cluster, error) {
-	lc, err := local.NewLocalCluster(conf.BaseName, outputDir)
+func NewCluster(conf *Options, rconf *platform.RuntimeConfig) (platform.Cluster, error) {
+	lc, err := local.NewLocalCluster(conf.BaseName, rconf)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/machine/qemu/cluster.go
+++ b/platform/machine/qemu/cluster.go
@@ -27,7 +27,6 @@ import (
 	"github.com/satori/go.uuid"
 
 	"github.com/coreos/mantle/platform"
-	"github.com/coreos/mantle/platform/conf"
 	"github.com/coreos/mantle/platform/local"
 	"github.com/coreos/mantle/system/exec"
 	"github.com/coreos/mantle/system/ns"
@@ -91,23 +90,14 @@ func (qc *Cluster) NewMachine(cfg string) (platform.Machine, error) {
 	netif := qc.Dnsmasq.GetInterface("br0")
 	ip := strings.Split(netif.DHCPv4[0].String(), "/")[0]
 
-	cfg = strings.Replace(cfg, "$public_ipv4", ip, -1)
-	cfg = strings.Replace(cfg, "$private_ipv4", ip, -1)
-
-	conf, err := conf.New(cfg)
+	conf, err := qc.MangleUserData(cfg, map[string]string{
+		"$public_ipv4":  ip,
+		"$private_ipv4": ip,
+	})
 	if err != nil {
 		qc.mu.Unlock()
 		return nil, err
 	}
-
-	keys, err := qc.Keys()
-	if err != nil {
-		qc.mu.Unlock()
-		return nil, err
-	}
-
-	conf.CopyKeys(keys)
-
 	qc.mu.Unlock()
 
 	var confPath string

--- a/platform/machine/qemu/cluster.go
+++ b/platform/machine/qemu/cluster.go
@@ -79,7 +79,7 @@ func NewCluster(conf *Options, rconf *platform.RuntimeConfig) (platform.Cluster,
 func (qc *Cluster) NewMachine(cfg string) (platform.Machine, error) {
 	id := uuid.NewV4()
 
-	dir := filepath.Join(qc.OutputDir(), id.String())
+	dir := filepath.Join(qc.Conf().OutputDir, id.String())
 	if err := os.Mkdir(dir, 0777); err != nil {
 		return nil, err
 	}

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -80,6 +80,11 @@ type Options struct {
 	BaseName string
 }
 
+// RuntimeConfig contains cluster-specific configuration.
+type RuntimeConfig struct {
+	OutputDir string
+}
+
 // Wrap a StdoutPipe as a io.ReadCloser
 type sshPipe struct {
 	s   *ssh.Session

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -83,6 +83,8 @@ type Options struct {
 // RuntimeConfig contains cluster-specific configuration.
 type RuntimeConfig struct {
 	OutputDir string
+
+	NoSSHKeyInUserData bool // don't inject SSH key into Ignition/cloud-config
 }
 
 // Wrap a StdoutPipe as a io.ReadCloser

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -85,6 +85,7 @@ type RuntimeConfig struct {
 	OutputDir string
 
 	NoSSHKeyInUserData bool // don't inject SSH key into Ignition/cloud-config
+	NoSSHKeyInMetadata bool // don't add SSH key to platform metadata
 }
 
 // Wrap a StdoutPipe as a io.ReadCloser

--- a/pluton/harness/run.go
+++ b/pluton/harness/run.go
@@ -63,7 +63,9 @@ func RunSuite(pattern string) {
 		bastionOpts := Opts.GCEOptions
 		bastionOpts.MachineType = "n1-standard-4"
 
-		cloud, err = gcloud.NewCluster(&bastionOpts, bastionDir)
+		cloud, err = gcloud.NewCluster(&bastionOpts, &platform.RuntimeConfig{
+			OutputDir: bastionDir,
+		})
 		if err != nil {
 			fmt.Printf("setting up bastion cluster: %v\n", err)
 			os.Exit(1)
@@ -120,7 +122,9 @@ func runTest(t pluton.Test, h *harness.H) {
 
 	switch Opts.CloudPlatform {
 	case "gce":
-		cloud, err = gcloud.NewCluster(&Opts.GCEOptions, h.OutputDir())
+		cloud, err = gcloud.NewCluster(&Opts.GCEOptions, &platform.RuntimeConfig{
+			OutputDir: h.OutputDir(),
+		})
 	default:
 		err = fmt.Errorf("invalid cloud platform %v", Opts.CloudPlatform)
 	}


### PR DESCRIPTION
We were always adding the kola SSH key to both the Ignition config and the platform keystore.  (Exception: `coreos.ignition.*.empty` injects a completely empty config, thus allowing the platform keystore to be handled by coreos-cloudinit.)  Separately test SSH key injection via coreos-metadata and via Ignition.  To support this, add infrastructure for selectively disabling functionality handled by the kola harness or by platform code.