### PR TITLE
ore: implement 'gc' subcommand for aws

### DIFF
--- a/cmd/ore/aws/gc.go
+++ b/cmd/ore/aws/gc.go
@@ -1,0 +1,48 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdGC = &cobra.Command{
+		Use:   "gc",
+		Short: "GC resources in AWS",
+		Long:  `Delete instances created over the given duration ago`,
+		RunE:  runGC,
+	}
+
+	gcDuration time.Duration
+)
+
+func init() {
+	AWS.AddCommand(cmdGC)
+	cmdGC.Flags().DurationVar(&gcDuration, "duration", 5*time.Hour, "how old resources must be before they're considered garbage")
+}
+
+func runGC(cmd *cobra.Command, args []string) error {
+	err := API.GC(gcDuration)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't gc: %v\n", err)
+		os.Exit(1)
+	}
+	return nil
+}

--- a/platform/api/aws/api.go
+++ b/platform/api/aws/api.go
@@ -15,6 +15,8 @@
 package aws
 
 import (
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -95,6 +97,12 @@ func New(opts *Options) (*API, error) {
 	}
 
 	return api, nil
+}
+
+// GC removes AWS resources that are at least gracePeriod old.
+// It attempts to only operate on resources that were created by a mantle tool.
+func (a *API) GC(gracePeriod time.Duration) error {
+	return a.gcEC2(gracePeriod)
 }
 
 // PreflightCheck validates that the aws configuration provided has valid

--- a/platform/api/aws/ec2.go
+++ b/platform/api/aws/ec2.go
@@ -137,6 +137,9 @@ func (a *API) CreateInstances(name, keyname, userdata string, count uint64) ([]*
 
 // TerminateInstances schedules EC2 instances to be terminated.
 func (a *API) TerminateInstances(ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
 	input := &ec2.TerminateInstancesInput{
 		InstanceIds: aws.StringSlice(ids),
 	}


### PR DESCRIPTION
The intent is that running this in a distributed-cron-like-thing should be enough to generally catch leaks.