### PR TITLE
kola/harness: add nondestructive flag for tests

### DIFF
--- a/harness/suite.go
+++ b/harness/suite.go
@@ -29,6 +29,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/coreos/mantle/util"
 )
 
 const (
@@ -269,13 +271,13 @@ func (s *Suite) runTests(out, tap io.Writer) error {
 	}
 	tRunner(t, func(t *H) {
 		for name, test := range s.tests {
-			t.Run(name, test)
+			t.Run(name, test, util.BoolToPtr(false))
 		}
 		// Run catching the signal rather than the tRunner as a separate
 		// goroutine to avoid adding a goroutine during the sequential
 		// phase as this pollutes the stacktrace output when aborting.
 		go func() { <-t.signal }()
-	})
+	}, util.BoolToPtr(false))
 	if !t.ran {
 		return SuiteEmpty
 	}

--- a/kola/register/register.go
+++ b/kola/register/register.go
@@ -56,6 +56,11 @@ type Test struct {
 	// greater than or equal to EndVersion. This will be ignored if
 	// the name fully matches without globbing.
 	EndVersion semver.Version
+
+	// NonDestructive marks that a test regardless can be ran on the
+	// same CoreOS machine as other tests, and regardless of outcome
+	// will leave the machine in the same state it was received in.
+	NonDestructive bool
 }
 
 // Registered tests live here. Mapping of names to tests.

--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,19 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+func BoolToPtr(b bool) *bool {
+	return &b
+}


### PR DESCRIPTION
Adds a NonDestructive flag for tests similar to Min/MaxVersion
flags which allows a test to denote that it is safe to run on the
same machine as other non-destructive tests. Currently for a test
to properly be non-destructive they must leave the machine in the
exact state that they received it in, even in the case of an error
during the test.

These tests can still be filtered down as usual, they will just be
ran on a cluster that is shared with any other tests which require
the same cluster setup.

In the `_kola_tmp` output a symlink is created for each test which
points to the output directory for the cluster that it ran on.