### PR TITLE
kola/tests: change containerd test min version

### DIFF
--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -196,7 +196,7 @@ systemd:
 		Name:        "docker.containerd-restart",
 		Run:         dockerContainerdRestart,
 		ClusterSize: 1,
-		MinVersion:  semver.Version{Major: 1520},
+		MinVersion:  semver.Version{Major: 1506},
 		UserData: conf.ContainerLinuxConfig(`
 systemd:
   units:


### PR DESCRIPTION
https://github.com/coreos/coreos-overlay/pull/2703 was merged for 1506 instead of 1520. Update the test to reflect that.