### PR TITLE
selinux: allow disabling and test surviving reboots

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -312,6 +312,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string) {
 		OutputDir:          h.OutputDir(),
 		NoSSHKeyInUserData: t.HasFlag(register.NoSSHKeyInUserData),
 		NoSSHKeyInMetadata: t.HasFlag(register.NoSSHKeyInMetadata),
+		NoEnableSelinux:    t.HasFlag(register.NoEnableSelinux),
 	}
 	c, err := NewCluster(pltfrm, rconf)
 	if err != nil {

--- a/kola/register/register.go
+++ b/kola/register/register.go
@@ -29,6 +29,7 @@ const (
 	NoSSHKeyInUserData    Flag = iota // don't inject SSH key into Ignition/cloud-config
 	NoSSHKeyInMetadata                // don't add SSH key to platform metadata
 	NoEmergencyShellCheck             // don't check console output for emergency shell invocation
+	NoEnableSelinux                   // don't enable selinux when starting or rebooting a machine
 )
 
 // Test provides the main test abstraction for kola. The run function is

--- a/platform/machine/aws/cluster.go
+++ b/platform/machine/aws/cluster.go
@@ -104,7 +104,7 @@ func (ac *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 		return nil, err
 	}
 
-	if err := platform.StartMachine(mach, mach.journal); err != nil {
+	if err := platform.StartMachine(mach, mach.journal, ac.RuntimeConf()); err != nil {
 		mach.Destroy()
 		return nil, err
 	}

--- a/platform/machine/aws/cluster.go
+++ b/platform/machine/aws/cluster.go
@@ -15,8 +15,6 @@
 package aws
 
 import (
-	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -106,17 +104,7 @@ func (ac *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 		return nil, err
 	}
 
-	if err := mach.journal.Start(context.TODO(), mach); err != nil {
-		mach.Destroy()
-		return nil, err
-	}
-
-	if err := platform.CheckMachine(mach); err != nil {
-		mach.Destroy()
-		return nil, fmt.Errorf("machine %q failed basic checks: %v", mach.ID(), err)
-	}
-
-	if err := platform.EnableSelinux(mach); err != nil {
+	if err := platform.StartMachine(mach, mach.journal); err != nil {
 		mach.Destroy()
 		return nil, err
 	}

--- a/platform/machine/aws/machine.go
+++ b/platform/machine/aws/machine.go
@@ -57,7 +57,7 @@ func (am *machine) SSH(cmd string) ([]byte, error) {
 }
 
 func (m *machine) Reboot() error {
-	return platform.RebootMachine(m, m.journal)
+	return platform.RebootMachine(m, m.journal, m.cluster.RuntimeConf())
 }
 
 func (am *machine) Destroy() error {

--- a/platform/machine/aws/machine.go
+++ b/platform/machine/aws/machine.go
@@ -15,7 +15,6 @@
 package aws
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 
@@ -58,19 +57,7 @@ func (am *machine) SSH(cmd string) ([]byte, error) {
 }
 
 func (m *machine) Reboot() error {
-	if err := platform.StartReboot(m); err != nil {
-		return err
-	}
-	if err := m.journal.Start(context.TODO(), m); err != nil {
-		return err
-	}
-	if err := platform.CheckMachine(m); err != nil {
-		return err
-	}
-	if err := platform.EnableSelinux(m); err != nil {
-		return err
-	}
-	return nil
+	return platform.RebootMachine(m, m.journal)
 }
 
 func (am *machine) Destroy() error {

--- a/platform/machine/esx/cluster.go
+++ b/platform/machine/esx/cluster.go
@@ -15,7 +15,6 @@
 package esx
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"os"
@@ -109,17 +108,7 @@ ExecStart=/usr/bin/bash -c 'echo "COREOS_ESX_IPV4_PRIVATE_0=$(ip addr show ens19
 		return nil, err
 	}
 
-	if err := mach.journal.Start(context.TODO(), mach); err != nil {
-		mach.Destroy()
-		return nil, err
-	}
-
-	if err := platform.CheckMachine(mach); err != nil {
-		mach.Destroy()
-		return nil, fmt.Errorf("machine %q failed basic checks: %v", mach.ID(), err)
-	}
-
-	if err := platform.EnableSelinux(mach); err != nil {
+	if err := platform.StartMachine(mach, mach.journal); err != nil {
 		mach.Destroy()
 		return nil, err
 	}

--- a/platform/machine/esx/cluster.go
+++ b/platform/machine/esx/cluster.go
@@ -108,7 +108,7 @@ ExecStart=/usr/bin/bash -c 'echo "COREOS_ESX_IPV4_PRIVATE_0=$(ip addr show ens19
 		return nil, err
 	}
 
-	if err := platform.StartMachine(mach, mach.journal); err != nil {
+	if err := platform.StartMachine(mach, mach.journal, ec.RuntimeConf()); err != nil {
 		mach.Destroy()
 		return nil, err
 	}

--- a/platform/machine/esx/machine.go
+++ b/platform/machine/esx/machine.go
@@ -15,7 +15,6 @@
 package esx
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -59,19 +58,7 @@ func (em *machine) SSH(cmd string) ([]byte, error) {
 }
 
 func (m *machine) Reboot() error {
-	if err := platform.StartReboot(m); err != nil {
-		return err
-	}
-	if err := m.journal.Start(context.TODO(), m); err != nil {
-		return err
-	}
-	if err := platform.CheckMachine(m); err != nil {
-		return err
-	}
-	if err := platform.EnableSelinux(m); err != nil {
-		return err
-	}
-	return nil
+	return platform.RebootMachine(m, m.journal)
 }
 
 func (em *machine) Destroy() error {

--- a/platform/machine/esx/machine.go
+++ b/platform/machine/esx/machine.go
@@ -58,7 +58,7 @@ func (em *machine) SSH(cmd string) ([]byte, error) {
 }
 
 func (m *machine) Reboot() error {
-	return platform.RebootMachine(m, m.journal)
+	return platform.RebootMachine(m, m.journal, m.cluster.RuntimeConf())
 }
 
 func (em *machine) Destroy() error {

--- a/platform/machine/gcloud/cluster.go
+++ b/platform/machine/gcloud/cluster.go
@@ -105,7 +105,7 @@ func (gc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 		return nil, err
 	}
 
-	if err := platform.StartMachine(gm, gm.journal); err != nil {
+	if err := platform.StartMachine(gm, gm.journal, gc.RuntimeConf()); err != nil {
 		gm.Destroy()
 		return nil, err
 	}

--- a/platform/machine/gcloud/cluster.go
+++ b/platform/machine/gcloud/cluster.go
@@ -16,7 +16,6 @@
 package gcloud
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 
@@ -106,20 +105,11 @@ func (gc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 		return nil, err
 	}
 
-	if err := gm.journal.Start(context.TODO(), gm); err != nil {
+	if err := platform.StartMachine(gm, gm.journal); err != nil {
 		gm.Destroy()
 		return nil, err
 	}
 
-	if err := platform.CheckMachine(gm); err != nil {
-		gm.Destroy()
-		return nil, err
-	}
-
-	if err := platform.EnableSelinux(gm); err != nil {
-		gm.Destroy()
-		return nil, err
-	}
 	gc.AddMach(gm)
 
 	return gm, nil

--- a/platform/machine/gcloud/machine.go
+++ b/platform/machine/gcloud/machine.go
@@ -1,7 +1,20 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gcloud
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 
@@ -45,19 +58,7 @@ func (gm *machine) SSH(cmd string) ([]byte, error) {
 }
 
 func (m *machine) Reboot() error {
-	if err := platform.StartReboot(m); err != nil {
-		return err
-	}
-	if err := m.journal.Start(context.TODO(), m); err != nil {
-		return err
-	}
-	if err := platform.CheckMachine(m); err != nil {
-		return err
-	}
-	if err := platform.EnableSelinux(m); err != nil {
-		return err
-	}
-	return nil
+	return platform.RebootMachine(m, m.journal)
 }
 
 func (gm *machine) Destroy() error {

--- a/platform/machine/gcloud/machine.go
+++ b/platform/machine/gcloud/machine.go
@@ -58,7 +58,7 @@ func (gm *machine) SSH(cmd string) ([]byte, error) {
 }
 
 func (m *machine) Reboot() error {
-	return platform.RebootMachine(m, m.journal)
+	return platform.RebootMachine(m, m.journal, m.gc.RuntimeConf())
 }
 
 func (gm *machine) Destroy() error {

--- a/platform/machine/packet/cluster.go
+++ b/platform/machine/packet/cluster.go
@@ -15,7 +15,6 @@
 package packet
 
 import (
-	"context"
 	"crypto/rand"
 	"fmt"
 	"os"
@@ -141,17 +140,7 @@ func (pc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 		return nil, err
 	}
 
-	if err := mach.journal.Start(context.TODO(), mach); err != nil {
-		mach.Destroy()
-		return nil, err
-	}
-
-	if err := platform.CheckMachine(mach); err != nil {
-		mach.Destroy()
-		return nil, fmt.Errorf("machine %q failed basic checks: %v", mach.ID(), err)
-	}
-
-	if err := platform.EnableSelinux(mach); err != nil {
+	if err := platform.StartMachine(mach, mach.journal); err != nil {
 		mach.Destroy()
 		return nil, err
 	}

--- a/platform/machine/packet/cluster.go
+++ b/platform/machine/packet/cluster.go
@@ -140,7 +140,7 @@ func (pc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 		return nil, err
 	}
 
-	if err := platform.StartMachine(mach, mach.journal); err != nil {
+	if err := platform.StartMachine(mach, mach.journal, pc.RuntimeConf()); err != nil {
 		mach.Destroy()
 		return nil, err
 	}

--- a/platform/machine/packet/machine.go
+++ b/platform/machine/packet/machine.go
@@ -57,7 +57,7 @@ func (pm *machine) SSH(cmd string) ([]byte, error) {
 }
 
 func (m *machine) Reboot() error {
-	return platform.RebootMachine(m, m.journal)
+	return platform.RebootMachine(m, m.journal, m.cluster.RuntimeConf())
 }
 
 func (pm *machine) Destroy() error {

--- a/platform/machine/packet/machine.go
+++ b/platform/machine/packet/machine.go
@@ -15,7 +15,6 @@
 package packet
 
 import (
-	"context"
 	"strings"
 
 	"golang.org/x/crypto/ssh"
@@ -58,19 +57,7 @@ func (pm *machine) SSH(cmd string) ([]byte, error) {
 }
 
 func (m *machine) Reboot() error {
-	if err := platform.StartReboot(m); err != nil {
-		return err
-	}
-	if err := m.journal.Start(context.TODO(), m); err != nil {
-		return err
-	}
-	if err := platform.CheckMachine(m); err != nil {
-		return err
-	}
-	if err := platform.EnableSelinux(m); err != nil {
-		return err
-	}
-	return nil
+	return platform.RebootMachine(m, m.journal)
 }
 
 func (pm *machine) Destroy() error {

--- a/platform/machine/qemu/cluster.go
+++ b/platform/machine/qemu/cluster.go
@@ -15,7 +15,6 @@
 package qemu
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -202,20 +201,11 @@ func (qc *Cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 		return nil, err
 	}
 
-	if err := qm.journal.Start(context.TODO(), qm); err != nil {
+	if err := platform.StartMachine(qm, qm.journal); err != nil {
 		qm.Destroy()
 		return nil, err
 	}
 
-	if err := platform.CheckMachine(qm); err != nil {
-		qm.Destroy()
-		return nil, err
-	}
-
-	if err := platform.EnableSelinux(qm); err != nil {
-		qm.Destroy()
-		return nil, err
-	}
 	qc.AddMach(qm)
 
 	return qm, nil

--- a/platform/machine/qemu/cluster.go
+++ b/platform/machine/qemu/cluster.go
@@ -201,7 +201,7 @@ func (qc *Cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 		return nil, err
 	}
 
-	if err := platform.StartMachine(qm, qm.journal); err != nil {
+	if err := platform.StartMachine(qm, qm.journal, qc.RuntimeConf()); err != nil {
 		qm.Destroy()
 		return nil, err
 	}

--- a/platform/machine/qemu/machine.go
+++ b/platform/machine/qemu/machine.go
@@ -15,7 +15,6 @@
 package qemu
 
 import (
-	"context"
 	"io/ioutil"
 
 	"golang.org/x/crypto/ssh"
@@ -60,19 +59,7 @@ func (m *machine) SSH(cmd string) ([]byte, error) {
 }
 
 func (m *machine) Reboot() error {
-	if err := platform.StartReboot(m); err != nil {
-		return err
-	}
-	if err := m.journal.Start(context.TODO(), m); err != nil {
-		return err
-	}
-	if err := platform.CheckMachine(m); err != nil {
-		return err
-	}
-	if err := platform.EnableSelinux(m); err != nil {
-		return err
-	}
-	return nil
+	return platform.RebootMachine(m, m.journal)
 }
 
 func (m *machine) Destroy() error {

--- a/platform/machine/qemu/machine.go
+++ b/platform/machine/qemu/machine.go
@@ -59,7 +59,7 @@ func (m *machine) SSH(cmd string) ([]byte, error) {
 }
 
 func (m *machine) Reboot() error {
-	return platform.RebootMachine(m, m.journal)
+	return platform.RebootMachine(m, m.journal, m.qc.RuntimeConf())
 }
 
 func (m *machine) Destroy() error {

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -95,6 +95,7 @@ type RuntimeConfig struct {
 
 	NoSSHKeyInUserData bool // don't inject SSH key into Ignition/cloud-config
 	NoSSHKeyInMetadata bool // don't add SSH key to platform metadata
+	NoEnableSelinux    bool // don't enable selinux when starting or rebooting a machine
 }
 
 // Wrap a StdoutPipe as a io.ReadCloser

--- a/platform/util.go
+++ b/platform/util.go
@@ -15,6 +15,7 @@
 package platform
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -99,6 +100,30 @@ func StartReboot(m Machine) error {
 	}
 	if err != nil {
 		return fmt.Errorf("issuing reboot command failed: %v", out)
+	}
+	return nil
+}
+
+// RebootMachine will reboot a given machine, provided the machine's journal and
+// runtime config.
+func RebootMachine(m Machine, j *Journal) error {
+	if err := StartReboot(m); err != nil {
+		return fmt.Errorf("machine %q failed to begin rebooting: %v", m.ID(), err)
+	}
+	return StartMachine(m, j)
+}
+
+// RebootMachine will start a given machine, provided the machine's journal and
+// runtime config.
+func StartMachine(m Machine, j *Journal) error {
+	if err := j.Start(context.TODO(), m); err != nil {
+		return fmt.Errorf("machine %q failed to start: %v", m.ID(), err)
+	}
+	if err := CheckMachine(m); err != nil {
+		return fmt.Errorf("machine %q failed basic checks: %v", m.ID(), err)
+	}
+	if err := EnableSelinux(m); err != nil {
+		return fmt.Errorf("machine %q failed to enable selinux: %v", m.ID(), err)
 	}
 	return nil
 }

--- a/platform/util.go
+++ b/platform/util.go
@@ -122,8 +122,10 @@ func StartMachine(m Machine, j *Journal, c RuntimeConfig) error {
 	if err := CheckMachine(m); err != nil {
 		return fmt.Errorf("machine %q failed basic checks: %v", m.ID(), err)
 	}
-	if err := EnableSelinux(m); err != nil {
-		return fmt.Errorf("machine %q failed to enable selinux: %v", m.ID(), err)
+	if !c.NoEnableSelinux {
+		if err := EnableSelinux(m); err != nil {
+			return fmt.Errorf("machine %q failed to enable selinux: %v", m.ID(), err)
+		}
 	}
 	return nil
 }

--- a/platform/util.go
+++ b/platform/util.go
@@ -106,16 +106,16 @@ func StartReboot(m Machine) error {
 
 // RebootMachine will reboot a given machine, provided the machine's journal and
 // runtime config.
-func RebootMachine(m Machine, j *Journal) error {
+func RebootMachine(m Machine, j *Journal, c RuntimeConfig) error {
 	if err := StartReboot(m); err != nil {
 		return fmt.Errorf("machine %q failed to begin rebooting: %v", m.ID(), err)
 	}
-	return StartMachine(m, j)
+	return StartMachine(m, j, c)
 }
 
 // RebootMachine will start a given machine, provided the machine's journal and
 // runtime config.
-func StartMachine(m Machine, j *Journal) error {
+func StartMachine(m Machine, j *Journal, c RuntimeConfig) error {
 	if err := j.Start(context.TODO(), m); err != nil {
 		return fmt.Errorf("machine %q failed to start: %v", m.ID(), err)
 	}


### PR DESCRIPTION
This PR has two commits:
- The first one adds a new flag to `platform.RuntimeConfig` to signal that selinux should not be enabled when machines are created or rebooted
- The second one modifies the `coreos.selinux.enforce` test to check that selinux is not enabled before enabling it, and then follow [the docs](https://coreos.com/os/docs/latest/selinux.html#enable-selinux-enforcement) to enable selinux, reboot, and check that it is still enabled.