### PR TITLE
Revert "cmd/plume: Upload raw images to AWS"

### DIFF
--- a/cmd/plume/README.md
+++ b/cmd/plume/README.md
@@ -16,7 +16,7 @@ for board in amd64-usr arm64-usr; do
     ./build_image --board=$board --upload --sign="$KEYID" prod
 done
 # amd64-usr only
-for format in ami azure gce; do
+for format in ami_vmdk azure gce; do
     ./image_to_vm.sh --prod_image --board=amd64-usr --format=$format --upload --sign="$KEYID"
 done
 ```

--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -392,7 +392,7 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imageName, 
 		}
 
 		plog.Printf("Creating EBS snapshot...")
-		snapshot, err = api.CreateSnapshot(imageName, s3ObjectURL, aws.EC2ImageFormatRaw)
+		snapshot, err = api.CreateSnapshot(imageName, s3ObjectURL, aws.EC2ImageFormatVmdk)
 		if err != nil {
 			return nil, nil, fmt.Errorf("unable to create snapshot: %v", err)
 		}
@@ -574,7 +574,7 @@ func awsUploadAmiLists(ctx context.Context, bucket *storage.Bucket, spec *channe
 
 // awsPreRelease runs everything necessary to prepare a CoreOS release for AWS.
 //
-// This includes uploading the ami image to an S3 bucket in each EC2
+// This includes uploading the ami_vmdk image to an S3 bucket in each EC2
 // partition, creating HVM and PV AMIs, and replicating the AMIs to each
 // region.
 func awsPreRelease(ctx context.Context, client *http.Client, src *storage.Bucket, spec *channelSpec, imageInfo *imageInfo) error {

--- a/cmd/plume/specs.go
+++ b/cmd/plume/specs.go
@@ -179,7 +179,7 @@ var (
 				BaseName:        "ContainerLinuxUser",
 				BaseDescription: "CoreOS Container Linux development image",
 				Prefix:          "coreos_production_ami_",
-				Image:           "coreos_production_ami_image.bin.bz2",
+				Image:           "coreos_production_ami_vmdk_image.vmdk.bz2",
 				Partitions: []awsPartitionSpec{
 					awsPartitionSpec{
 						Name:         "AWS West",
@@ -222,7 +222,7 @@ var (
 				BaseName:        "ContainerLinuxDeveloper",
 				BaseDescription: "CoreOS Container Linux development image",
 				Prefix:          "coreos_production_ami_",
-				Image:           "coreos_production_ami_image.bin.bz2",
+				Image:           "coreos_production_ami_vmdk_image.vmdk.bz2",
 				Partitions: []awsPartitionSpec{
 					awsPartitionSpec{
 						Name:         "AWS West",
@@ -292,7 +292,7 @@ var (
 				BaseName:        "CoreOS",
 				BaseDescription: "CoreOS Container Linux",
 				Prefix:          "coreos_production_ami_",
-				Image:           "coreos_production_ami_image.bin.bz2",
+				Image:           "coreos_production_ami_vmdk_image.vmdk.bz2",
 				Partitions:      awsPartitions,
 			},
 		},
@@ -347,7 +347,7 @@ var (
 				BaseName:        "CoreOS",
 				BaseDescription: "CoreOS Container Linux",
 				Prefix:          "coreos_production_ami_",
-				Image:           "coreos_production_ami_image.bin.bz2",
+				Image:           "coreos_production_ami_vmdk_image.vmdk.bz2",
 				Partitions:      awsPartitions,
 			},
 		},
@@ -392,7 +392,7 @@ var (
 				BaseName:        "CoreOS",
 				BaseDescription: "CoreOS Container Linux",
 				Prefix:          "coreos_production_ami_",
-				Image:           "coreos_production_ami_image.bin.bz2",
+				Image:           "coreos_production_ami_vmdk_image.vmdk.bz2",
 				Partitions:      awsPartitions,
 			},
 		},


### PR DESCRIPTION
VMDKs appear to work again.

This reverts commit 28758ce7449b324680095e7605b5fd61973c9d81.