### PR TITLE
harness: add support for additional reporters

### DIFF
--- a/harness/reporters/json.go
+++ b/harness/reporters/json.go
@@ -1,0 +1,72 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reporters
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/coreos/mantle/harness/testresult"
+)
+
+type jsonReporter struct {
+	Tests    []jsonTest            `json:"tests"`
+	Result   testresult.TestResult `json:"result"`
+	filename string
+
+	// Context variables
+	Platform string `json:"platform"`
+	Version  string `json:"version"`
+}
+
+type jsonTest struct {
+	Name     string                `json:"name"`
+	Result   testresult.TestResult `json:"result"`
+	Duration time.Duration         `json:"duration"`
+	Output   string                `json:"output"`
+}
+
+func NewJSONReporter(filename, platform, version string) *jsonReporter {
+	return &jsonReporter{
+		Platform: platform,
+		Version:  version,
+		filename: filename,
+	}
+}
+
+func (r *jsonReporter) ReportTest(name string, result testresult.TestResult, duration time.Duration, b []byte) {
+	r.Tests = append(r.Tests, jsonTest{
+		Name:     name,
+		Result:   result,
+		Duration: duration,
+		Output:   string(b),
+	})
+}
+
+func (r *jsonReporter) Output(path string) error {
+	f, err := os.Create(filepath.Join(path, r.filename))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return json.NewEncoder(f).Encode(r)
+}
+
+func (r *jsonReporter) SetResult(result testresult.TestResult) {
+	r.Result = result
+}

--- a/harness/reporters/reporter.go
+++ b/harness/reporters/reporter.go
@@ -1,0 +1,51 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reporters
+
+import (
+	"time"
+
+	"github.com/coreos/mantle/harness/testresult"
+)
+
+type Reporters []Reporter
+
+func (reps Reporters) ReportTest(name string, result testresult.TestResult, duration time.Duration, b []byte) {
+	for _, r := range reps {
+		r.ReportTest(name, result, duration, b)
+	}
+}
+
+func (reps Reporters) Output(path string) error {
+	for _, r := range reps {
+		err := r.Output(path)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (reps Reporters) SetResult(s testresult.TestResult) {
+	for _, r := range reps {
+		r.SetResult(s)
+	}
+}
+
+type Reporter interface {
+	ReportTest(string, testresult.TestResult, time.Duration, []byte)
+	Output(string) error
+	SetResult(testresult.TestResult)
+}

--- a/harness/testresult/status.go
+++ b/harness/testresult/status.go
@@ -1,0 +1,23 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testresult
+
+const (
+	Fail TestResult = "FAIL"
+	Skip TestResult = "SKIP"
+	Pass TestResult = "PASS"
+)
+
+type TestResult string

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -29,6 +29,7 @@ import (
 	"github.com/coreos/pkg/capnslog"
 
 	"github.com/coreos/mantle/harness"
+	"github.com/coreos/mantle/harness/reporters"
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/kola/torcx"
@@ -203,6 +204,8 @@ func versionOutsideRange(version, minVersion, endVersion semver.Version) bool {
 // outputDir is where various test logs and data will be written for
 // analysis after the test run. If it already exists it will be erased!
 func RunTests(pattern, pltfrm, outputDir string) error {
+	var versionStr string
+
 	// Avoid incurring cost of starting machine in getClusterSemver when
 	// either:
 	// 1) none of the selected tests care about the version
@@ -240,6 +243,8 @@ func RunTests(pattern, pltfrm, outputDir string) error {
 			plog.Fatal(err)
 		}
 
+		versionStr = version.String()
+
 		// one more filter pass now that we know real version
 		tests, err = filterTests(tests, pattern, pltfrm, *version)
 		if err != nil {
@@ -251,6 +256,9 @@ func RunTests(pattern, pltfrm, outputDir string) error {
 		OutputDir: outputDir,
 		Parallel:  TestParallelism,
 		Verbose:   true,
+		Reporters: reporters.Reporters{
+			reporters.NewJSONReporter("report.json", pltfrm, versionStr),
+		},
 	}
 	var htests harness.Tests
 	for _, test := range tests {


### PR DESCRIPTION
Adds a new mechanism into the harness to provide support for
additional reporters. New reporters can be defined inside of
`harness/reporters` & should implement the `Reporter` interface.

The first additional reporter provided is the JSONReporter. `kola`
runs will now produce an additional file inside of the `_kola_tmp`
logs named `report.json`.