### PR TITLE
cmd/ore: Add GC subcommands for do, gcloud, oci, packet

### DIFF
--- a/cmd/ore/do/gc.go
+++ b/cmd/ore/do/gc.go
@@ -1,0 +1,54 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package do
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdGC = &cobra.Command{
+		Use:   "gc",
+		Short: "GC resources in DO",
+		Long:  `Delete droplets created over the given duration ago.`,
+		RunE:  runGC,
+	}
+
+	gcDuration time.Duration
+)
+
+func init() {
+	DO.AddCommand(cmdGC)
+	cmdGC.Flags().DurationVar(&gcDuration, "duration", 5*time.Hour, "how old resources must be before they're considered garbage")
+}
+
+func runGC(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		fmt.Fprintf(os.Stderr, "Unrecognized args in do gc cmd: %v\n", args)
+		os.Exit(2)
+	}
+
+	if err := API.GC(context.Background(), gcDuration); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
+	return nil
+}

--- a/cmd/ore/gcloud/gc.go
+++ b/cmd/ore/gcloud/gc.go
@@ -1,0 +1,53 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcloud
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdGC = &cobra.Command{
+		Use:   "gc",
+		Short: "GC resources in GCE",
+		Long:  `Delete instances created over the given duration ago.`,
+		RunE:  runGC,
+	}
+
+	gcDuration time.Duration
+)
+
+func init() {
+	GCloud.AddCommand(cmdGC)
+	cmdGC.Flags().DurationVar(&gcDuration, "duration", 5*time.Hour, "how old resources must be before they're considered garbage")
+}
+
+func runGC(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		fmt.Fprintf(os.Stderr, "Unrecognized args in gcloud gc cmd: %v\n", args)
+		os.Exit(2)
+	}
+
+	if err := api.GC(gcDuration); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
+	return nil
+}

--- a/cmd/ore/oci/gc.go
+++ b/cmd/ore/oci/gc.go
@@ -1,0 +1,53 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdGC = &cobra.Command{
+		Use:   "gc",
+		Short: "GC resources in OCI",
+		Long:  `Delete devices created over the given duration ago.`,
+		RunE:  runGC,
+	}
+
+	gcDuration time.Duration
+)
+
+func init() {
+	OCI.AddCommand(cmdGC)
+	cmdGC.Flags().DurationVar(&gcDuration, "duration", 5*time.Hour, "how old resources must be before they're considered garbage")
+}
+
+func runGC(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		fmt.Fprintf(os.Stderr, "Unrecognized args in oci gc cmd: %v\n", args)
+		os.Exit(2)
+	}
+
+	if err := API.GC(gcDuration); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
+	return nil
+}

--- a/cmd/ore/packet/gc.go
+++ b/cmd/ore/packet/gc.go
@@ -1,0 +1,53 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdGC = &cobra.Command{
+		Use:   "gc",
+		Short: "GC resources in Packet",
+		Long:  `Delete devices created over the given duration ago.`,
+		RunE:  runGC,
+	}
+
+	gcDuration time.Duration
+)
+
+func init() {
+	Packet.AddCommand(cmdGC)
+	cmdGC.Flags().DurationVar(&gcDuration, "duration", 5*time.Hour, "how old resources must be before they're considered garbage")
+}
+
+func runGC(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		fmt.Fprintf(os.Stderr, "Unrecognized args in packet gc cmd: %v\n", args)
+		os.Exit(2)
+	}
+
+	if err := API.GC(gcDuration); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
+	return nil
+}

--- a/platform/api/gcloud/api.go
+++ b/platform/api/gcloud/api.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	"google.golang.org/api/compute/v1"
@@ -101,4 +102,8 @@ func New(opts *Options) (*API, error) {
 
 func (a *API) Client() *http.Client {
 	return a.client
+}
+
+func (a *API) GC(gracePeriod time.Duration) error {
+	return a.gcInstances(gracePeriod)
 }

--- a/platform/api/gcloud/compute.go
+++ b/platform/api/gcloud/compute.go
@@ -31,7 +31,15 @@ func (a *API) vmname() string {
 
 // Taken from: https://github.com/golang/build/blob/master/buildlet/gce.go
 func (a *API) mkinstance(userdata, name string, keys []*agent.Key) *compute.Instance {
-	var metadataItems []*compute.MetadataItems
+	mantle := "mantle"
+	metadataItems := []*compute.MetadataItems{
+		&compute.MetadataItems{
+			// this should be done with a label instead, but
+			// our old vendored Go binding doesn't support those
+			Key:   "created-by",
+			Value: &mantle,
+		},
+	}
 	if len(keys) > 0 {
 		var sshKeys string
 		for i, key := range keys {

--- a/platform/api/oci/api.go
+++ b/platform/api/oci/api.go
@@ -16,6 +16,7 @@ package oci
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/oracle/bmcs-go-sdk"
 
@@ -110,6 +111,10 @@ func New(opts *Options) (*API, error) {
 		client: client,
 		opts:   opts,
 	}, nil
+}
+
+func (a *API) GC(gracePeriod time.Duration) error {
+	return a.gcInstances(gracePeriod)
 }
 
 func boolToPtr(b bool) *bool {

--- a/platform/api/oci/instance.go
+++ b/platform/api/oci/instance.go
@@ -157,3 +157,31 @@ func (a *API) GetConsoleOutput(instanceID string) (string, error) {
 
 	return content.Data, nil
 }
+
+func (a *API) gcInstances(gracePeriod time.Duration) error {
+	threshold := time.Now().Add(-gracePeriod)
+
+	result, err := a.client.ListInstances(a.opts.CompartmentID, nil)
+	if err != nil {
+		return err
+	}
+	for _, instance := range result.Instances {
+		if instance.Metadata["created_by"] != "mantle" {
+			continue
+		}
+
+		if instance.TimeCreated.After(threshold) {
+			continue
+		}
+
+		switch instance.State {
+		case "TERMINATING", "TERMINATED":
+			continue
+		}
+
+		if err := a.TerminateInstance(instance.ID); err != nil {
+			return fmt.Errorf("couldn't terminate instance %v: %v", instance.ID, err)
+		}
+	}
+	return nil
+}

--- a/platform/api/oci/instance.go
+++ b/platform/api/oci/instance.go
@@ -35,7 +35,9 @@ func (a *API) CreateInstance(name, userdata, sshKey string) (*Machine, error) {
 		return nil, err
 	}
 
-	metadata := map[string]string{}
+	metadata := map[string]string{
+		"created_by": "mantle",
+	}
 	if userdata != "" {
 		metadata["user_data"] = base64.StdEncoding.EncodeToString([]byte(userdata))
 	}


### PR DESCRIPTION
This leaves only `esx` unimplemented.

We currently only GC instances, not images or SSH keys.