### PR TITLE
Introduce SSH method which handles stderr better, use it in all tests

### DIFF
--- a/cmd/kola/bootchart.go
+++ b/cmd/kola/bootchart.go
@@ -72,9 +72,9 @@ func runBootchart(cmd *cobra.Command, args []string) {
 	}
 	defer m.Destroy()
 
-	out, err := m.SSH("systemd-analyze plot")
+	out, stderr, err := m.NewSSH("systemd-analyze plot")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "SSH failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "SSH failed: %v: %s\n", err, stderr)
 		os.Exit(1)
 	}
 

--- a/cmd/kola/bootchart.go
+++ b/cmd/kola/bootchart.go
@@ -72,7 +72,7 @@ func runBootchart(cmd *cobra.Command, args []string) {
 	}
 	defer m.Destroy()
 
-	out, stderr, err := m.NewSSH("systemd-analyze plot")
+	out, stderr, err := m.SSH("systemd-analyze plot")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "SSH failed: %v: %s\n", err, stderr)
 		os.Exit(1)

--- a/cmd/kola/updatepayload.go
+++ b/cmd/kola/updatepayload.go
@@ -177,7 +177,7 @@ func runUpdateTest() error {
 	}
 
 	// Invalidate USR-A to ensure the update is legit.
-	if out, stderr, err := m.NewSSH("sudo coreos-setgoodroot && " +
+	if out, stderr, err := m.SSH("sudo coreos-setgoodroot && " +
 		"sudo wipefs /dev/disk/by-partlabel/USR-A"); err != nil {
 		return fmt.Errorf("invalidating USR-A failed: %s: %v: %s", out, err, stderr)
 	}
@@ -198,7 +198,7 @@ func tryUpdate(m platform.Machine) error {
 	plog.Infof("Triggering update_engine")
 
 	/* trigger update, monitor the progress. */
-	out, stderr, err := m.NewSSH("update_engine_client -check_for_update")
+	out, stderr, err := m.SSH("update_engine_client -check_for_update")
 	if err != nil {
 		return fmt.Errorf("Executing update_engine_client failed: %v: %v: %s", out, err, stderr)
 	}
@@ -208,7 +208,7 @@ func tryUpdate(m platform.Machine) error {
 	for status != "UPDATE_STATUS_UPDATED_NEED_REBOOT" && time.Since(start) < updateTimeout {
 		time.Sleep(10 * time.Second)
 
-		envs, stderr, err := m.NewSSH("update_engine_client -status 2>/dev/null")
+		envs, stderr, err := m.SSH("update_engine_client -status 2>/dev/null")
 		if err != nil {
 			return fmt.Errorf("checking status failed: %v: %s", err, stderr)
 		}
@@ -283,7 +283,7 @@ func checkUsrB(m platform.Machine) error {
 // checkUsrPartition inspects /proc/cmdline of the machine, looking for the
 // expected partition mounted at /usr.
 func checkUsrPartition(m platform.Machine, accept []string) error {
-	out, stderr, err := m.NewSSH("cat /proc/cmdline")
+	out, stderr, err := m.SSH("cat /proc/cmdline")
 	if err != nil {
 		return fmt.Errorf("cat /proc/cmdline: %v: %v: %s", out, err, stderr)
 	}

--- a/cmd/kola/updatepayload.go
+++ b/cmd/kola/updatepayload.go
@@ -177,9 +177,9 @@ func runUpdateTest() error {
 	}
 
 	// Invalidate USR-A to ensure the update is legit.
-	if out, err := m.SSH("sudo coreos-setgoodroot && " +
+	if out, stderr, err := m.NewSSH("sudo coreos-setgoodroot && " +
 		"sudo wipefs /dev/disk/by-partlabel/USR-A"); err != nil {
-		return fmt.Errorf("invalidating USR-A failed: %v: %v", out, err)
+		return fmt.Errorf("invalidating USR-A failed: %s: %v: %s", out, err, stderr)
 	}
 
 	if err := tryUpdate(m); err != nil {
@@ -198,9 +198,9 @@ func tryUpdate(m platform.Machine) error {
 	plog.Infof("Triggering update_engine")
 
 	/* trigger update, monitor the progress. */
-	out, err := m.SSH("update_engine_client -check_for_update")
+	out, stderr, err := m.NewSSH("update_engine_client -check_for_update")
 	if err != nil {
-		return fmt.Errorf("Executing update_engine_client failed: %v: %v", out, err)
+		return fmt.Errorf("Executing update_engine_client failed: %v: %v: %s", out, err, stderr)
 	}
 
 	start := time.Now()
@@ -208,9 +208,9 @@ func tryUpdate(m platform.Machine) error {
 	for status != "UPDATE_STATUS_UPDATED_NEED_REBOOT" && time.Since(start) < updateTimeout {
 		time.Sleep(10 * time.Second)
 
-		envs, err := m.SSH("update_engine_client -status 2>/dev/null")
+		envs, stderr, err := m.NewSSH("update_engine_client -status 2>/dev/null")
 		if err != nil {
-			return fmt.Errorf("checking status failed: %v", err)
+			return fmt.Errorf("checking status failed: %v: %s", err, stderr)
 		}
 
 		em := splitNewlineEnv(string(envs))
@@ -283,9 +283,9 @@ func checkUsrB(m platform.Machine) error {
 // checkUsrPartition inspects /proc/cmdline of the machine, looking for the
 // expected partition mounted at /usr.
 func checkUsrPartition(m platform.Machine, accept []string) error {
-	out, err := m.SSH("cat /proc/cmdline")
+	out, stderr, err := m.NewSSH("cat /proc/cmdline")
 	if err != nil {
-		return fmt.Errorf("cat /proc/cmdline: %v: %v", out, err)
+		return fmt.Errorf("cat /proc/cmdline: %v: %v: %s", out, err, stderr)
 	}
 	plog.Debugf("Kernel cmdline: %s", out)
 

--- a/kola/cluster/cluster.go
+++ b/kola/cluster/cluster.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/coreos/mantle/harness"
 	"github.com/coreos/mantle/platform"
@@ -89,4 +90,20 @@ func (t *TestCluster) DropFile(localPath string) error {
 		}
 	}
 	return nil
+}
+
+// SSH runs a ssh command on the given machine in the cluster. It differs from
+// Machine.SSH in that stderr is written to the test's output as a 'Log' line.
+// This ensures the output will be correctly accumulated under the correct
+// test.
+func (t *TestCluster) SSH(m platform.Machine, cmd string) ([]byte, error) {
+	stdout, stderr, err := m.NewSSH(cmd)
+
+	if len(stderr) > 0 {
+		for _, line := range strings.Split(string(stderr), "\n") {
+			t.Log(line)
+		}
+	}
+
+	return stdout, err
 }

--- a/kola/cluster/cluster.go
+++ b/kola/cluster/cluster.go
@@ -97,7 +97,7 @@ func (t *TestCluster) DropFile(localPath string) error {
 // This ensures the output will be correctly accumulated under the correct
 // test.
 func (t *TestCluster) SSH(m platform.Machine, cmd string) ([]byte, error) {
-	stdout, stderr, err := m.NewSSH(cmd)
+	stdout, stderr, err := m.SSH(cmd)
 
 	if len(stderr) > 0 {
 		for _, line := range strings.Split(string(stderr), "\n") {

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -307,7 +307,7 @@ func getClusterSemver(pltfrm, outputDir string) (*semver.Version, error) {
 		return nil, fmt.Errorf("creating new machine for semver check: %v", err)
 	}
 
-	out, stderr, err := m.NewSSH("grep ^VERSION_ID= /etc/os-release")
+	out, stderr, err := m.SSH("grep ^VERSION_ID= /etc/os-release")
 	if err != nil {
 		return nil, fmt.Errorf("parsing /etc/os-release: %v: %s", err, stderr)
 	}

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -307,9 +307,9 @@ func getClusterSemver(pltfrm, outputDir string) (*semver.Version, error) {
 		return nil, fmt.Errorf("creating new machine for semver check: %v", err)
 	}
 
-	out, err := m.SSH("grep ^VERSION_ID= /etc/os-release")
+	out, stderr, err := m.NewSSH("grep ^VERSION_ID= /etc/os-release")
 	if err != nil {
-		return nil, fmt.Errorf("parsing /etc/os-release: %v", err)
+		return nil, fmt.Errorf("parsing /etc/os-release: %v: %s", err, stderr)
 	}
 
 	version, err := semver.NewVersion(strings.Split(string(out), "=")[1])

--- a/kola/tests/coretest/testgroupglue.go
+++ b/kola/tests/coretest/testgroupglue.go
@@ -16,7 +16,7 @@ func LocalTests(c cluster.TestCluster) {
 // run clustering based tests
 func ClusterTests(c cluster.TestCluster) {
 	// wait for etcd to come up
-	if err := etcd.GetClusterHealth(c.Machines()[0], len(c.Machines())); err != nil {
+	if err := etcd.GetClusterHealth(c, c.Machines()[0], len(c.Machines())); err != nil {
 		c.Fatal(err)
 	}
 

--- a/kola/tests/docker/torcx_docker_flag.go
+++ b/kola/tests/docker/torcx_docker_flag.go
@@ -60,13 +60,13 @@ func dockerTorcxFlagFile(c cluster.TestCluster) {
 	checkTorcxDockerVersions(c, m, `^1\.12$`, `^1\.12\.`)
 
 	// flag=no
-	if _, err := m.SSH("echo no | sudo tee /etc/coreos/docker-1.12"); err != nil {
+	if _, err := c.SSH(m, "echo no | sudo tee /etc/coreos/docker-1.12"); err != nil {
 		c.Fatalf("couldn't set docker flag to no: %s", err)
 	}
 	if err := m.Reboot(); err != nil {
 		c.Fatalf("could not reboot: %v", err)
 	}
-	if _, err := m.SSH(`sudo rm -rf /var/lib/docker`); err != nil {
+	if _, err := c.SSH(m, `sudo rm -rf /var/lib/docker`); err != nil {
 		c.Fatalf("could not wipe /var/lib/docker: %v", err)
 	}
 	checkTorcxDockerVersions(c, m, `^1[7-9]\.`, `^1[7-9]\.`)

--- a/kola/tests/docker/torcx_manifest_pkgs.go
+++ b/kola/tests/docker/torcx_manifest_pkgs.go
@@ -107,7 +107,7 @@ func dockerTorcxManifestPkgs(c cluster.TestCluster) {
 	}
 
 	// Make sure the default torcx config was fine
-	if _, err := m.SSH(`docker version`); err != nil {
+	if _, err := c.SSH(m, `docker version`); err != nil {
 		c.Fatalf("could not run docker: %v", err)
 	}
 
@@ -122,7 +122,7 @@ func dockerTorcxManifestPkgs(c cluster.TestCluster) {
 
 func testPackageVersion(m platform.Machine, c cluster.TestCluster, version string) {
 	c.Run("install-torcx-profile", func(c cluster.TestCluster) {
-		_, err := m.SSH(fmt.Sprintf(`sudo tee /etc/torcx/profiles/docker.json <<EOF
+		_, err := c.SSH(m, fmt.Sprintf(`sudo tee /etc/torcx/profiles/docker.json <<EOF
 {
   "kind": "profile-manifest-v0",
   "value": {
@@ -144,7 +144,7 @@ echo "docker" | sudo tee /etc/torcx/next-profile
 		if err := m.Reboot(); err != nil {
 			c.Fatalf("could not reboot: %v", err)
 		}
-		if _, err := m.SSH(`sudo rm -rf /var/lib/docker`); err != nil {
+		if _, err := c.SSH(m, `sudo rm -rf /var/lib/docker`); err != nil {
 			c.Fatalf("could not wipe /var/lib/docker: %v", err)
 		}
 		currentVersion := getTorcxDockerReference(c, m)
@@ -165,7 +165,7 @@ echo "docker" | sudo tee /etc/torcx/next-profile
 }
 
 func getTorcxDockerReference(c cluster.TestCluster, m platform.Machine) string {
-	ver, err := m.SSH(`jq -r '.value.images[] | select(.name == "docker").reference' /run/torcx/profile.json`)
+	ver, err := c.SSH(m, `jq -r '.value.images[] | select(.name == "docker").reference' /run/torcx/profile.json`)
 	if err != nil {
 		c.Fatalf("could not get current docker ref: %v", err)
 	}
@@ -173,7 +173,7 @@ func getTorcxDockerReference(c cluster.TestCluster, m platform.Machine) string {
 }
 
 func getDockerServerVersion(c cluster.TestCluster, m platform.Machine) string {
-	ver, err := m.SSH(`curl -s --unix-socket /var/run/docker.sock http://docker/v1.24/info | jq -r '.ServerVersion'`)
+	ver, err := c.SSH(m, `curl -s --unix-socket /var/run/docker.sock http://docker/v1.24/info | jq -r '.ServerVersion'`)
 	if err != nil {
 		c.Fatalf("could not get docker version: %v", err)
 	}

--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -59,7 +59,7 @@ func Discovery(c cluster.TestCluster) {
 	var err error
 
 	// NOTE(pb): this check makes the next code somewhat redundant
-	if err = GetClusterHealth(c.Machines()[0], len(c.Machines())); err != nil {
+	if err = GetClusterHealth(c, c.Machines()[0], len(c.Machines())); err != nil {
 		c.Fatalf("discovery failed cluster-health check: %v", err)
 	}
 

--- a/kola/tests/fleet/fleet.go
+++ b/kola/tests/fleet/fleet.go
@@ -138,16 +138,16 @@ func Proxy(c cluster.TestCluster) {
 	defer proxy.Destroy()
 
 	// Wait for all etcd cluster nodes to be ready.
-	if err = etcd.GetClusterHealth(master, 1); err != nil {
+	if err = etcd.GetClusterHealth(c, master, 1); err != nil {
 		c.Fatalf("cluster health master: %v", err)
 	}
-	if err = etcd.GetClusterHealth(proxy, 1); err != nil {
+	if err = etcd.GetClusterHealth(c, proxy, 1); err != nil {
 		c.Fatalf("cluster health proxy: %v", err)
 	}
 
 	// Several seconds can pass after etcd is ready before fleet notices.
 	fleetStart := func() error {
-		_, err = proxy.SSH("fleetctl start /home/core/hello.service")
+		_, err = c.SSH(proxy, "fleetctl start /home/core/hello.service")
 		return err
 	}
 	if err := util.Retry(5, 5*time.Second, fleetStart); err != nil {
@@ -155,7 +155,7 @@ func Proxy(c cluster.TestCluster) {
 	}
 
 	fleetList := func() error {
-		status, err := proxy.SSH("fleetctl list-units -l -fields active -no-legend")
+		status, err := c.SSH(proxy, "fleetctl list-units -l -fields active -no-legend")
 		if err != nil {
 			return err
 		}

--- a/kola/tests/ignition/execution.go
+++ b/kola/tests/ignition/execution.go
@@ -68,7 +68,7 @@ func runsOnce(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
 	// remove file created by Ignition; fail if it doesn't exist
-	_, err := m.SSH("sudo rm /etc/ignition-ran")
+	_, err := c.SSH(m, "sudo rm /etc/ignition-ran")
 	if err != nil {
 		c.Fatalf("Couldn't remove flag file: %v", err)
 	}
@@ -79,7 +79,7 @@ func runsOnce(c cluster.TestCluster) {
 	}
 
 	// make sure file hasn't been recreated
-	_, err = m.SSH("test -e /etc/ignition-ran")
+	_, err = c.SSH(m, "test -e /etc/ignition-ran")
 	if err == nil {
 		c.Fatalf("Flag file recreated after reboot")
 	}

--- a/kola/tests/ignition/filesystem.go
+++ b/kola/tests/ignition/filesystem.go
@@ -309,7 +309,7 @@ func swapUsrB(c cluster.TestCluster) {
 func testFormatted(c cluster.TestCluster, fs, label string) {
 	m := c.Machines()[0]
 
-	out, err := m.SSH("sudo blkid -s UUID -o value /dev/disk/by-label/" + label)
+	out, err := c.SSH(m, "sudo blkid -s UUID -o value /dev/disk/by-label/"+label)
 	if err != nil {
 		c.Fatalf("failed to run blkid: %s: %v", out, err)
 	}
@@ -321,7 +321,7 @@ func testFormatted(c cluster.TestCluster, fs, label string) {
 		c.Fatalf("filesystem wasn't correctly formatted:\n%s", out)
 	}
 
-	out, err = m.SSH("sudo blkid -s TYPE -o value /dev/disk/by-label/" + label)
+	out, err = c.SSH(m, "sudo blkid -s TYPE -o value /dev/disk/by-label/"+label)
 	if err != nil {
 		c.Fatalf("failed to run blkid: %s: %v", out, err)
 	}
@@ -335,7 +335,7 @@ func testRoot(c cluster.TestCluster, fs string) {
 
 	testFormatted(c, fs, "ROOT")
 
-	out, err := m.SSH("findmnt --noheadings --output FSTYPE --target /")
+	out, err := c.SSH(m, "findmnt --noheadings --output FSTYPE --target /")
 	if err != nil {
 		c.Fatalf("failed to run findmnt: %s: %v", out, err)
 	}
@@ -349,7 +349,7 @@ func ext4CheckExisting(c cluster.TestCluster) {
 
 	// Redirect /dev/null to stdin so isatty(stdin) fails and the -p flag can be
 	// checked
-	out, err := m.SSH("sudo mkfs.ext4 -p /dev/disk/by-partlabel/ROOT < /dev/null")
+	out, err := c.SSH(m, "sudo mkfs.ext4 -p /dev/disk/by-partlabel/ROOT < /dev/null")
 	if err == nil {
 		c.Fatalf("mkfs.ext4 returned sucessfully when it should have failed")
 	}
@@ -363,7 +363,7 @@ func ext4CheckExisting2_1(c cluster.TestCluster) {
 	m1 := c.Machines()[0]
 
 	// Get root filesystem UUID
-	out, err := m1.SSH("sudo blkid /dev/disk/by-partlabel/ROOT -s UUID -o value")
+	out, err := c.SSH(m1, "sudo blkid /dev/disk/by-partlabel/ROOT -s UUID -o value")
 	if err != nil {
 		c.Fatalf("Couldn't get m1 filesystem UUID: %v", err)
 	}
@@ -376,7 +376,7 @@ func ext4CheckExisting2_1(c cluster.TestCluster) {
 	}
 
 	// Verify UUID hasn't changed
-	out, err = m2.SSH("sudo blkid /dev/disk/by-partlabel/ROOT -s UUID -o value")
+	out, err = c.SSH(m2, "sudo blkid /dev/disk/by-partlabel/ROOT -s UUID -o value")
 	if err != nil {
 		c.Fatalf("Couldn't get m2 filesystem UUID: %v", err)
 	}

--- a/kola/tests/ignition/passwd.go
+++ b/kola/tests/ignition/passwd.go
@@ -168,12 +168,12 @@ func groups(c cluster.TestCluster) {
 	}
 
 	for _, t := range tests {
-		if out, err := getent(m, "group", t.group); err != nil {
+		if out, err := getent(c, m, "group", t.group); err != nil {
 			c.Fatal(err)
 		} else if out != t.groupRecord {
 			c.Errorf("%q wasn't correctly created: got %q, expected %q", t.group, out, t.groupRecord)
 		}
-		if out, err := getent(m, "gshadow", t.group); err != nil {
+		if out, err := getent(c, m, "gshadow", t.group); err != nil {
 			c.Fatal(err)
 		} else if out != t.gshadowRecord {
 			c.Errorf("%q wasn't correctly created: got %q, expected %q", t.group, out, t.gshadowRecord)
@@ -207,13 +207,13 @@ func users(c cluster.TestCluster) {
 	}
 
 	for _, t := range tests {
-		if out, err := getent(m, "passwd", t.user); err != nil {
+		if out, err := getent(c, m, "passwd", t.user); err != nil {
 			c.Fatal(err)
 		} else if out != t.passwdRecord {
 			c.Errorf("%q wasn't correctly created: got %q, expected %q", t.user, out, t.passwdRecord)
 		}
 
-		out, err := getent(m, "shadow", t.user)
+		out, err := getent(c, m, "shadow", t.user)
 		if err != nil {
 			c.Fatal(err)
 		}
@@ -229,9 +229,9 @@ func users(c cluster.TestCluster) {
 	}
 }
 
-func getent(m platform.Machine, database string, entry string) (string, error) {
+func getent(c cluster.TestCluster, m platform.Machine, database string, entry string) (string, error) {
 	cmd := fmt.Sprintf("sudo getent %s %s", database, entry)
-	if out, err := m.SSH(cmd); err == nil {
+	if out, err := c.SSH(m, cmd); err == nil {
 		return string(out), nil
 	} else {
 		return "", fmt.Errorf("failed to run `%s`: %s: %v", cmd, out, err)

--- a/kola/tests/ignition/sethostname.go
+++ b/kola/tests/ignition/sethostname.go
@@ -76,7 +76,7 @@ func init() {
 func setHostname(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
-	out, err := m.SSH("hostnamectl")
+	out, err := c.SSH(m, "hostnamectl")
 	if err != nil {
 		c.Fatalf("failed to run hostnamectl: %s: %v", out, err)
 	}

--- a/kola/tests/kubernetes/kubelet_wrapper.go
+++ b/kola/tests/kubernetes/kubelet_wrapper.go
@@ -60,10 +60,10 @@ func testKubeletWrapperVarLog(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
 	// Wait up to 10 minutes the version
-	_, err := m.SSH(`
+	_, err := c.SSH(m, `
 	for i in {1..120}; do 
 		sleep 5
-		if journalctl -u kubelet -o cat | grep '` + versionOutput + `' &>/dev/null; then
+		if journalctl -u kubelet -o cat | grep '`+versionOutput+`' &>/dev/null; then
 			exit 0
 		fi
 	done

--- a/kola/tests/metadata/contents.go
+++ b/kola/tests/metadata/contents.go
@@ -80,7 +80,7 @@ func verifyPacket(c cluster.TestCluster) {
 func verify(c cluster.TestCluster, keys ...string) {
 	m := c.Machines()[0]
 
-	out, err := m.SSH("cat /run/metadata/coreos")
+	out, err := c.SSH(m, "cat /run/metadata/coreos")
 	if err != nil {
 		c.Fatalf("failed to cat /run/metadata/coreos: %s: %v", out, err)
 	}

--- a/kola/tests/misc/files.go
+++ b/kola/tests/misc/files.go
@@ -46,7 +46,7 @@ func sugidFiles(c cluster.TestCluster, validfiles []string, mode string) {
 
 	command := fmt.Sprintf("sudo find / -ignore_readdir_race -path /sys -prune -o -path /proc -prune -o -path /var/lib/rkt -prune -o -type f -perm -%v -print", mode)
 
-	output, err := m.SSH(command)
+	output, err := c.SSH(m, command)
 	if err != nil {
 		c.Fatalf("Failed to run find: output %s, status: %v", output, err)
 	}
@@ -88,7 +88,7 @@ func DeadLinks(c cluster.TestCluster) {
 
 	command := fmt.Sprintf("sudo find / -ignore_readdir_race -path %s -prune -o -xtype l -print", strings.Join(ignore, " -prune -o -path "))
 
-	output, err := m.SSH(command)
+	output, err := c.SSH(m, command)
 	if err != nil {
 		c.Fatalf("Failed to run %v: output %s, status: %v", command, output, err)
 	}
@@ -136,7 +136,7 @@ func SGIDFiles(c cluster.TestCluster) {
 func WritableFiles(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
-	output, err := m.SSH("sudo find / -ignore_readdir_race -path /sys -prune -o -path /proc -prune -o -path /var/lib/rkt -prune -o -type f -perm -0002 -print")
+	output, err := c.SSH(m, "sudo find / -ignore_readdir_race -path /sys -prune -o -path /proc -prune -o -path /var/lib/rkt -prune -o -type f -perm -0002 -print")
 	if err != nil {
 		c.Fatalf("Failed to run find: output %s, status: %v", output, err)
 	}
@@ -149,7 +149,7 @@ func WritableFiles(c cluster.TestCluster) {
 func WritableDirs(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
-	output, err := m.SSH("sudo find / -ignore_readdir_race -path /sys -prune -o -path /proc -prune -o -path /var/lib/rkt -prune -o -type d -perm -0002 -a ! -perm -1000 -print")
+	output, err := c.SSH(m, "sudo find / -ignore_readdir_race -path /sys -prune -o -path /proc -prune -o -path /var/lib/rkt -prune -o -type d -perm -0002 -a ! -perm -1000 -print")
 	if err != nil {
 		c.Fatalf("Failed to run find: output %s, status: %v", output, err)
 	}
@@ -181,7 +181,7 @@ func StickyDirs(c cluster.TestCluster) {
 
 	command := fmt.Sprintf("sudo find / -ignore_readdir_race -path %s -prune -o -type d -perm /1000 -print", strings.Join(ignore, " -prune -o -path "))
 
-	output, err := m.SSH(command)
+	output, err := c.SSH(m, command)
 	if err != nil {
 		c.Fatalf("Failed to run find: output %s, status: %v", output, err)
 	}
@@ -225,7 +225,7 @@ func Blacklist(c cluster.TestCluster) {
 
 	command := fmt.Sprintf("sudo find / -ignore_readdir_race -path %s -prune -o -path '%s' -print", strings.Join(skip, " -prune -o -path "), strings.Join(blacklist, "' -print -o -path '"))
 
-	output, err := m.SSH(command)
+	output, err := c.SSH(m, command)
 	if err != nil {
 		c.Fatalf("Failed to run find: output %s, status: %v", output, err)
 	}

--- a/kola/tests/misc/install.go
+++ b/kola/tests/misc/install.go
@@ -48,7 +48,7 @@ func InstallCloudConfig(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
 	// Verify the host name was set from the cloud-config file
-	if output, err := m.SSH("hostname"); err != nil || !bytes.Equal(output, []byte("cloud-config-worked")) {
+	if output, err := c.SSH(m, "hostname"); err != nil || !bytes.Equal(output, []byte("cloud-config-worked")) {
 		c.Fatalf("hostname: %q: %v", output, err)
 	}
 }

--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -50,7 +50,7 @@ func checkListeners(c cluster.TestCluster, expectedListeners []listener) {
 	m := c.Machines()[0]
 
 	command := "sudo netstat -plutn"
-	output, err := m.SSH(command)
+	output, err := c.SSH(m, command)
 	if err != nil {
 		c.Fatalf("Failed to run %s: output %s, status: %v", command, output, err)
 	}
@@ -123,7 +123,7 @@ func NetworkInitramfsSecondBoot(c cluster.TestCluster) {
 	m.Reboot()
 
 	// get journal lines from the current boot
-	output, err := m.SSH("journalctl -b 0 -o cat -u initrd-switch-root.target -u systemd-networkd.service")
+	output, err := c.SSH(m, "journalctl -b 0 -o cat -u initrd-switch-root.target -u systemd-networkd.service")
 	if err != nil {
 		c.Fatalf("couldn't run journalctl: %v", err)
 	}

--- a/kola/tests/misc/nfs.go
+++ b/kola/tests/misc/nfs.go
@@ -93,7 +93,7 @@ func testNFS(c cluster.TestCluster, nfsversion int) {
 	c.Log("NFS server booted.")
 
 	/* poke a file in /tmp */
-	tmp, err := m1.SSH("mktemp")
+	tmp, err := c.SSH(m1, "mktemp")
 	if err != nil {
 		c.Fatalf("Machine.SSH: %s", err)
 	}
@@ -123,7 +123,7 @@ func testNFS(c cluster.TestCluster, nfsversion int) {
 	c.Log("NFS client booted.")
 
 	checkmount := func() error {
-		status, err := m2.SSH("systemctl is-active mnt.mount")
+		status, err := c.SSH(m2, "systemctl is-active mnt.mount")
 		if err != nil || string(status) != "active" {
 			return fmt.Errorf("mnt.mount status is %q: %v", status, err)
 		}
@@ -136,7 +136,7 @@ func testNFS(c cluster.TestCluster, nfsversion int) {
 		c.Fatal(err)
 	}
 
-	_, err = m2.SSH(fmt.Sprintf("stat /mnt/%s", path.Base(string(tmp))))
+	_, err = c.SSH(m2, fmt.Sprintf("stat /mnt/%s", path.Base(string(tmp))))
 	if err != nil {
 		c.Fatalf("file %q does not exist", tmp)
 	}

--- a/kola/tests/misc/ntp.go
+++ b/kola/tests/misc/ntp.go
@@ -41,7 +41,7 @@ func NTP(c cluster.TestCluster) {
 	}
 	defer m.Destroy()
 
-	out, err := m.SSH("networkctl status eth0")
+	out, err := c.SSH(m, "networkctl status eth0")
 	if err != nil {
 		c.Fatalf("networkctl: %v", err)
 	}
@@ -50,7 +50,7 @@ func NTP(c cluster.TestCluster) {
 	}
 
 	checker := func() error {
-		out, err = m.SSH("systemctl status systemd-timesyncd.service")
+		out, err = c.SSH(m, "systemctl status systemd-timesyncd.service")
 		if err != nil {
 			return fmt.Errorf("systemctl: %v", err)
 		}

--- a/kola/tests/misc/omaha.go
+++ b/kola/tests/misc/omaha.go
@@ -66,7 +66,7 @@ func OmahaPing(c cluster.TestCluster) {
 
 	m := c.Machines()[0]
 
-	out, err := m.SSH("update_engine_client -check_for_update")
+	out, err := c.SSH(m, "update_engine_client -check_for_update")
 	if err != nil {
 		c.Fatalf("failed to execute update_engine_client -check_for_update: %v: %v", out, err)
 	}

--- a/kola/tests/misc/raid.go
+++ b/kola/tests/misc/raid.go
@@ -164,7 +164,7 @@ type blockdevice struct {
 // checkIfMountpointIsRaid will check if a given machine has a device of type
 // raid1 mounted at the given mountpoint. If it does not, the test is failed.
 func checkIfMountpointIsRaid(c cluster.TestCluster, m platform.Machine, mountpoint string) {
-	output, err := m.SSH("lsblk --json")
+	output, err := c.SSH(m, "lsblk --json")
 	if err != nil {
 		c.Fatalf("couldn't list block devices: %v", err)
 	}

--- a/kola/tests/misc/selinux.go
+++ b/kola/tests/misc/selinux.go
@@ -44,7 +44,7 @@ func SelinuxEnforce(c cluster.TestCluster) {
 		{"sudo cp --remove-destination $(readlink -f /etc/selinux/config) /etc/selinux/config", false, ""},
 		{"sudo sed -i 's/SELINUX=permissive/SELINUX=enforcing/' /etc/selinux/config", false, ""},
 	} {
-		output, err := m.SSH(cmd.cmdline)
+		output, err := c.SSH(m, cmd.cmdline)
 		if err != nil {
 			c.Fatalf("failed to run %q: output: %q status: %q", cmd.cmdline, output, err)
 		}
@@ -59,7 +59,7 @@ func SelinuxEnforce(c cluster.TestCluster) {
 		c.Fatalf("failed to reboot machine: %v", err)
 	}
 
-	output, err := m.SSH("getenforce")
+	output, err := c.SSH(m, "getenforce")
 	if err != nil {
 		c.Fatalf("failed to run \"getenforce\": output: %q status: %q", output, err)
 	}

--- a/kola/tests/misc/toolbox.go
+++ b/kola/tests/misc/toolbox.go
@@ -34,7 +34,7 @@ func init() {
 func dnfInstall(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
-	output, err := m.SSH(`toolbox sh -c 'dnf install -y tcpdump; tcpdump --version >/dev/null && echo PASS' 2>/dev/null`)
+	output, err := c.SSH(m, `toolbox sh -c 'dnf install -y tcpdump; tcpdump --version >/dev/null && echo PASS' 2>/dev/null`)
 
 	if err != nil {
 		c.Fatalf("Error running dnf install in toolbox: %v", err)

--- a/kola/tests/misc/update.go
+++ b/kola/tests/misc/update.go
@@ -106,8 +106,8 @@ func RecoverBadUsr(c cluster.TestCluster) {
 	})
 
 	// create verity metadata for USR-B
-	output, err := m.SSH("sudo veritysetup format --hash=sha256 " +
-		"--data-block-size 4096 --hash-block-size 4096 --data-blocks 25600 --hash-offset 104857600 " +
+	output, err := c.SSH(m, "sudo veritysetup format --hash=sha256 "+
+		"--data-block-size 4096 --hash-block-size 4096 --data-blocks 25600 --hash-offset 104857600 "+
 		"/dev/disk/by-partlabel/USR-B /dev/disk/by-partlabel/USR-B")
 	if err != nil {
 		c.Fatalf("Failed to run veritysetup: output %s, status: %v", output, err)
@@ -136,7 +136,7 @@ func RecoverBadUsr(c cluster.TestCluster) {
 // run commands as root
 func runAsRoot(c cluster.TestCluster, m platform.Machine, commands []string) {
 	for _, command := range commands {
-		output, err := m.SSH("sudo " + command)
+		output, err := c.SSH(m, "sudo "+command)
 		if err != nil {
 			c.Fatalf("Failed to run %q: output %s, status: %v", command, output, err)
 		}
@@ -145,7 +145,7 @@ func runAsRoot(c cluster.TestCluster, m platform.Machine, commands []string) {
 
 func assertBootedUsr(c cluster.TestCluster, m platform.Machine, usr string) {
 	usrdev := getUsrDeviceNode(c, m)
-	target, err := m.SSH("readlink -f /dev/disk/by-partlabel/" + usr)
+	target, err := c.SSH(m, "readlink -f /dev/disk/by-partlabel/"+usr)
 	if err != nil {
 		c.Fatalf("Failed to readlink: output %s, status %v", target, err)
 	}

--- a/kola/tests/misc/users.go
+++ b/kola/tests/misc/users.go
@@ -42,7 +42,7 @@ func CheckUserShells(c cluster.TestCluster) {
 		"core":     "/bin/bash",
 	}
 
-	output, err := m.SSH("getent passwd")
+	output, err := c.SSH(m, "getent passwd")
 	if err != nil {
 		c.Fatalf("Failed to run grep: output %s, status: %v", output, err)
 	}

--- a/kola/tests/packages/ipvsadm.go
+++ b/kola/tests/packages/ipvsadm.go
@@ -25,7 +25,7 @@ func ipvsadm(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
 	// Test it runs at all
-	out, err := m.SSH("sudo ipvsadm")
+	out, err := c.SSH(m, "sudo ipvsadm")
 	if err != nil {
 		c.Fatalf("could not run ipvsadm: %v", err)
 	}
@@ -42,13 +42,13 @@ func ipvsadm(c cluster.TestCluster) {
 	-a -t 207.175.44.110:80 -r 192.168.10.4:80 -m
 	-a -t 207.175.44.110:80 -r 192.168.10.5:80 -m
 	" | sudo ipvsadm -R`
-	out, err = m.SSH(cmd)
+	out, err = c.SSH(m, cmd)
 	if err != nil {
 		c.Fatalf("could not run ipvsadm: %v", err)
 	}
 
 	// Test we can read back what we just did
-	out, err = m.SSH("sudo ipvsadm -Ln")
+	out, err = c.SSH(m, "sudo ipvsadm -Ln")
 	if err != nil {
 		c.Fatalf("could not run ipvsadm: %v", err)
 	}
@@ -63,13 +63,13 @@ func ipvsadm(c cluster.TestCluster) {
 	}
 
 	// Test we can delete the service
-	out, err = m.SSH("sudo ipvsadm -D -t 207.175.44.110:80")
+	out, err = c.SSH(m, "sudo ipvsadm -D -t 207.175.44.110:80")
 	if err != nil {
 		c.Fatalf("could not run ipvsadm: %v", err)
 	}
 
 	// Ensure it was really deleted
-	out, err = m.SSH("sudo ipvsadm -Ln")
+	out, err = c.SSH(m, "sudo ipvsadm -Ln")
 	if err != nil {
 		c.Fatalf("could not run ipvsadm: %v", err)
 	}

--- a/kola/tests/rkt/rkt.go
+++ b/kola/tests/rkt/rkt.go
@@ -58,8 +58,8 @@ func init() {
 
 }
 
-func rktEtcd(t cluster.TestCluster) {
-	m := t.Machines()[0]
+func rktEtcd(c cluster.TestCluster) {
+	m := c.Machines()[0]
 
 	etcdCmd := "etcdctl cluster-health"
 	etcdCheck := func() error {
@@ -72,95 +72,95 @@ func rktEtcd(t cluster.TestCluster) {
 	}
 
 	if err := util.Retry(60, 3*time.Second, etcdCheck); err != nil {
-		t.Fatalf("etcd in rkt failed health check: %v", err)
+		c.Fatalf("etcd in rkt failed health check: %v", err)
 	}
 }
 
 // we use subtests to improve testing performance here. Creating the aci is
 // more expensive than actually running most of these tests.
-func rktBase(t cluster.TestCluster) {
-	m := t.Machines()[0]
+func rktBase(c cluster.TestCluster) {
+	m := c.Machines()[0]
 
 	// TODO this should not be necessary, but is at the time of writing
 	m.SSH("sudo setenforce 0")
 
-	createTestAci(t, m, "test.rkt.aci", []string{"echo", "sleep", "sh"})
+	createTestAci(c, m, "test.rkt.aci", []string{"echo", "sleep", "sh"})
 
-	journalForPodContains := func(t cluster.TestCluster, uuidFile string, contains string) {
+	journalForPodContains := func(c cluster.TestCluster, uuidFile string, contains string) {
 		output, err := m.SSH(fmt.Sprintf("journalctl --dir /var/log/journal/$(cat %s | sed 's/-//g')", uuidFile))
 		if err != nil {
-			t.Fatalf("error running journalctl: %v", err)
+			c.Fatalf("error running journalctl: %v", err)
 		}
 		if !bytes.Contains(output, []byte(contains)) {
-			t.Fatalf("expected journal logs from machine dir to include app output %q; was %s", contains, output)
+			c.Fatalf("expected journal logs from machine dir to include app output %q; was %s", contains, output)
 		}
 	}
 
-	t.Run("cli", func(t cluster.TestCluster) {
+	c.Run("cli", func(c cluster.TestCluster) {
 		uuidFile := "/tmp/run-test.uuid"
 
 		output, err := m.SSH(fmt.Sprintf("sudo rkt run --uuid-file-save=%s test.rkt.aci:latest --exec=sh -- -c 'echo success'", uuidFile))
 		if err != nil {
-			t.Fatalf("failed to run test aci: %v, %s", err, output)
+			c.Fatalf("failed to run test aci: %v, %s", err, output)
 		}
 		defer m.SSH(fmt.Sprintf("sudo rkt rm --uuid-file=%s", uuidFile))
 
 		if !bytes.Contains(output, []byte("success")) {
-			t.Fatalf("expected rkt stdout to include app output ('success'); was %s", output)
+			c.Fatalf("expected rkt stdout to include app output ('success'); was %s", output)
 		}
 
-		journalForPodContains(t, uuidFile, "success")
+		journalForPodContains(c, uuidFile, "success")
 	})
 
-	t.Run("unit", func(t cluster.TestCluster) {
+	c.Run("unit", func(c cluster.TestCluster) {
 		uuidFile := "/tmp/run-as-unit-test.uuid"
 
 		output, err := m.SSH(fmt.Sprintf("sudo systemd-run --quiet --unit run-as-unit.service -- rkt run --uuid-file-save=%s test.rkt.aci:latest --exec=sh -- -c 'echo success'", uuidFile))
 		if err != nil {
-			t.Fatalf("failed to systemd-run rkt: %v, %s", err, output)
+			c.Fatalf("failed to systemd-run rkt: %v, %s", err, output)
 		}
 		defer m.SSH(fmt.Sprintf("sudo rkt rm --uuid-file=%s", uuidFile))
 
 		output, err = m.SSH(fmt.Sprintf("while ! [ -s %s ]; do sleep 0.1; done; rkt status --wait $(cat %s)", uuidFile, uuidFile))
 		if err != nil {
-			t.Fatalf("error waiting for rkt: %v, %s", err, output)
+			c.Fatalf("error waiting for rkt: %v, %s", err, output)
 		}
 
-		journalForPodContains(t, uuidFile, "success")
+		journalForPodContains(c, uuidFile, "success")
 	})
 
-	t.Run("machinectl-integration", func(t cluster.TestCluster) {
+	c.Run("machinectl-integration", func(c cluster.TestCluster) {
 		uuidFile := "/tmp/run-machinectl.uuid"
 
 		output, err := m.SSH(fmt.Sprintf("sudo systemd-run --quiet --unit run-machinectl -- rkt run --uuid-file-save=%s test.rkt.aci:latest --exec=sleep -- inf", uuidFile))
 		if err != nil {
-			t.Fatalf("failed to run test aci: %v, %s", err, output)
+			c.Fatalf("failed to run test aci: %v, %s", err, output)
 		}
 		defer m.SSH(fmt.Sprintf("sudo rkt rm --uuid-file=%s", uuidFile))
 
 		output, err = m.SSH(fmt.Sprintf("while ! [ -s %s ]; do sleep 0.1; done; rkt status --wait-ready $(cat %s)", uuidFile, uuidFile))
 		if err != nil {
-			t.Fatalf("error waiting for rkt: %v, %s", err, output)
+			c.Fatalf("error waiting for rkt: %v, %s", err, output)
 		}
 
 		machinectlOutput, err := m.SSH(fmt.Sprintf("machinectl show rkt-$(cat %s)", uuidFile))
 		if err != nil {
-			t.Fatalf("error running machinectl: %v, %s", err, output)
+			c.Fatalf("error running machinectl: %v, %s", err, output)
 		}
 
 		for _, line := range []string{"State=running", "Class=container", "Service=rkt"} {
 			if !bytes.Contains(machinectlOutput, []byte(line)) {
-				t.Fatalf("expected machinectl to include %q: was %s", line, machinectlOutput)
+				c.Fatalf("expected machinectl to include %q: was %s", line, machinectlOutput)
 			}
 		}
 
 		output, err = m.SSH(fmt.Sprintf("sudo rkt stop --uuid-file=%s", uuidFile))
 		if err != nil {
-			t.Fatalf("error stopping app: %v, %s", err, output)
+			c.Fatalf("error stopping app: %v, %s", err, output)
 		}
 		output, err = m.SSH(fmt.Sprintf("rkt status --wait $(cat %s)", uuidFile))
 		if err != nil {
-			t.Fatalf("error waiting for app to stop: %v, %s", err, output)
+			c.Fatalf("error waiting for app to stop: %v, %s", err, output)
 		}
 	})
 }

--- a/kola/tests/systemd/journald.go
+++ b/kola/tests/systemd/journald.go
@@ -73,7 +73,7 @@ func journalRemote(c cluster.TestCluster) {
 
 	// log a unique message on gatewayd machine
 	msg := "supercalifragilisticexpialidocious"
-	out, err := gateway.SSH("logger " + msg)
+	out, err := c.SSH(gateway, "logger "+msg)
 	if err != nil {
 		c.Fatalf("logger: %v: %v", out, err)
 	}
@@ -87,7 +87,7 @@ func journalRemote(c cluster.TestCluster) {
 
 	// collect logs from gatewayd machine
 	cmd := fmt.Sprintf("sudo systemd-run --unit systemd-journal-remote-client /usr/lib/systemd/systemd-journal-remote --url http://%s:19531", gateway.PrivateIP())
-	out, err = collector.SSH(cmd)
+	out, err = c.SSH(collector, cmd)
 	if err != nil {
 		c.Fatalf("failed to start systemd-journal-remote: %v: %v", out, err)
 	}
@@ -95,7 +95,7 @@ func journalRemote(c cluster.TestCluster) {
 	// find the message on the collector
 	journalReader := func() error {
 		cmd = fmt.Sprintf("sudo journalctl _HOSTNAME=gateway -t core --file /var/log/journal/remote/remote-%s.journal", gateway.PrivateIP())
-		out, err = collector.SSH(cmd)
+		out, err = c.SSH(collector, cmd)
 		if err != nil {
 			return fmt.Errorf("journalctl: %v: %v", out, err)
 		}

--- a/kola/tests/systemd/sysusers.go
+++ b/kola/tests/systemd/sysusers.go
@@ -49,7 +49,7 @@ func gshadowParser(c cluster.TestCluster) {
 		`sudo sh -c "echo 'grp2:*::root' >> /etc/gshadow"`,
 		`sudo systemd-sysusers`,
 	} {
-		output, err := m.SSH(cmd)
+		output, err := c.SSH(m, cmd)
 		if err != nil {
 			c.Fatalf("failed to run %q: output: %q status: %v", cmd, output, err)
 		}

--- a/kola/tests/torcx/torcx.go
+++ b/kola/tests/torcx/torcx.go
@@ -42,7 +42,7 @@ systemd:
 
 func torcxEnable(c cluster.TestCluster) {
 	m := c.Machines()[0]
-	output, err := m.SSH(`systemctl is-enabled docker`)
+	output, err := c.SSH(m, `systemctl is-enabled docker`)
 	if err != nil {
 		c.Fatalf("expected no error: %v", err)
 	}

--- a/platform/base.go
+++ b/platform/base.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"sync"
 	"time"
 
@@ -96,27 +95,7 @@ func (bc *BaseCluster) PasswordSSHClient(ip string, user string, password string
 
 // SSH executes the given command, cmd, on the given Machine, m. It returns the
 // stdout and stderr of the command and an error.
-func (bc *BaseCluster) SSH(m Machine, cmd string) ([]byte, error) {
-	client, err := bc.SSHClient(m.IP())
-	if err != nil {
-		return nil, err
-	}
-	defer client.Close()
-
-	session, err := client.NewSession()
-	if err != nil {
-		return nil, err
-	}
-	defer session.Close()
-
-	session.Stderr = os.Stderr
-	out, err := session.Output(cmd)
-	out = bytes.TrimSpace(out)
-	return out, err
-}
-
-// NewSSH is a temporary method as part of refactoring SSH
-func (bc *BaseCluster) NewSSH(m Machine, cmd string) ([]byte, []byte, error) {
+func (bc *BaseCluster) SSH(m Machine, cmd string) ([]byte, []byte, error) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	client, err := bc.SSHClient(m.IP())

--- a/platform/base.go
+++ b/platform/base.go
@@ -94,6 +94,8 @@ func (bc *BaseCluster) PasswordSSHClient(ip string, user string, password string
 	return sshClient, nil
 }
 
+// SSH executes the given command, cmd, on the given Machine, m. It returns the
+// stdout and stderr of the command and an error.
 func (bc *BaseCluster) SSH(m Machine, cmd string) ([]byte, error) {
 	client, err := bc.SSHClient(m.IP())
 	if err != nil {
@@ -113,6 +115,29 @@ func (bc *BaseCluster) SSH(m Machine, cmd string) ([]byte, error) {
 	out, err := session.Output(cmd)
 	out = bytes.TrimSpace(out)
 	return out, err
+}
+
+// NewSSH is a temporary method as part of refactoring SSH
+func (bc *BaseCluster) NewSSH(m Machine, cmd string) ([]byte, []byte, error) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	client, err := bc.SSHClient(m.IP())
+	if err != nil {
+		return nil, nil, err
+	}
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		return nil, nil, err
+	}
+	defer session.Close()
+
+	session.Stdout = &stdout
+	session.Stderr = &stderr
+	err = session.Run(cmd)
+	out := bytes.TrimSpace(stdout.Bytes())
+	return out, stderr.Bytes(), err
 }
 
 func (bc *BaseCluster) Machines() []Machine {

--- a/platform/base.go
+++ b/platform/base.go
@@ -95,6 +95,7 @@ func (bc *BaseCluster) PasswordSSHClient(ip string, user string, password string
 
 // SSH executes the given command, cmd, on the given Machine, m. It returns the
 // stdout and stderr of the command and an error.
+// Leading and trailing whitespace is trimmed from each.
 func (bc *BaseCluster) SSH(m Machine, cmd string) ([]byte, []byte, error) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -113,8 +114,9 @@ func (bc *BaseCluster) SSH(m Machine, cmd string) ([]byte, []byte, error) {
 	session.Stdout = &stdout
 	session.Stderr = &stderr
 	err = session.Run(cmd)
-	out := bytes.TrimSpace(stdout.Bytes())
-	return out, stderr.Bytes(), err
+	outBytes := bytes.TrimSpace(stdout.Bytes())
+	errBytes := bytes.TrimSpace(stderr.Bytes())
+	return outBytes, errBytes, err
 }
 
 func (bc *BaseCluster) Machines() []Machine {

--- a/platform/base.go
+++ b/platform/base.go
@@ -101,14 +101,12 @@ func (bc *BaseCluster) SSH(m Machine, cmd string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	defer client.Close()
 
 	session, err := client.NewSession()
 	if err != nil {
 		return nil, err
 	}
-
 	defer session.Close()
 
 	session.Stderr = os.Stderr

--- a/platform/machine/aws/machine.go
+++ b/platform/machine/aws/machine.go
@@ -52,12 +52,8 @@ func (am *machine) PasswordSSHClient(user string, password string) (*ssh.Client,
 	return am.cluster.PasswordSSHClient(am.IP(), user, password)
 }
 
-func (am *machine) SSH(cmd string) ([]byte, error) {
+func (am *machine) SSH(cmd string) ([]byte, []byte, error) {
 	return am.cluster.SSH(am, cmd)
-}
-
-func (am *machine) NewSSH(cmd string) ([]byte, []byte, error) {
-	return am.cluster.NewSSH(am, cmd)
 }
 
 func (m *machine) Reboot() error {

--- a/platform/machine/aws/machine.go
+++ b/platform/machine/aws/machine.go
@@ -56,6 +56,10 @@ func (am *machine) SSH(cmd string) ([]byte, error) {
 	return am.cluster.SSH(am, cmd)
 }
 
+func (am *machine) NewSSH(cmd string) ([]byte, []byte, error) {
+	return am.cluster.NewSSH(am, cmd)
+}
+
 func (m *machine) Reboot() error {
 	return platform.RebootMachine(m, m.journal, m.cluster.RuntimeConf())
 }

--- a/platform/machine/esx/machine.go
+++ b/platform/machine/esx/machine.go
@@ -53,12 +53,8 @@ func (em *machine) PasswordSSHClient(user string, password string) (*ssh.Client,
 	return em.cluster.PasswordSSHClient(em.IP(), user, password)
 }
 
-func (em *machine) SSH(cmd string) ([]byte, error) {
+func (em *machine) SSH(cmd string) ([]byte, []byte, error) {
 	return em.cluster.SSH(em, cmd)
-}
-
-func (em *machine) NewSSH(cmd string) ([]byte, []byte, error) {
-	return em.cluster.NewSSH(em, cmd)
 }
 
 func (m *machine) Reboot() error {

--- a/platform/machine/esx/machine.go
+++ b/platform/machine/esx/machine.go
@@ -57,6 +57,10 @@ func (em *machine) SSH(cmd string) ([]byte, error) {
 	return em.cluster.SSH(em, cmd)
 }
 
+func (em *machine) NewSSH(cmd string) ([]byte, []byte, error) {
+	return em.cluster.NewSSH(em, cmd)
+}
+
 func (m *machine) Reboot() error {
 	return platform.RebootMachine(m, m.journal, m.cluster.RuntimeConf())
 }

--- a/platform/machine/gcloud/machine.go
+++ b/platform/machine/gcloud/machine.go
@@ -53,12 +53,8 @@ func (gm *machine) PasswordSSHClient(user string, password string) (*ssh.Client,
 	return gm.gc.PasswordSSHClient(gm.IP(), user, password)
 }
 
-func (gm *machine) SSH(cmd string) ([]byte, error) {
+func (gm *machine) SSH(cmd string) ([]byte, []byte, error) {
 	return gm.gc.SSH(gm, cmd)
-}
-
-func (gm *machine) NewSSH(cmd string) ([]byte, []byte, error) {
-	return gm.gc.NewSSH(gm, cmd)
 }
 
 func (m *machine) Reboot() error {

--- a/platform/machine/gcloud/machine.go
+++ b/platform/machine/gcloud/machine.go
@@ -57,6 +57,10 @@ func (gm *machine) SSH(cmd string) ([]byte, error) {
 	return gm.gc.SSH(gm, cmd)
 }
 
+func (gm *machine) NewSSH(cmd string) ([]byte, []byte, error) {
+	return gm.gc.NewSSH(gm, cmd)
+}
+
 func (m *machine) Reboot() error {
 	return platform.RebootMachine(m, m.journal, m.gc.RuntimeConf())
 }

--- a/platform/machine/packet/machine.go
+++ b/platform/machine/packet/machine.go
@@ -56,6 +56,10 @@ func (pm *machine) SSH(cmd string) ([]byte, error) {
 	return pm.cluster.SSH(pm, cmd)
 }
 
+func (pm *machine) NewSSH(cmd string) ([]byte, []byte, error) {
+	return pm.cluster.NewSSH(pm, cmd)
+}
+
 func (m *machine) Reboot() error {
 	return platform.RebootMachine(m, m.journal, m.cluster.RuntimeConf())
 }

--- a/platform/machine/packet/machine.go
+++ b/platform/machine/packet/machine.go
@@ -52,12 +52,8 @@ func (pm *machine) PasswordSSHClient(user string, password string) (*ssh.Client,
 	return pm.cluster.PasswordSSHClient(pm.IP(), user, password)
 }
 
-func (pm *machine) SSH(cmd string) ([]byte, error) {
+func (pm *machine) SSH(cmd string) ([]byte, []byte, error) {
 	return pm.cluster.SSH(pm, cmd)
-}
-
-func (pm *machine) NewSSH(cmd string) ([]byte, []byte, error) {
-	return pm.cluster.NewSSH(pm, cmd)
 }
 
 func (m *machine) Reboot() error {

--- a/platform/machine/qemu/machine.go
+++ b/platform/machine/qemu/machine.go
@@ -54,12 +54,8 @@ func (m *machine) PasswordSSHClient(user string, password string) (*ssh.Client, 
 	return m.qc.PasswordSSHClient(m.IP(), user, password)
 }
 
-func (m *machine) SSH(cmd string) ([]byte, error) {
+func (m *machine) SSH(cmd string) ([]byte, []byte, error) {
 	return m.qc.SSH(m, cmd)
-}
-
-func (m *machine) NewSSH(cmd string) ([]byte, []byte, error) {
-	return m.qc.NewSSH(m, cmd)
 }
 
 func (m *machine) Reboot() error {

--- a/platform/machine/qemu/machine.go
+++ b/platform/machine/qemu/machine.go
@@ -58,6 +58,10 @@ func (m *machine) SSH(cmd string) ([]byte, error) {
 	return m.qc.SSH(m, cmd)
 }
 
+func (m *machine) NewSSH(cmd string) ([]byte, []byte, error) {
+	return m.qc.NewSSH(m, cmd)
+}
+
 func (m *machine) Reboot() error {
 	return platform.RebootMachine(m, m.journal, m.qc.RuntimeConf())
 }

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -53,6 +53,11 @@ type Machine interface {
 	// SSH runs a single command over a new SSH connection.
 	SSH(cmd string) ([]byte, error)
 
+	// NewSSH is a temporary copy of ssh with a different signature so
+	// refactoring can be done in pieces for ease of review.
+	// A later commit replaces SSH with NewSSH
+	NewSSH(cmd string) ([]byte, []byte, error)
+
 	// Reboot restarts the machine and waits for it to come back.
 	Reboot() error
 

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -1,4 +1,4 @@
-// Copyright 2016 CoreOS, Inc.
+// Copyright 2017 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ const (
 	sshTimeout = 10 * time.Second
 )
 
-// Machine represents a CoreOS instance.
+// Machine represents a Container Linux instance.
 type Machine interface {
 	// ID returns the plaform-specific machine identifier.
 	ID() string
@@ -69,9 +69,9 @@ type Machine interface {
 	ConsoleOutput() string
 }
 
-// Cluster represents a cluster of CoreOS machines within a single platform.
+// Cluster represents a cluster of Container Linux machines within a single platform.
 type Cluster interface {
-	// NewMachine creates a new CoreOS machine.
+	// NewMachine creates a new Container Linux machine.
 	NewMachine(userdata *conf.UserData) (Machine, error)
 
 	// Machines returns a slice of the active machines in the Cluster.
@@ -250,7 +250,7 @@ func NewMachines(c Cluster, userdata *conf.UserData, n int) ([]Machine, error) {
 
 // CheckMachine tests a machine for various error conditions such as ssh
 // being available and no systemd units failing at the time ssh is reachable.
-// It also ensures the remote system is running CoreOS.
+// It also ensures the remote system is running Container Linux by CoreOS.
 //
 // TODO(mischief): better error messages.
 func CheckMachine(m Machine) error {
@@ -267,14 +267,14 @@ func CheckMachine(m Machine) error {
 		return fmt.Errorf("ssh unreachable: %v", err)
 	}
 
-	// ensure we're talking to a CoreOS system
+	// ensure we're talking to a Container Linux system
 	out, stderr, err := m.NewSSH("grep ^ID= /etc/os-release")
 	if err != nil {
 		return fmt.Errorf("no /etc/os-release file: %s: %s", err, stderr)
 	}
 
 	if !bytes.Equal(out, []byte("ID=coreos")) {
-		return fmt.Errorf("not a CoreOS instance")
+		return fmt.Errorf("not a Container Linux instance")
 	}
 
 	// ensure no systemd units failed during boot

--- a/platform/util.go
+++ b/platform/util.go
@@ -81,9 +81,9 @@ func Manhole(m Machine) error {
 
 // Enable SELinux on a machine (skip on machines without SELinux support)
 func EnableSelinux(m Machine) error {
-	_, err := m.SSH("if type -P setenforce; then sudo setenforce 1; fi")
+	_, stderr, err := m.NewSSH("if type -P setenforce; then sudo setenforce 1; fi")
 	if err != nil {
-		return fmt.Errorf("Unable to enable SELinux: %v", err)
+		return fmt.Errorf("Unable to enable SELinux: %s: %s", err, stderr)
 	}
 	return nil
 }
@@ -93,13 +93,13 @@ func EnableSelinux(m Machine) error {
 func StartReboot(m Machine) error {
 	// stop sshd so that commonMachineChecks will only work if the machine
 	// actually rebooted
-	out, err := m.SSH("sudo systemctl stop sshd.socket && sudo reboot")
+	out, stderr, err := m.NewSSH("sudo systemctl stop sshd.socket && sudo reboot")
 	if _, ok := err.(*ssh.ExitMissingError); ok {
 		// A terminated session is perfectly normal during reboot.
 		err = nil
 	}
 	if err != nil {
-		return fmt.Errorf("issuing reboot command failed: %v", out)
+		return fmt.Errorf("issuing reboot command failed: %s: %s: %s", out, err, stderr)
 	}
 	return nil
 }

--- a/platform/util.go
+++ b/platform/util.go
@@ -81,7 +81,7 @@ func Manhole(m Machine) error {
 
 // Enable SELinux on a machine (skip on machines without SELinux support)
 func EnableSelinux(m Machine) error {
-	_, stderr, err := m.NewSSH("if type -P setenforce; then sudo setenforce 1; fi")
+	_, stderr, err := m.SSH("if type -P setenforce; then sudo setenforce 1; fi")
 	if err != nil {
 		return fmt.Errorf("Unable to enable SELinux: %s: %s", err, stderr)
 	}
@@ -93,7 +93,7 @@ func EnableSelinux(m Machine) error {
 func StartReboot(m Machine) error {
 	// stop sshd so that commonMachineChecks will only work if the machine
 	// actually rebooted
-	out, stderr, err := m.NewSSH("sudo systemctl stop sshd.socket && sudo reboot")
+	out, stderr, err := m.SSH("sudo systemctl stop sshd.socket && sudo reboot")
 	if _, ok := err.(*ssh.ExitMissingError); ok {
 		// A terminated session is perfectly normal during reboot.
 		err = nil


### PR DESCRIPTION
The primary problem this is fixing is that `m.SSH`, by default, pipes all stderr directly to `os.Stderr`. This means that stderr is often located significantly before the "FAIL: " associated with a test, and sometimes it's difficult to correlate them exactly.

This problem will only get worse as our tooling around dealing with test output gets better.

This PR fixes that problem by introducing a new SSH method on `cluster.TestCluster` which collects stderr and writes it to the test harness's output buffer with `Logf`.

All tests were rewritten to use this.

This also replaces the original `m.SSH` method with one which returns stderr rather than putting it on `os.Stderr`.

Now that tests have a more ergonomic option, it seems fine to let the other callers deal with stderr themselves.