### PR TITLE
platform/base: Render CLCs with platform

### DIFF
--- a/cmd/ore/packet/create-device.go
+++ b/cmd/ore/packet/create-device.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	ctplatform "github.com/coreos/container-linux-config-transpiler/config/platform"
 	"github.com/coreos/mantle/platform/conf"
 )
 
@@ -65,7 +66,7 @@ func runCreateDevice(cmd *cobra.Command, args []string) error {
 		}
 		userdata = conf.Unknown(string(data))
 	}
-	conf, err := userdata.Render()
+	conf, err := userdata.Render(ctplatform.Packet)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't parse userdata file %v: %v\n", userDataPath, err)
 		os.Exit(1)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7ae2bd4cddb0e3428f6e304a4811d90d4bebace04a4a6227c40b8402a9d4d055
-updated: 2017-08-02T15:35:40.940553064-07:00
+hash: 963a35f11f8b2de0b5021d586f0b82d09773dce07271ec0de93dfa3aedd9625d
+updated: 2017-08-25T17:03:34.112032005-07:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -55,10 +55,11 @@ imports:
 - name: github.com/boltdb/bolt
   version: dfb21201d9270c1082d5fb0f07f500311ff72f18
 - name: github.com/coreos/container-linux-config-transpiler
-  version: 390af23d7792fd6b90ff93a33acd003dbf82d6cf
+  version: d42f09a1374bc318d853b53e5a31148db68a4e2a
   subpackages:
   - config
   - config/astyaml
+  - config/platform
   - config/templating
   - config/types
   - config/types/util

--- a/glide.yaml
+++ b/glide.yaml
@@ -74,9 +74,10 @@ import:
 - package: github.com/boltdb/bolt
   version: v1.2.1
 - package: github.com/coreos/container-linux-config-transpiler
-  version: v0.4.1
+  version: v0.4.2
   subpackages:
   - config
+  - config/platform
   - config/templating
   - config/types
   - config/types/util

--- a/platform/base.go
+++ b/platform/base.go
@@ -40,15 +40,16 @@ type BaseCluster struct {
 	machmap    map[string]Machine
 	consolemap map[string]string
 
-	name  string
-	rconf *RuntimeConfig
+	name       string
+	rconf      *RuntimeConfig
+	ctPlatform string
 }
 
-func NewBaseCluster(basename string, rconf *RuntimeConfig) (*BaseCluster, error) {
-	return NewBaseClusterWithDialer(basename, rconf, network.NewRetryDialer())
+func NewBaseCluster(basename string, rconf *RuntimeConfig, ctPlatform string) (*BaseCluster, error) {
+	return NewBaseClusterWithDialer(basename, rconf, ctPlatform, network.NewRetryDialer())
 }
 
-func NewBaseClusterWithDialer(basename string, rconf *RuntimeConfig, dialer network.Dialer) (*BaseCluster, error) {
+func NewBaseClusterWithDialer(basename string, rconf *RuntimeConfig, ctPlatform string, dialer network.Dialer) (*BaseCluster, error) {
 	agent, err := network.NewSSHAgent(dialer)
 	if err != nil {
 		return nil, err
@@ -60,6 +61,7 @@ func NewBaseClusterWithDialer(basename string, rconf *RuntimeConfig, dialer netw
 		consolemap: make(map[string]string),
 		name:       fmt.Sprintf("%s-%s", basename, uuid.NewV4()),
 		rconf:      rconf,
+		ctPlatform: ctPlatform,
 	}
 
 	return bc, nil
@@ -152,7 +154,7 @@ func (bc *BaseCluster) RenderUserData(userdata *conf.UserData, ignitionVars map[
 		}
 	}
 
-	conf, err := userdata.Render()
+	conf, err := userdata.Render(bc.ctPlatform)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/conf/conf.go
+++ b/platform/conf/conf.go
@@ -131,7 +131,7 @@ func (u *UserData) IsIgnition() bool {
 
 // Render parses userdata and returns a new Conf. It returns an error if the
 // userdata can't be parsed.
-func (u *UserData) Render() (*Conf, error) {
+func (u *UserData) Render(ctPlatform string) (*Conf, error) {
 	c := &Conf{}
 
 	switch u.kind {
@@ -185,8 +185,7 @@ func (u *UserData) Render() (*Conf, error) {
 			plog.Warningf("parsing Container Linux config: %s", report)
 		}
 
-		// TODO(bgilbert): substitute cloud-specific variables via ct
-		ignc, report := ct.ConvertAs2_0(clc, "", ast)
+		ignc, report := ct.ConvertAs2_0(clc, ctPlatform, ast)
 		if report.IsFatal() {
 			return nil, fmt.Errorf("rendering Container Linux config: %s", report)
 		} else if len(report.Entries) > 0 {

--- a/platform/conf/conf_test.go
+++ b/platform/conf/conf_test.go
@@ -42,7 +42,7 @@ func TestConfCopyKey(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		conf, err := tt.Render()
+		conf, err := tt.Render("")
 		if err != nil {
 			t.Errorf("failed to parse config %d: %v", i, err)
 			continue

--- a/platform/local/cluster.go
+++ b/platform/local/cluster.go
@@ -55,7 +55,7 @@ func NewLocalCluster(basename string, rconf *platform.RuntimeConfig) (*LocalClus
 	lc.AddCloser(&lc.nshandle)
 
 	nsdialer := network.NewNsDialer(lc.nshandle)
-	lc.BaseCluster, err = platform.NewBaseClusterWithDialer(basename, rconf, nsdialer)
+	lc.BaseCluster, err = platform.NewBaseClusterWithDialer(basename, rconf, "", nsdialer)
 	if err != nil {
 		lc.Destroy()
 		return nil, err

--- a/platform/machine/aws/cluster.go
+++ b/platform/machine/aws/cluster.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 
+	ctplatform "github.com/coreos/container-linux-config-transpiler/config/platform"
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/api/aws"
 	"github.com/coreos/mantle/platform/conf"
@@ -40,7 +41,7 @@ func NewCluster(opts *aws.Options, rconf *platform.RuntimeConfig) (platform.Clus
 		return nil, err
 	}
 
-	bc, err := platform.NewBaseCluster(opts.BaseName, rconf)
+	bc, err := platform.NewBaseCluster(opts.BaseName, rconf, ctplatform.EC2)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/machine/esx/cluster.go
+++ b/platform/machine/esx/cluster.go
@@ -44,7 +44,7 @@ func NewCluster(opts *esx.Options, rconf *platform.RuntimeConfig) (platform.Clus
 		return nil, err
 	}
 
-	bc, err := platform.NewBaseCluster(opts.BaseName, rconf)
+	bc, err := platform.NewBaseCluster(opts.BaseName, rconf, "")
 	if err != nil {
 		return nil, err
 	}

--- a/platform/machine/gcloud/cluster.go
+++ b/platform/machine/gcloud/cluster.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 
+	ctplatform "github.com/coreos/container-linux-config-transpiler/config/platform"
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/api/gcloud"
 	"github.com/coreos/mantle/platform/conf"
@@ -43,7 +44,7 @@ func NewCluster(opts *gcloud.Options, rconf *platform.RuntimeConfig) (platform.C
 		return nil, err
 	}
 
-	bc, err := platform.NewBaseCluster(opts.BaseName, rconf)
+	bc, err := platform.NewBaseCluster(opts.BaseName, rconf, ctplatform.GCE)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/machine/packet/cluster.go
+++ b/platform/machine/packet/cluster.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 
+	ctplatform "github.com/coreos/container-linux-config-transpiler/config/platform"
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/api/packet"
 	"github.com/coreos/mantle/platform/conf"
@@ -43,7 +44,7 @@ func NewCluster(opts *packet.Options, rconf *platform.RuntimeConfig) (platform.C
 		return nil, err
 	}
 
-	bc, err := platform.NewBaseCluster(opts.BaseName, rconf)
+	bc, err := platform.NewBaseCluster(opts.BaseName, rconf, ctplatform.Packet)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/coreos/container-linux-config-transpiler/config/config.go
+++ b/vendor/github.com/coreos/container-linux-config-transpiler/config/config.go
@@ -19,6 +19,7 @@ import (
 
 	yaml "github.com/ajeddeloh/yaml"
 	"github.com/coreos/container-linux-config-transpiler/config/astyaml"
+	"github.com/coreos/container-linux-config-transpiler/config/platform"
 	"github.com/coreos/container-linux-config-transpiler/config/types"
 	ignTypes "github.com/coreos/ignition/config/v2_0/types"
 	"github.com/coreos/ignition/config/validate"
@@ -66,6 +67,14 @@ func Parse(data []byte) (types.Config, validate.AstNode, report.Report) {
 // ConvertAs2_0 also accepts a platform string, which can either be one of the
 // platform strings defined in config/templating/templating.go or an empty
 // string if [dynamic data](doc/dynamic-data.md) isn't used.
-func ConvertAs2_0(in types.Config, platform string, ast validate.AstNode) (ignTypes.Config, report.Report) {
-	return types.ConvertAs2_0(in, platform, ast)
+func ConvertAs2_0(in types.Config, p string, ast validate.AstNode) (ignTypes.Config, report.Report) {
+	if !platform.IsSupportedPlatform(p) {
+		r := report.Report{}
+		r.Add(report.Entry{
+			Kind:    report.EntryError,
+			Message: "unsupported platform",
+		})
+		return ignTypes.Config{}, r
+	}
+	return types.ConvertAs2_0(in, p, ast)
 }

--- a/vendor/github.com/coreos/container-linux-config-transpiler/config/platform/platform.go
+++ b/vendor/github.com/coreos/container-linux-config-transpiler/config/platform/platform.go
@@ -1,0 +1,44 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platform
+
+const (
+	Azure             = "azure"
+	DO                = "digitalocean"
+	EC2               = "ec2"
+	GCE               = "gce"
+	Packet            = "packet"
+	OpenStackMetadata = "openstack-metadata"
+	VagrantVirtualbox = "vagrant-virtualbox"
+)
+
+var Platforms = []string{
+	Azure,
+	DO,
+	EC2,
+	GCE,
+	Packet,
+	OpenStackMetadata,
+	VagrantVirtualbox,
+}
+
+func IsSupportedPlatform(platform string) bool {
+	for _, supportedPlatform := range Platforms {
+		if supportedPlatform == platform {
+			return true
+		}
+	}
+	return platform == ""
+}

--- a/vendor/github.com/coreos/container-linux-config-transpiler/config/templating/templating.go
+++ b/vendor/github.com/coreos/container-linux-config-transpiler/config/templating/templating.go
@@ -17,32 +17,14 @@ package templating
 import (
 	"fmt"
 	"strings"
+
+	"github.com/coreos/container-linux-config-transpiler/config/platform"
 )
 
 var (
 	ErrUnknownPlatform = fmt.Errorf("unsupported platform")
 	ErrUnknownField    = fmt.Errorf("unknown field")
 )
-
-const (
-	PlatformAzure             = "azure"
-	PlatformDO                = "digitalocean"
-	PlatformEC2               = "ec2"
-	PlatformGCE               = "gce"
-	PlatformPacket            = "packet"
-	PlatformOpenStackMetadata = "openstack-metadata"
-	PlatformVagrantVirtualbox = "vagrant-virtualbox"
-)
-
-var Platforms = []string{
-	PlatformAzure,
-	PlatformDO,
-	PlatformEC2,
-	PlatformGCE,
-	PlatformPacket,
-	PlatformOpenStackMetadata,
-	PlatformVagrantVirtualbox,
-}
 
 const (
 	fieldHostname  = "HOSTNAME"
@@ -53,12 +35,12 @@ const (
 )
 
 var platformTemplatingMap = map[string]map[string]string{
-	PlatformAzure: {
+	platform.Azure: {
 		// TODO: is this right?
 		fieldV4Private: "COREOS_AZURE_IPV4_DYNAMIC",
 		fieldV4Public:  "COREOS_AZURE_IPV4_VIRTUAL",
 	},
-	PlatformDO: {
+	platform.DO: {
 		// TODO: unused: COREOS_DIGITALOCEAN_IPV4_ANCHOR_0
 		fieldHostname:  "COREOS_DIGITALOCEAN_HOSTNAME",
 		fieldV4Private: "COREOS_DIGITALOCEAN_IPV4_PRIVATE_0",
@@ -66,28 +48,28 @@ var platformTemplatingMap = map[string]map[string]string{
 		fieldV6Private: "COREOS_DIGITALOCEAN_IPV6_PRIVATE_0",
 		fieldV6Public:  "COREOS_DIGITALOCEAN_IPV6_PUBLIC_0",
 	},
-	PlatformEC2: {
+	platform.EC2: {
 		fieldHostname:  "COREOS_EC2_HOSTNAME",
 		fieldV4Private: "COREOS_EC2_IPV4_LOCAL",
 		fieldV4Public:  "COREOS_EC2_IPV4_PUBLIC",
 	},
-	PlatformGCE: {
+	platform.GCE: {
 		fieldHostname:  "COREOS_GCE_HOSTNAME",
 		fieldV4Private: "COREOS_GCE_IP_LOCAL_0",
 		fieldV4Public:  "COREOS_GCE_IP_EXTERNAL_0",
 	},
-	PlatformPacket: {
+	platform.Packet: {
 		fieldHostname:  "COREOS_PACKET_HOSTNAME",
 		fieldV4Private: "COREOS_PACKET_IPV4_PRIVATE_0",
 		fieldV4Public:  "COREOS_PACKET_IPV4_PUBLIC_0",
 		fieldV6Public:  "COREOS_PACKET_IPV6_PUBLIC_0",
 	},
-	PlatformOpenStackMetadata: {
+	platform.OpenStackMetadata: {
 		fieldHostname:  "COREOS_OPENSTACK_HOSTNAME",
 		fieldV4Private: "COREOS_OPENSTACK_IPV4_LOCAL",
 		fieldV4Public:  "COREOS_OPENSTACK_IPV4_PUBLIC",
 	},
-	PlatformVagrantVirtualbox: {
+	platform.VagrantVirtualbox: {
 		fieldHostname:  "COREOS_VAGRANT_VIRTUALBOX_HOSTNAME",
 		fieldV4Private: "COREOS_VAGRANT_VIRTUALBOX_PRIVATE_IPV4",
 	},

--- a/vendor/github.com/coreos/container-linux-config-transpiler/config/types/passwd.go
+++ b/vendor/github.com/coreos/container-linux-config-transpiler/config/types/passwd.go
@@ -55,6 +55,9 @@ type Group struct {
 func init() {
 	register2_0(func(in Config, ast validate.AstNode, out ignTypes.Config, platform string) (ignTypes.Config, report.Report, validate.AstNode) {
 		for _, user := range in.Passwd.Users {
+			if user.Name != "core" && user.Create == nil {
+				user.Create = &UserCreate{}
+			}
 			newUser := ignTypes.User{
 				Name:              user.Name,
 				PasswordHash:      user.PasswordHash,


### PR DESCRIPTION
This updates the BaseCluster to know what ctplatform it's for, and for
each of those platforms render Container Linux configs appropriately.

Platforms CT does not have specific support for pass in the empty
string, which results in them working fine for any CLCs that do not use
special variables.

These platforms can still use CLCs for userdata as long as they don't
reference special platform-specific variables.

cc @bgilbert 