### PR TITLE
tests/kubernetes: temporarily disable rkt test

### DIFF
--- a/kola/tests/kubernetes/basic.go
+++ b/kola/tests/kubernetes/basic.go
@@ -34,7 +34,6 @@ var basicTags = []string{
 // regester each tag once per runtime
 var runtimes = []string{
 	"docker",
-	"rkt",
 }
 
 func init() {


### PR DESCRIPTION
This test has known issues. Namely, kubernetes 1.3 doesn't work with new
versions of rkt (>1.25) due to re-using volume names.

Upgrading the kubernetes version should fix that specific issue, but is
a more involved process. In the meanwhile, we should disable this since
it's just flaky noise.