### PR TITLE
platform/oci: update tests

### DIFF
--- a/kola/tests/docker/torcx_docker_flag.go
+++ b/kola/tests/docker/torcx_docker_flag.go
@@ -50,6 +50,7 @@ write_files:
   - path: "/etc/coreos/docker-1.12"
     content: yes
 `),
+		ExcludePlatforms: []string{"oci"},
 	})
 }
 

--- a/platform/api/oci/instance.go
+++ b/platform/api/oci/instance.go
@@ -35,8 +35,9 @@ func (a *API) CreateInstance(name, userdata, sshKey string) (*Machine, error) {
 		return nil, err
 	}
 
-	metadata := map[string]string{
-		"user_data": base64.StdEncoding.EncodeToString([]byte(userdata)),
+	metadata := map[string]string{}
+	if userdata != "" {
+		metadata["user_data"] = base64.StdEncoding.EncodeToString([]byte(userdata))
 	}
 	if sshKey != "" {
 		metadata["ssh_authorized_keys"] = sshKey

--- a/platform/api/oci/instance.go
+++ b/platform/api/oci/instance.go
@@ -24,7 +24,7 @@ import (
 	"github.com/coreos/mantle/util"
 )
 
-func (a *API) CreateInstance(name, userdata string) (*Machine, error) {
+func (a *API) CreateInstance(name, userdata, sshKey string) (*Machine, error) {
 	vcn, err := a.GetVCN("kola")
 	if err != nil {
 		return nil, err
@@ -35,10 +35,15 @@ func (a *API) CreateInstance(name, userdata string) (*Machine, error) {
 		return nil, err
 	}
 
+	metadata := map[string]string{
+		"user_data": base64.StdEncoding.EncodeToString([]byte(userdata)),
+	}
+	if sshKey != "" {
+		metadata["ssh_authorized_keys"] = sshKey
+	}
+
 	opts := baremetal.LaunchInstanceOptions{
-		Metadata: map[string]string{
-			"user_data": base64.StdEncoding.EncodeToString([]byte(userdata)),
-		},
+		Metadata: metadata,
 		CreateVnicOptions: &baremetal.CreateVnicOptions{
 			AssignPublicIp: boolToPtr(true),
 			SubnetID:       subnet.ID,

--- a/platform/conf/conf.go
+++ b/platform/conf/conf.go
@@ -425,6 +425,12 @@ func keysToStrings(keys []*agent.Key) (keyStrs []string) {
 }
 
 // IsIgnition returns true if the config is for Ignition.
+// Returns false in the case of empty configs as on most platforms,
+// this will default back to cloudconfig
 func (c *Conf) IsIgnition() bool {
 	return c.ignitionV1 != nil || c.ignitionV2 != nil || c.ignitionV21 != nil
+}
+
+func (c *Conf) IsEmpty() bool {
+	return !c.IsIgnition() && c.cloudconfig == nil && c.script == ""
 }

--- a/platform/machine/oci/cluster.go
+++ b/platform/machine/oci/cluster.go
@@ -70,7 +70,7 @@ func (oc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 		return nil, err
 	}
 
-	if !conf.IsIgnition() {
+	if !conf.IsIgnition() && !conf.IsEmpty() {
 		return nil, fmt.Errorf("only Ignition is supported on OCI")
 	}
 


### PR DESCRIPTION
Blacklists cloudconfig tests, adds an `IsEmpty` function to `platform/conf`, & implements the `authorized_ssh_key` metadata key.

See individual commit messages for context.