### PR TITLE
platform: add cleanup of serial file and vm folders to esx

### DIFF
--- a/platform/machine/esx/machine.go
+++ b/platform/machine/esx/machine.go
@@ -76,6 +76,10 @@ func (em *machine) Destroy() error {
 		return err
 	}
 
+	if err := em.cluster.api.CleanupDevice(em.ID()); err != nil {
+		return err
+	}
+
 	em.cluster.DelMach(em)
 
 	return nil


### PR DESCRIPTION
Currently we leak a file & folder on the datastore. This adds the
removal of these items to the API and is called inside of `Destroy`
after the serial file is downloaded.