### PR TITLE
kola/etcd: add etcd-member and etcdctl tests

### DIFF
--- a/platform/conf/conf.go
+++ b/platform/conf/conf.go
@@ -194,7 +194,7 @@ func (u *UserData) Render(ctPlatform string) (*Conf, error) {
 
 		ignc, report := ct.ConvertAs2_0(clc, ctPlatform, ast)
 		if report.IsFatal() {
-			return nil, fmt.Errorf("rendering Container Linux config: %s", report)
+			return nil, fmt.Errorf("rendering Container Linux config for platform %q: %s", ctPlatform, report)
 		} else if len(report.Entries) > 0 {
 			plog.Warningf("rendering Container Linux config: %s", report)
 		}


### PR DESCRIPTION
I promised a forthcoming test in https://github.com/coreos/coreos-overlay/pull/2720#issuecomment-324794069, so here's a shot at it.

These both pass on images built off master (tested against gce). Neither passes on the current alpha due to them depending on etcdctl v3.