### PR TITLE
Enable kola on arm64 machines

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -372,9 +372,17 @@ func runTest(h *harness.H, t *register.Test, pltfrm string) {
 func architecture(pltfrm string) string {
 	nativeArch := "amd64"
 	if pltfrm == "qemu" && QEMUOptions.Board != "" {
-		nativeArch = strings.SplitN(QEMUOptions.Board, "-", 2)[0]
+		nativeArch = boardToArch(QEMUOptions.Board)
+	}
+	if pltfrm == "packet" && PacketOptions.Board != "" {
+		nativeArch = boardToArch(PacketOptions.Board)
 	}
 	return nativeArch
+}
+
+// returns the arch part of an sdk board name
+func boardToArch(board string) string {
+	return strings.SplitN(board, "-", 2)[0]
 }
 
 // scpKolet searches for a kolet binary and copies it to the machine.

--- a/platform/machine/qemu/cluster.go
+++ b/platform/machine/qemu/cluster.go
@@ -133,12 +133,14 @@ func (qc *Cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 			"qemu-system-x86_64",
 			"-machine", "accel=kvm",
 			"-cpu", "host",
+			"-m", "1024",
 		}
 	case "arm64-usr":
 		qmCmd = []string{
 			"qemu-system-aarch64",
 			"-machine", "virt",
 			"-cpu", "cortex-a57",
+			"-m", "2048",
 		}
 	default:
 		panic(qc.opts.Board)
@@ -148,7 +150,6 @@ func (qc *Cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 	qmCmd = append(qmCmd,
 		"-bios", qc.opts.BIOSImage,
 		"-smp", "1",
-		"-m", "1024",
 		"-uuid", qm.id,
 		"-display", "none",
 		"-add-fd", "fd=4,set=1",

--- a/sdk/repo.go
+++ b/sdk/repo.go
@@ -22,11 +22,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/coreos/mantle/system"
 	"github.com/coreos/mantle/system/exec"
 )
 
 const (
-	defaultBoard = "amd64-usr"
 	defaultGroup = "developer"
 
 	// In the SDK chroot the repo is always at this location
@@ -84,6 +84,7 @@ func RepoCache() string {
 }
 
 func DefaultBoard() string {
+	defaultBoard := system.PortageArch() + "-usr"
 	cfg := filepath.Join(RepoRoot(), defaultBoardCfg)
 	board, err := ioutil.ReadFile(cfg)
 	if err != nil {


### PR DESCRIPTION
Allows kola to run on arm64 hosts.  Also includes a patch that increases the debug output of dnsmasq.
