### PR TITLE
kola/tests/docker: Remove /var/lib/docker before changing versions

### DIFF
--- a/kola/tests/docker/torcx_manifest_pkgs.go
+++ b/kola/tests/docker/torcx_manifest_pkgs.go
@@ -144,6 +144,9 @@ echo "docker" | sudo tee /etc/torcx/next-profile
 		if err := m.Reboot(); err != nil {
 			c.Fatalf("could not reboot: %v", err)
 		}
+		if _, err := m.SSH(`sudo rm -rf /var/lib/docker`); err != nil {
+			c.Fatalf("could not wipe /var/lib/docker: %v", err)
+		}
 		currentVersion, err := m.SSH(`jq -r '.value.images[] | select(.name == "docker").reference' /run/torcx/profile.json`)
 		if err != nil {
 			c.Fatalf("could not get current docker ref: %v", err)


### PR DESCRIPTION
Docker 17.* attempts to use an existing graphdriver by default, but the test expects its fallback "overlay2" driver.  When a system is booted on 1.12, it will be using "overlay", so the test fails when it reboots into 17.06 and still has "overlay".

This wipes out the /var/lib/docker directory before starting the new version after reboot, so Docker 17.06 will start using the "overlay2" driver.  This effectively changes the test to not be concerned about testing in-place Docker upgrades, rather it is just reusing the same system to test different versions for efficiency.