### PR TITLE
kola: check for additional messages on console

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -82,6 +82,10 @@ var (
 			match: regexp.MustCompile("Oops:"),
 		},
 		{
+			desc:  "kernel warning",
+			match: regexp.MustCompile(`WARNING: CPU: \d+ PID: \d+ at (.+)`),
+		},
+		{
 			desc:  "excessive bonding link status messages",
 			match: regexp.MustCompile("(?s:link status up for interface [^,]+, enabling it in [0-9]+ ms.*?){10}"),
 		},

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -86,8 +86,14 @@ var (
 			match: regexp.MustCompile(`WARNING: CPU: \d+ PID: \d+ at (.+)`),
 		},
 		{
+			// https://github.com/coreos/bugs/issues/2065
 			desc:  "excessive bonding link status messages",
 			match: regexp.MustCompile("(?s:link status up for interface [^,]+, enabling it in [0-9]+ ms.*?){10}"),
+		},
+		{
+			// https://github.com/coreos/bugs/issues/2180
+			desc:  "ext4 delayed allocation failure",
+			match: regexp.MustCompile(`EXT4-fs \([^)]+\): Delayed block allocation failed for inode \d+ at logical offset \d+ with max blocks \d+ with (error \d+)`),
 		},
 		{
 			desc:  "Go panic",


### PR DESCRIPTION
Catch both cases of coreos/bugs#2180, independently of the `extend-filesystems.service` failure.