### PR TITLE
kola/docker: network more reliably

### DIFF
--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -444,10 +444,20 @@ func dockerNetworksReliably(c cluster.TestCluster) {
 		c.Fatal(err)
 	}
 
-	output, err := m.SSH(`seq 1 100 | xargs -i -n 1 -P 20 docker run ping sh -c 'out=$(ping -i 0.1 172.17.0.1 -w 1); if [[ "$?" != 0 ]]; then echo "{} FAIL"; echo "$out"; exit 1; else echo "{} PASS"; fi'`)
+	output, err := m.SSH(`for i in $(seq 1 100); do 
+		echo -n "$i: "
+		docker run --rm ping sh -c 'ping -i 0.2 172.17.0.1 -w 1 >/dev/null && echo PASS || echo FAIL'
+	done`)
 	if err != nil {
 		c.Fatalf("could not run 100 containers pinging the bridge: %v: %v", err, string(output))
 	}
+
+	numPass := strings.Count(string(output), "PASS")
+
+	if numPass != 100 {
+		c.Fatalf("Expected 100 passes, but output was: %s", output)
+	}
+
 }
 
 // Regression test for CVE-2016-8867


### PR DESCRIPTION
The previous xargs magic was overly complicated and, more importantly,
resulted in flakes.

This makes it pass more reliably, and still falls in-line with the
regression it was originally written to catch.