### PR TITLE
cork: allow repo syncing forcibly

### DIFF
--- a/cmd/cork/create.go
+++ b/cmd/cork/create.go
@@ -52,6 +52,7 @@ var (
 
 	// only for `update` command
 	allowCreate      bool
+	forceSync        bool
 	downgradeInPlace bool
 	downgradeReplace bool
 	newVersion       string
@@ -133,6 +134,8 @@ func init() {
 	updateCmd.Flags().AddFlagSet(creationFlags)
 	updateCmd.Flags().BoolVar(&allowCreate,
 		"create", false, "Create the SDK chroot if missing")
+	updateCmd.Flags().BoolVar(&forceSync,
+		"force-sync", false, "Overrwrite stale .git directories if needed")
 	updateCmd.Flags().BoolVar(&downgradeInPlace,
 		"downgrade-in-place", false,
 		"Allow in-place downgrades of SDK chroot")
@@ -247,7 +250,7 @@ func updateRepo() {
 		}
 	}
 
-	if err := sdk.RepoSync(chrootName); err != nil {
+	if err := sdk.RepoSync(chrootName, forceSync); err != nil {
 		plog.Fatalf("repo sync failed: %v", err)
 	}
 

--- a/sdk/repo.go
+++ b/sdk/repo.go
@@ -148,8 +148,10 @@ func RepoVerifyTag(branch string) error {
 	return tag.Run()
 }
 
-func RepoSync(chroot string) error {
-	return enterChroot(
-		chroot, chrootRepoRoot, "--",
-		"repo", "sync", "--no-clone-bundle")
+func RepoSync(chroot string, force bool) error {
+	args := []string{"--", "repo", "sync", "--no-clone-bundle"}
+	if force {
+		args = append(args, "--force-sync")
+	}
+	return enterChroot(chroot, chrootRepoRoot, args...)
 }


### PR DESCRIPTION
This is helpful for, e.g., automated builders which are fine with
discarding git repos.