### PR TITLE
sdk: Use short options for sudo

### DIFF
--- a/sdk/create.go
+++ b/sdk/create.go
@@ -32,7 +32,7 @@ import (
 // Must run inside the SDK chroot, easiest to just assemble a script to do it
 const (
 	safePath   = "PATH=/usr/sbin:/usr/bin:/sbin:/bin"
-	sudoPrompt = "--prompt=sudo password for %p: "
+	sudoPrompt = "sudo password for %p: "
 	script     = `#!/bin/bash
 set -e
 
@@ -152,7 +152,7 @@ func Setup(name string) error {
 
 	plog.Info("Configuring SDK chroot")
 	sh := exec.Command(
-		"sudo", sudoPrompt,
+		"sudo", "-p", sudoPrompt,
 		"chroot", chroot,
 		"/usr/bin/env", "-i",
 		"/bin/bash", "--login")
@@ -191,7 +191,7 @@ func extract(tar, dir string) error {
 		return err
 	}
 
-	untar := exec.Command("sudo", sudoPrompt,
+	untar := exec.Command("sudo", "-p", sudoPrompt,
 		"tar", "--numeric-owner", "-x")
 	untar.Dir = dir
 	untar.Stdin = unzipped
@@ -254,7 +254,7 @@ func Delete(name string) error {
 	}
 
 	plog.Noticef("Removing SDK at %s", chroot)
-	rm := exec.Command("sudo", sudoPrompt, "rm", "-rf", chroot)
+	rm := exec.Command("sudo", "-p", sudoPrompt, "rm", "-rf", chroot)
 	rm.Stderr = os.Stderr
 	if err := rm.Run(); err != nil {
 		return err

--- a/sdk/enter.go
+++ b/sdk/enter.go
@@ -498,7 +498,7 @@ func OldEnter(name string, args ...string) error {
 	// selectively pass through environment variables instead of the
 	// catch-all -E which is probably a better way to do it.
 	enterCmd := exec.Command(
-		"sudo", sudoPrompt, "-E",
+		"sudo", "-p", sudoPrompt, "-E",
 		"unshare", "--mount", "--",
 		filepath.Join(RepoRoot(), enterChrootSh),
 		"--chroot", chroot, "--cache_dir", RepoCache(), "--")

--- a/system/exec/multicall.go
+++ b/system/exec/multicall.go
@@ -86,8 +86,7 @@ func (e Entrypoint) Command(args ...string) *ExecCmd {
 // Sudo will prepare the *ExecCmd for the given entrypoint to be run as root
 // via sudo with the provided args.
 func (e Entrypoint) Sudo(args ...string) *ExecCmd {
-	args = append([]string{"--preserve-env",
-		"--prompt=sudo password for %p: ", "--",
+	args = append([]string{"-E", "-p", "sudo password for %p: ", "--",
 		exePath, entryArgPrefix + string(e)}, args...)
 	cmd := Command("sudo", args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{


### PR DESCRIPTION
Long options were added in sudo 1.8.8. CentOS 7.3 has 1.8.6.

Fixes https://github.com/coreos/mantle/issues/647.

cc: @jedsmith