### PR TITLE
kola: By default, put test results in a subdirectory of _kola_temp

### DIFF
--- a/cmd/kola/bootchart.go
+++ b/cmd/kola/bootchart.go
@@ -50,7 +50,7 @@ func runBootchart(cmd *cobra.Command, args []string) {
 	}
 
 	var err error
-	outputDir, err = kola.CleanOutputDir(outputDir)
+	outputDir, err = kola.SetupOutputDir(outputDir, kolaPlatform)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Setup failed: %v\n", err)
 		os.Exit(1)

--- a/cmd/kola/kola.go
+++ b/cmd/kola/kola.go
@@ -84,7 +84,14 @@ func runRun(cmd *cobra.Command, args []string) {
 		pattern = "*" // run all tests by default
 	}
 
-	err := kola.RunTests(pattern, kolaPlatform, outputDir)
+	var err error
+	outputDir, err = kola.SetupOutputDir(outputDir, kolaPlatform)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
+	err = kola.RunTests(pattern, kolaPlatform, outputDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/cmd/kola/kola.go
+++ b/cmd/kola/kola.go
@@ -15,8 +15,10 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"text/tabwriter"
 
@@ -96,6 +98,60 @@ func runRun(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
+
+	// needs to be after RunTests() because harness empties the directory
+	if err := writeProps(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func writeProps() error {
+	f, err := os.OpenFile(filepath.Join(outputDir, "properties.json"), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "    ")
+
+	type AWS struct {
+		Region       string `json:"region"`
+		AMI          string `json:"ami"`
+		InstanceType string `json:"type"`
+	}
+	type GCE struct {
+		Image       string `json:"image"`
+		MachineType string `json:"type"`
+	}
+	type QEMU struct {
+		Image string `json:"image"`
+	}
+	return enc.Encode(&struct {
+		Cmdline  []string `json:"cmdline"`
+		Platform string   `json:"platform"`
+		Board    string   `json:"board"`
+		AWS      AWS      `json:"aws"`
+		GCE      GCE      `json:"gce"`
+		QEMU     QEMU     `json:"qemu"`
+	}{
+		Cmdline:  os.Args,
+		Platform: kolaPlatform,
+		Board:    kola.QEMUOptions.Board,
+		AWS: AWS{
+			Region:       kola.AWSOptions.Region,
+			AMI:          kola.AWSOptions.AMI,
+			InstanceType: kola.AWSOptions.InstanceType,
+		},
+		GCE: GCE{
+			Image:       kola.GCEOptions.Image,
+			MachineType: kola.GCEOptions.MachineType,
+		},
+		QEMU: QEMU{
+			Image: kola.QEMUOptions.DiskImage,
+		},
+	})
 }
 
 func runList(cmd *cobra.Command, args []string) {

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -44,7 +44,7 @@ func init() {
 	bv := root.PersistentFlags().BoolVar
 
 	// general options
-	sv(&outputDir, "output-dir", "_kola_temp", "Temporary output directory for test data and logs")
+	sv(&outputDir, "output-dir", "", "Temporary output directory for test data and logs")
 	sv(&kolaPlatform, "platform", "qemu", "VM platform: "+strings.Join(kolaPlatforms, ", "))
 	root.PersistentFlags().IntVar(&kola.TestParallelism, "parallel", 1, "number of tests to run in parallel")
 	sv(&kola.TAPFile, "tapfile", "", "file to write TAP results to")

--- a/cmd/kola/qemu.go
+++ b/cmd/kola/qemu.go
@@ -48,7 +48,7 @@ func runQemu(cmd *cobra.Command, args []string) {
 		os.Exit(2)
 	}
 
-	outputDir, err := kola.CleanOutputDir(outputDir)
+	outputDir, err := kola.SetupOutputDir(outputDir, "qemu")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Setup failed: %v\n", err)
 		os.Exit(1)

--- a/cmd/kola/spawn.go
+++ b/cmd/kola/spawn.go
@@ -75,7 +75,7 @@ func doSpawn(cmd *cobra.Command, args []string) error {
 		userdata = "#cloud-config"
 	}
 
-	outputDir, err = kola.CleanOutputDir(outputDir)
+	outputDir, err = kola.SetupOutputDir(outputDir, kolaPlatform)
 	if err != nil {
 		return fmt.Errorf("Setup failed: %v", err)
 	}

--- a/cmd/kola/updatepayload.go
+++ b/cmd/kola/updatepayload.go
@@ -130,7 +130,7 @@ func runUpdatePayload(cmd *cobra.Command, args []string) {
 }
 
 func runUpdateTest() error {
-	outputDir, err := kola.CleanOutputDir(outputDir)
+	outputDir, err := kola.SetupOutputDir(outputDir, "qemu")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Setup failed: %v\n", err)
 		os.Exit(1)

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -237,9 +237,9 @@ func RunTests(pattern, pltfrm, outputDir string) error {
 	}
 
 	if err != nil {
-		fmt.Println("FAIL")
+		fmt.Printf("FAIL, output in %v\n", outputDir)
 	} else {
-		fmt.Println("PASS")
+		fmt.Printf("PASS, output in %v\n", outputDir)
 	}
 
 	return err

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -399,15 +399,5 @@ func checkConsole(h *harness.H, t *register.Test, c platform.Cluster) {
 
 // CleanOutputDir creates an empty directory, any existing data will be wiped!
 func CleanOutputDir(outputDir string) (string, error) {
-	outputDir = filepath.Clean(outputDir)
-	if outputDir == "." {
-		return "", fmt.Errorf("kola: missing output directory path")
-	}
-	if err := os.RemoveAll(outputDir); err != nil {
-		return "", err
-	}
-	if err := os.MkdirAll(outputDir, 0777); err != nil {
-		return "", err
-	}
-	return outputDir, nil
+	return harness.CleanOutputDir(outputDir)
 }

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -397,7 +397,42 @@ func checkConsole(h *harness.H, t *register.Test, c platform.Cluster) {
 	}
 }
 
-// CleanOutputDir creates an empty directory, any existing data will be wiped!
-func CleanOutputDir(outputDir string) (string, error) {
-	return harness.CleanOutputDir(outputDir)
+func SetupOutputDir(outputDir, platform string) (string, error) {
+	defaulted := outputDir == ""
+	defaultBaseDirName := "_kola_temp"
+	defaultDirName := fmt.Sprintf("%s-%s-%d", platform, time.Now().Format("2006-01-02-1504"), os.Getpid())
+
+	if defaulted {
+		if _, err := os.Stat(defaultBaseDirName); os.IsNotExist(err) {
+			if err := os.Mkdir(defaultBaseDirName, 0777); err != nil {
+				return "", err
+			}
+		}
+		outputDir = filepath.Join(defaultBaseDirName, defaultDirName)
+	}
+
+	outputDir, err := harness.CleanOutputDir(outputDir)
+	if err != nil {
+		return "", err
+	}
+
+	if defaulted {
+		linkPath := filepath.Join(defaultBaseDirName, platform+"-latest")
+		st, err := os.Lstat(linkPath)
+		if err == nil {
+			if (st.Mode() & os.ModeType) != os.ModeSymlink {
+				return "", fmt.Errorf("%v exists and is not a symlink", linkPath)
+			}
+			if err := os.Remove(linkPath); err != nil {
+				return "", err
+			}
+		} else if !os.IsNotExist(err) {
+			return "", err
+		}
+		if err := os.Symlink(defaultDirName, linkPath); err != nil {
+			return "", err
+		}
+	}
+
+	return outputDir, nil
 }


### PR DESCRIPTION
Put test results in a subdirectory of `_kola_temp` named after the platform, date, and pid.  Maintain a `<platform>-latest` symlink in `_kola_temp` that points to that subdirectory.  This prevents simultaneous test runs from clobbering each other and makes it trivial to preserve history across runs.

If `--output-dir` is specified, continue using it directly.

Also save some test run parameters to the output directory and report the directory path to stdout at the end of the run.