### PR TITLE
cmd/kola: make -s the default for kola spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ runs any tests whose registered names matches a glob pattern.
 The list command lists all of the available tests.
 
 ### kola spawn
-The spawn command launches Container Linux instances. Use `-s` to open a shell on
-the spawned instance.
+The spawn command launches Container Linux instances.
 
 ### kola mkimage
 The mkimage command creates a copy of the input image with its primary console set

--- a/cmd/kola/spawn.go
+++ b/cmd/kola/spawn.go
@@ -47,7 +47,7 @@ var (
 func init() {
 	cmdSpawn.Flags().IntVarP(&spawnNodeCount, "nodecount", "c", 1, "number of nodes to spawn")
 	cmdSpawn.Flags().StringVarP(&spawnUserData, "userdata", "u", "", "userdata to pass to the instances")
-	cmdSpawn.Flags().BoolVarP(&spawnShell, "shell", "s", false, "spawn a shell in an instance before exiting")
+	cmdSpawn.Flags().BoolVarP(&spawnShell, "shell", "s", true, "spawn a shell in an instance before exiting")
 	cmdSpawn.Flags().BoolVarP(&spawnRemove, "remove", "r", true, "remove instances after shell exits")
 	cmdSpawn.Flags().BoolVarP(&spawnVerbose, "verbose", "v", false, "output information about spawned instances")
 	cmdSpawn.Flags().StringVar(&spawnMachineOptions, "qemu-options", "", "experimental: path to QEMU machine options json")


### PR DESCRIPTION
Users seldom want to start a machine and then immediately terminate it.