### PR TITLE
kola/aws: allow specifying a channel for ami id

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -73,7 +73,7 @@ func init() {
 	}
 	// Container Linux 1430.0.0 (alpha) on us-west-2
 	sv(&kola.AWSOptions.Region, "aws-region", defaultRegion, "AWS region")
-	sv(&kola.AWSOptions.AMI, "aws-ami", "ami-b1620fd1", "AWS AMI ID")
+	sv(&kola.AWSOptions.AMI, "aws-ami", "alpha", `AWS AMI ID, or (alpha|beta|stable) to use the latest image`)
 	sv(&kola.AWSOptions.InstanceType, "aws-type", "t2.small", "AWS instance type")
 	sv(&kola.AWSOptions.SecurityGroup, "aws-sg", "kola", "AWS security group name")
 

--- a/platform/api/aws/ami.go
+++ b/platform/api/aws/ami.go
@@ -1,0 +1,91 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+)
+
+// relaseAMIs matches the structure of the AMIs listed in our
+// coreos_production_ami_all.json release file
+type releaseAMIs struct {
+	AMIS []struct {
+		Name string `json:"name"`
+		PV   string `json:"pv"`
+		HVM  string `json:"hvm"`
+	} `json:"amis"`
+}
+
+var amiCache struct {
+	alphaOnce sync.Once
+	alphaAMIs *releaseAMIs
+
+	betaOnce sync.Once
+	betaAMIs *releaseAMIs
+
+	stableOnce sync.Once
+	stableAMIs *releaseAMIs
+}
+
+// resolveAMI is used to minimize network requests while allowing resolution of
+// release channels to specific AMI ids.
+// If any issue occurs attempting to resolve a given AMI, e.g. a network error,
+// this method panics.
+func resolveAMI(ami string, region string) string {
+	resolveChannel := func(channel string) *releaseAMIs {
+		resp, err := http.DefaultClient.Get(fmt.Sprintf("https://%s.release.core-os.net/amd64-usr/current/coreos_production_ami_all.json", channel))
+		if err != nil {
+			panic(fmt.Errorf("unable to fetch %v AMI json: %v", channel, err))
+		}
+
+		var amis releaseAMIs
+		err = json.NewDecoder(resp.Body).Decode(&amis)
+		if err != nil {
+			panic(fmt.Errorf("unable to parse release bucket %v AMI: %v", channel, err))
+		}
+		return &amis
+	}
+
+	var channelAmis *releaseAMIs
+	switch ami {
+	case "alpha":
+		amiCache.alphaOnce.Do(func() {
+			amiCache.alphaAMIs = resolveChannel(ami)
+		})
+		channelAmis = amiCache.alphaAMIs
+	case "beta":
+		amiCache.betaOnce.Do(func() {
+			amiCache.betaAMIs = resolveChannel(ami)
+		})
+		channelAmis = amiCache.betaAMIs
+	case "stable":
+		amiCache.stableOnce.Do(func() {
+			amiCache.stableAMIs = resolveChannel(ami)
+		})
+		channelAmis = amiCache.stableAMIs
+	default:
+		return ami
+	}
+
+	for _, ami := range channelAmis.AMIS {
+		if ami.Name == region {
+			return ami.HVM
+		}
+	}
+	panic(fmt.Sprintf("could not find %v ami in %+v", ami, amiCache.alphaAMIs.AMIS))
+}

--- a/platform/api/aws/api.go
+++ b/platform/api/aws/api.go
@@ -44,6 +44,9 @@ type Options struct {
 	// SecretKey is the optional secret key to use. It will override all other sources
 	SecretKey string
 
+	// AMI is the AWS AMI to launch EC2 instances with.
+	// If it is one of the special strings alpha|beta|stable, it will be resolved
+	// to an actual ID.
 	AMI           string
 	InstanceType  string
 	SecurityGroup string
@@ -61,6 +64,7 @@ type API struct {
 // configured in ~/.aws.
 // No validation is done that credentials exist and before using the API a
 // preflight check is recommended via api.PreflightCheck
+// Note that this method may modify Options to update the AMI ID
 func New(opts *Options) (*API, error) {
 	awsCfg := aws.Config{Region: aws.String(opts.Region)}
 	if opts.AccessKeyID != "" {
@@ -76,6 +80,8 @@ func New(opts *Options) (*API, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	opts.AMI = resolveAMI(opts.AMI, opts.Region)
 
 	api := &API{
 		session: sess,


### PR DESCRIPTION
This allows a caller to use the channel name instead of the AMI id.

It's meant as a simple quality-of-life improvement.