### PR TITLE
platform/conf: update userdata isignition to check for clc's

### DIFF
--- a/platform/base.go
+++ b/platform/base.go
@@ -152,7 +152,7 @@ func (bc *BaseCluster) RenderUserData(userdata *conf.UserData, ignitionVars map[
 	}
 
 	// hacky solution for unified ignition metadata variables
-	if userdata.IsIgnition() {
+	if userdata.IsIgnitionCompatible() {
 		for k, v := range ignitionVars {
 			userdata = userdata.Subst(k, v)
 		}

--- a/platform/conf/conf.go
+++ b/platform/conf/conf.go
@@ -125,8 +125,8 @@ func (u *UserData) Subst(old, new string) *UserData {
 	return &ret
 }
 
-func (u *UserData) IsIgnition() bool {
-	return u.kind == kindIgnition
+func (u *UserData) IsIgnitionCompatible() bool {
+	return u.kind == kindIgnition || u.kind == kindContainerLinuxConfig
 }
 
 // Render parses userdata and returns a new Conf. It returns an error if the


### PR DESCRIPTION
Currently the `IsIgnition` function on the `UserData` object only
returns `true` if the `UserData` is already in `Ignition` form.
CLC's are translated to `Ignition` configs when `Render` is called,
so they should also be marked as `Ignition` in this function.

Renames the function from `IsIgnition` to `IsIgnitionCompatible` to
reflect the change.

More discussion [here](https://github.com/coreos/mantle/pull/730#discussion_r144758775)