### PR TITLE
platform/conf: Use Ignition 2.0.0 parser for 2.0.0 configs

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 72d1ea9edc735b71388127026eca427edda90e011b71644860fd9a9c69949c2c
-updated: 2017-07-24T11:51:32.031519805-07:00
+hash: 7ae2bd4cddb0e3428f6e304a4811d90d4bebace04a4a6227c40b8402a9d4d055
+updated: 2017-08-02T15:35:40.940553064-07:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -130,7 +130,7 @@ imports:
   - journal
   - unit
 - name: github.com/coreos/ignition
-  version: e6a8281592b13fd582157d7dd44777ca9851d842
+  version: 11813c57bc05f30644bbae7891ae30a4a62e0b33
   subpackages:
   - config
   - config/types

--- a/glide.yaml
+++ b/glide.yaml
@@ -148,7 +148,7 @@ import:
   - journal
   - unit
 - package: github.com/coreos/ignition
-  version: v0.17.1
+  version: v0.17.2
   subpackages:
   - config
   - config/types

--- a/platform/conf/conf_test.go
+++ b/platform/conf/conf_test.go
@@ -35,6 +35,7 @@ func TestConfCopyKey(t *testing.T) {
 
 	tests := []*UserData{
 		ContainerLinuxConfig(""),
+		Ignition(`{ "ignition": { "version": "2.1.0" } }`),
 		Ignition(`{ "ignition": { "version": "2.0.0" } }`),
 		Ignition(`{ "ignitionVersion": 1 }`),
 		CloudConfig("#cloud-config"),


### PR DESCRIPTION
A 2.1.0 struct can contain a 2.0.0 config, but when serialized it contains empty JSON objects that aren't defined in the 2.0.0 spec, causing Ignition to produce warnings. Since Ignition now exports a function for determining the config version, use it to select the correct parser for the config version we have.