### PR TITLE
cmd/kola: add option to specify config file for all platforms

### DIFF
--- a/auth/esx.go
+++ b/auth/esx.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 )
 
-const configPath = ".config/esx.json"
+const ESXConfigPath = ".config/esx.json"
 
 // ESXProfile represents a parsed ESX profile. This is a custom format
 // specific to Mantle.
@@ -42,7 +42,7 @@ func ReadESXConfig(path string) (map[string]ESXProfile, error) {
 		if err != nil {
 			return nil, err
 		}
-		path = filepath.Join(user.HomeDir, configPath)
+		path = filepath.Join(user.HomeDir, ESXConfigPath)
 	}
 
 	f, err := os.Open(path)

--- a/auth/oci.go
+++ b/auth/oci.go
@@ -28,7 +28,7 @@ var (
 	plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "auth")
 )
 
-const ociConfigPath = ".oci/config"
+const OCIConfigPath = ".oci/config"
 
 // OCIProfile represents a parsed OCI profile.
 type OCIProfile struct {
@@ -60,7 +60,7 @@ func ReadOCIConfig(path string) (map[string]OCIProfile, error) {
 		if err != nil {
 			return nil, err
 		}
-		path = filepath.Join(user.HomeDir, ociConfigPath)
+		path = filepath.Join(user.HomeDir, OCIConfigPath)
 	}
 
 	profiles := make(map[string]OCIProfile)

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -72,7 +72,7 @@ func init() {
 	if defaultRegion == "" {
 		defaultRegion = "us-west-2"
 	}
-	// Container Linux 1430.0.0 (alpha) on us-west-2
+	sv(&kola.AWSOptions.CredentialsFile, "aws-credentials-file", "", "AWS credentials file (default \"~/.aws/credentials\")")
 	sv(&kola.AWSOptions.Region, "aws-region", defaultRegion, "AWS region")
 	sv(&kola.AWSOptions.Profile, "aws-profile", "default", "AWS profile name")
 	sv(&kola.AWSOptions.AMI, "aws-ami", "alpha", `AWS AMI ID, or (alpha|beta|stable) to use the latest image`)
@@ -91,11 +91,13 @@ func init() {
 	sv(&kola.PacketOptions.StorageURL, "packet-storage-url", "gs://users.developer.core-os.net/"+os.Getenv("USER")+"/mantle", "Google Storage base URL for temporary uploads")
 
 	// esx-specific options
+	sv(&kola.ESXOptions.ConfigPath, "esx-config-file", "", "ESX config file (default \"~/"+auth.ESXConfigPath+"\")")
 	sv(&kola.ESXOptions.Server, "esx-server", "", "ESX server")
 	sv(&kola.ESXOptions.Profile, "esx-profile", "", "ESX profile (default \"default\")")
 	sv(&kola.ESXOptions.BaseVMName, "esx-base-vm", "", "ESX base VM name")
 
 	// oci-specific options
+	sv(&kola.OCIOptions.ConfigPath, "oci-config-file", "", "OCI config file (default \"~/"+auth.OCIConfigPath+"\")")
 	sv(&kola.OCIOptions.Region, "oci-region", "", "OCI region")
 	sv(&kola.OCIOptions.Image, "oci-image", "", "OCI image id")
 	sv(&kola.OCIOptions.Shape, "oci-shape", "VM.Standard1.1", "OCI shape")


### PR DESCRIPTION
Currently only GCE & Packet have the ability to specify the config
file location. This adds the ability to set it for AWS, ESX & OCI.