### PR TITLE
aws: tag instances on creation, add 'createdby' tag

### DIFF
--- a/platform/api/aws/ec2.go
+++ b/platform/api/aws/ec2.go
@@ -85,6 +85,10 @@ func (a *API) CreateInstances(name, keyname, userdata string, count uint64) ([]*
 						Key:   aws.String("Name"),
 						Value: aws.String(name),
 					},
+					&ec2.Tag{
+						Key:   aws.String("CreatedBy"),
+						Value: aws.String("mantle"),
+					},
 				},
 			},
 		},

--- a/platform/api/aws/ec2.go
+++ b/platform/api/aws/ec2.go
@@ -77,6 +77,17 @@ func (a *API) CreateInstances(name, keyname, userdata string, count uint64) ([]*
 		IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
 			Name: &a.opts.IAMInstanceProfile,
 		},
+		TagSpecifications: []*ec2.TagSpecification{
+			&ec2.TagSpecification{
+				ResourceType: aws.String(ec2.ResourceTypeInstance),
+				Tags: []*ec2.Tag{
+					&ec2.Tag{
+						Key:   aws.String("Name"),
+						Value: aws.String(name),
+					},
+				},
+			},
+		},
 	}
 
 	reservations, err := a.ec2.RunInstances(&inst)
@@ -87,27 +98,6 @@ func (a *API) CreateInstances(name, keyname, userdata string, count uint64) ([]*
 	ids := make([]string, len(reservations.Instances))
 	for i, inst := range reservations.Instances {
 		ids[i] = *inst.InstanceId
-	}
-
-	for {
-		_, err := a.ec2.CreateTags(&ec2.CreateTagsInput{
-			Resources: aws.StringSlice(ids),
-			Tags: []*ec2.Tag{
-				&ec2.Tag{
-					Key:   aws.String("Name"),
-					Value: aws.String(name),
-				},
-			},
-		})
-		if err == nil {
-			break
-		}
-		if awserr, ok := err.(awserr.Error); !ok || awserr.Code() != "InvalidInstanceID.NotFound" {
-			a.TerminateInstances(ids)
-			return nil, fmt.Errorf("error creating tags: %v", err)
-		}
-		// eventual consistency
-		time.Sleep(5 * time.Second)
 	}
 
 	// loop until all machines are online


### PR DESCRIPTION
This will make cleaning up aws instances reliably easier.

See the individual commits. If desired, I can break out the second one to a separate PR since these are only tangentially related.