### PR TITLE
platform/conf: accept CLCs in conf.Unknown()

### DIFF
--- a/platform/conf/conf.go
+++ b/platform/conf/conf.go
@@ -111,8 +111,15 @@ func Unknown(data string) *UserData {
 	case v21.ErrScript:
 		u.kind = kindScript
 	default:
-		// we don't autodetect Container Linux configs
-		u.kind = kindIgnition
+		// Guess whether this is an Ignition config or a CLC.
+		// This treats an invalid Ignition config as a CLC, and a
+		// CLC in the JSON subset of YAML as an Ignition config.
+		var decoded interface{}
+		if err := json.Unmarshal([]byte(data), &decoded); err != nil {
+			u.kind = kindContainerLinuxConfig
+		} else {
+			u.kind = kindIgnition
+		}
 	}
 
 	return u


### PR DESCRIPTION
It's only used in two user-facing applications, `kola spawn` and `ore packet create-device`. In both cases it would be convenient to accept Container Linux Configs.