### PR TITLE
cork/create: fix interactive shell check

### DIFF
--- a/sdk/create.go
+++ b/sdk/create.go
@@ -107,7 +107,7 @@ cat >"$HOME"/.bash_profile <<EOF
 cd ${CHROOT_CWD:-~/trunk/src/scripts}
 EOF
 
-cat >"$HOME"/.bashrc <<EOF
+cat >"$HOME"/.bashrc << 'EOF'
 # .bashrc
 
 # This file is sourced by all *interactive* bash shells on startup,


### PR DESCRIPTION
Here strings will expand variables when used. This escapes them so they
are expanded when bash is run rather than when cork creates the bashrc