### PR TITLE
cmd/plume: Change AMI BaseName in user and developer channels

### DIFF
--- a/cmd/plume/specs.go
+++ b/cmd/plume/specs.go
@@ -176,7 +176,7 @@ var (
 				Limit:       2,
 			},
 			AWS: awsSpec{
-				BaseName:        "ContainerLinuxUser",
+				BaseName:        "Container-Linux",
 				BaseDescription: "CoreOS Container Linux development image",
 				Prefix:          "coreos_production_ami_",
 				Image:           "coreos_production_ami_vmdk_image.vmdk.bz2",
@@ -219,7 +219,7 @@ var (
 				Limit:       25,
 			},
 			AWS: awsSpec{
-				BaseName:        "ContainerLinuxDeveloper",
+				BaseName:        "Container-Linux",
 				BaseDescription: "CoreOS Container Linux development image",
 				Prefix:          "coreos_production_ami_",
 				Image:           "coreos_production_ami_vmdk_image.vmdk.bz2",


### PR DESCRIPTION
The channel name is appended to the BaseName, so we were getting `ContainerLinuxUser-user` and `ContainerLinuxDeveloper-developer`.