### PR TITLE
kola/tests/ignition: Disable btrfsroot tests on Ignition < 0.16

### DIFF
--- a/kola/tests/ignition/root.go
+++ b/kola/tests/ignition/root.go
@@ -17,6 +17,8 @@ package ignition
 import (
 	"strings"
 
+	"github.com/coreos/go-semver/semver"
+
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 )
@@ -66,12 +68,14 @@ func init() {
 		Run:         btrfsRoot,
 		ClusterSize: 1,
 		UserData:    btrfsConfigV1,
+		MinVersion:  semver.Version{Major: 1448},
 	})
 	register.Register(&register.Test{
 		Name:        "coreos.ignition.v2.btrfsroot",
 		Run:         btrfsRoot,
 		ClusterSize: 1,
 		UserData:    btrfsConfigV2,
+		MinVersion:  semver.Version{Major: 1448},
 	})
 
 	// Reformat the root as xfs


### PR DESCRIPTION
There is a known race.