### PR TITLE
kola/tests/docker: reduce docker flag MinVersion to 1520

### DIFF
--- a/kola/tests/docker/torcx_docker_flag.go
+++ b/kola/tests/docker/torcx_docker_flag.go
@@ -29,7 +29,7 @@ func init() {
 		Run:         dockerTorcxFlagFile,
 		ClusterSize: 1,
 		Name:        "docker.torcx-flag-file",
-		MinVersion:  semver.Version{Major: 1548},
+		MinVersion:  semver.Version{Major: 1520},
 		UserData: conf.ContainerLinuxConfig(`
 storage:
   files:
@@ -43,7 +43,7 @@ storage:
 		Run:         dockerTorcxFlagFileCloudConfig,
 		ClusterSize: 1,
 		Name:        "docker.torcx-flag-file.cloud-config",
-		MinVersion:  semver.Version{Major: 1548},
+		MinVersion:  semver.Version{Major: 1520},
 		UserData: conf.CloudConfig(`
 #cloud-config
 write_files:


### PR DESCRIPTION
Support was backported to 1520 (but notably not 1535).