### PR TITLE
kola/tests/docker: Drop torcx MinVersion to 1520

### DIFF
--- a/kola/tests/docker/torcx_manifest_pkgs.go
+++ b/kola/tests/docker/torcx_manifest_pkgs.go
@@ -36,7 +36,7 @@ func init() {
 		Name:             "docker.torcx-manifest-pkgs",
 		ExcludePlatforms: []string{"qemu"}, // Downloads torcx packages
 		// the first version torcx manifests were shipped
-		MinVersion: semver.Version{Major: 1535},
+		MinVersion: semver.Version{Major: 1520},
 	})
 }
 


### PR DESCRIPTION
The manifest changes were backported to 1520 to make it to stable.