### PR TITLE
WIP: plume: add OCI to plume

### DIFF
--- a/cmd/ore/oci/rename.go
+++ b/cmd/ore/oci/rename.go
@@ -1,0 +1,57 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdRename = &cobra.Command{
+		Use:   "rename",
+		Short: "Rename OCI image",
+		Long:  "Rename OCI image in objectstorage",
+		Run:   runRenameImage,
+	}
+
+	renameOldName string
+	renameNewName string
+	renameBucket  string
+)
+
+func init() {
+	cmdRename.Flags().StringVar(&renameOldName, "old-name", "", "Current image name")
+	cmdRename.Flags().StringVar(&renameNewName, "new-name", "", "New image name")
+	cmdRename.Flags().StringVar(&renameBucket, "bucket", "", "OCI storage bucket name")
+	OCI.AddCommand(cmdRename)
+}
+
+func runRenameImage(cmd *cobra.Command, args []string) {
+	if len(args) != 0 {
+		fmt.Fprintf(os.Stderr, "Unrecognized args in ore rename cmd: %v\n", args)
+		os.Exit(2)
+	}
+
+	err := API.RenameImage(renameBucket, renameOldName, renameNewName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed renaming image: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Image %v successfully renamed in OCI\n", renameNewName)
+}

--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -37,6 +37,7 @@ import (
 	"github.com/coreos/mantle/auth"
 	"github.com/coreos/mantle/platform/api/aws"
 	"github.com/coreos/mantle/platform/api/azure"
+	"github.com/coreos/mantle/platform/api/oci"
 	"github.com/coreos/mantle/sdk"
 	"github.com/coreos/mantle/storage"
 	"github.com/coreos/mantle/util"
@@ -59,12 +60,17 @@ var (
 			displayName: "Azure",
 			handler:     azurePreRelease,
 		},
+		"oci": platform{
+			displayName: "OCI",
+			handler:     ociPreRelease,
+		},
 	}
 	platformList []string
 
 	selectedPlatforms  []string
 	azureProfile       string
 	awsCredentialsFile string
+	ociProfile         string
 	verifyKeyFile      string
 	imageInfoFile      string
 )
@@ -77,6 +83,7 @@ type platform struct {
 type imageInfo struct {
 	AWS   *amiList        `json:"aws,omitempty"`
 	Azure *azureImageInfo `json:"azure,omitempty"`
+	OCI   *ociList        `json:"oci,omitempty"`
 }
 
 func init() {
@@ -88,6 +95,7 @@ func init() {
 	cmdPreRelease.Flags().StringSliceVar(&selectedPlatforms, "platform", platformList, "platform to pre-release")
 	cmdPreRelease.Flags().StringVar(&azureProfile, "azure-profile", "", "Azure Profile json file")
 	cmdPreRelease.Flags().StringVar(&awsCredentialsFile, "aws-credentials", "", "AWS credentials file")
+	cmdPreRelease.Flags().StringVar(&ociProfile, "oci-profile", "", "OCI profile file")
 	cmdPreRelease.Flags().StringVar(&verifyKeyFile,
 		"verify-key", "", "path to ASCII-armored PGP public key to be used in verifying download signatures.  Defaults to CoreOS Buildbot (0412 7D0B FABE C887 1FFB  2CCE 50E0 8855 93D2 DCB4)")
 	cmdPreRelease.Flags().StringVar(&imageInfoFile, "write-image-list", "", "optional output file describing uploaded images")
@@ -613,5 +621,61 @@ func awsPreRelease(ctx context.Context, client *http.Client, src *storage.Bucket
 	}
 
 	imageInfo.AWS = &amis
+	return nil
+}
+
+type ociList struct {
+	Images []string `json:"images"`
+}
+
+func ociUploadImage(acc ociAccountSpec, region ociRegionSpec, imageName, imagePath string, list *ociList) error {
+	api, err := oci.New(&oci.Options{
+		ConfigPath: ociProfile,
+		Profile:    acc.ProfileName,
+		Region:     region.Name,
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, bucket := range region.Buckets {
+		imageName := fmt.Sprintf("%v%v", bucket.Prefix, imageName)
+		img, err := api.UploadImage(bucket.Name, imageName, imagePath)
+		if err != nil {
+			return err
+		}
+		list.Images = append(list.Images, fmt.Sprintf(
+			"https://objectstorage.%s.oraclecloud.com/n/%s/b/%s/o/%s",
+			region.Name, img.HeadObject.Namespace, img.HeadObject.Bucket, imageName))
+	}
+
+	return nil
+}
+
+func ociPreRelease(ctx context.Context, client *http.Client, src *storage.Bucket, spec *channelSpec, imageInfo *imageInfo) error {
+	if spec.OCI.Image == "" {
+		plog.Notice("OCI image creation disabled.")
+		return nil
+	}
+
+	imageName := fmt.Sprintf("%v-%v-%v.img", spec.OCI.BaseName, specChannel, specVersion)
+	imageName = regexp.MustCompile(`[^A-Za-z0-9()\\./_-]`).ReplaceAllLiteralString(imageName, "_")
+
+	imagePath, err := getImageFile(client, src, spec.OCI.Image)
+	if err != nil {
+		return err
+	}
+
+	var list ociList
+	for _, acc := range spec.OCI.Accounts {
+		for _, region := range acc.Regions {
+			err = ociUploadImage(acc, region, imageName, imagePath, &list)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	imageInfo.OCI = &list
 	return nil
 }

--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -32,6 +32,7 @@ import (
 	"github.com/coreos/mantle/platform/api/aws"
 	"github.com/coreos/mantle/platform/api/azure"
 	"github.com/coreos/mantle/platform/api/gcloud"
+	"github.com/coreos/mantle/platform/api/oci"
 	"github.com/coreos/mantle/storage"
 	"github.com/coreos/mantle/storage/index"
 )
@@ -49,6 +50,7 @@ var (
 func init() {
 	cmdRelease.Flags().StringVar(&awsCredentialsFile, "aws-credentials", "", "AWS credentials file")
 	cmdRelease.Flags().StringVar(&azureProfile, "azure-profile", "", "Azure Profile json file")
+	cmdRelease.Flags().StringVar(&ociProfile, "oci-profile", "", "OCI profile file")
 	cmdRelease.Flags().BoolVarP(&releaseDryRun, "dry-run", "n", false,
 		"perform a trial run, do not make changes")
 	AddSpecFlags(cmdRelease.Flags())
@@ -91,6 +93,9 @@ func runRelease(cmd *cobra.Command, args []string) {
 
 	// Make AWS images public.
 	doAWS(ctx, client, src, &spec)
+
+	// Make OCI images public.
+	doOCI(ctx, client, src, &spec)
 
 	for _, dSpec := range spec.Destinations {
 		dst, err := storage.NewBucket(client, dSpec.BaseURL)
@@ -429,6 +434,54 @@ func doAWS(ctx context.Context, client *http.Client, src *storage.Bucket, spec *
 			}
 			publish(imageName)
 			publish(imageName + "-hvm")
+		}
+	}
+}
+
+func doOCI(ctx context.Context, client *http.Client, src *storage.Bucket, spec *channelSpec) {
+	if spec.OCI.Image == "" {
+		plog.Notice("OCI image creation disabled.")
+		return
+	}
+
+	imageName := fmt.Sprintf("%v-%v-%v.img", spec.OCI.BaseName, specChannel, specVersion)
+
+	for _, acc := range spec.OCI.Accounts {
+		for _, region := range acc.Regions {
+			api, err := oci.New(&oci.Options{
+				ConfigPath: ociProfile,
+				Profile:    acc.ProfileName,
+				Region:     region.Name,
+			})
+			if err != nil {
+				plog.Fatalf("creating client for %v in %v: %v", acc.ProfileName, region.Name, err)
+			}
+
+			for _, bucket := range region.Buckets {
+				// If the bucket Prefix is an empty string then the bucket is not
+				// considered a release bucket, skip it.
+				if bucket.Prefix == "" {
+					continue
+				}
+
+				// If the released image already exists then continue.
+				if _, err = api.HeadImage(bucket.Name, imageName); err == nil {
+					continue
+				}
+
+				preName := fmt.Sprintf("%v%v", bucket.Prefix, imageName)
+				_, err = api.HeadImage(bucket.Name, preName)
+				if err != nil {
+					plog.Fatalf("couldn't find image %q in %v %v: %v", preName, acc.ProfileName, region.Name, err)
+				}
+
+				if !releaseDryRun {
+					err = api.RenameImage(bucket.Name, preName, imageName)
+					if err != nil {
+						plog.Fatalf("renaming image %q in %v %v: %v", preName, acc.ProfileName, region.Name, err)
+					}
+				}
+			}
 		}
 	}
 }

--- a/cmd/plume/specs.go
+++ b/cmd/plume/specs.go
@@ -82,6 +82,32 @@ type awsSpec struct {
 	Partitions      []awsPartitionSpec // AWS partitions
 }
 
+type ociBucketSpec struct {
+	Name string
+
+	// If this prefix is anything other than empty string the bucket
+	// will be considered a release bucket and a rename will occur
+	// during the plume release stage which will remove the Prefix
+	// string from the front of the image name.
+	Prefix string
+}
+
+type ociRegionSpec struct {
+	Name    string
+	Buckets []ociBucketSpec
+}
+
+type ociAccountSpec struct {
+	ProfileName string
+	Regions     []ociRegionSpec
+}
+
+type ociSpec struct {
+	BaseName string
+	Image    string
+	Accounts []ociAccountSpec
+}
+
 type channelSpec struct {
 	BaseURL      string // Copy from $BaseURL/$Board/$Version
 	Boards       []string
@@ -89,6 +115,7 @@ type channelSpec struct {
 	GCE          gceSpec
 	Azure        azureSpec
 	AWS          awsSpec
+	OCI          ociSpec
 }
 
 var (
@@ -98,6 +125,7 @@ var (
 	gceBoards         = []string{"amd64-usr"}
 	azureBoards       = []string{"amd64-usr"}
 	awsBoards         = []string{"amd64-usr"}
+	ociBoards         = []string{"amd64-usr"}
 	azureEnvironments = []azureEnvironmentSpec{
 		azureEnvironmentSpec{
 			SubscriptionName:     "BizSpark",
@@ -206,6 +234,26 @@ var (
 					},
 				},
 			},
+			OCI: ociSpec{
+				BaseName: "Container-Linux",
+				Image:    "coreos_production_oracle_oci_qcow_image.img.bz2",
+				Accounts: []ociAccountSpec{
+					ociAccountSpec{
+						ProfileName: "developer",
+						Regions: []ociRegionSpec{
+							ociRegionSpec{
+								Name: "us-phoenix-1",
+								Buckets: []ociBucketSpec{
+									ociBucketSpec{
+										Name:   "plume-user",
+										Prefix: "",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		"developer": channelSpec{
 			BaseURL: "gs://builds.developer.core-os.net/boards",
@@ -234,6 +282,26 @@ var (
 						},
 						Regions: []string{
 							"us-west-2",
+						},
+					},
+				},
+			},
+			OCI: ociSpec{
+				BaseName: "Container-Linux",
+				Image:    "coreos_production_oracle_oci_qcow_image.img.bz2",
+				Accounts: []ociAccountSpec{
+					ociAccountSpec{
+						ProfileName: "developer",
+						Regions: []ociRegionSpec{
+							ociRegionSpec{
+								Name: "us-phoenix-1",
+								Buckets: []ociBucketSpec{
+									ociBucketSpec{
+										Name:   "plume-developer",
+										Prefix: "",
+									},
+								},
+							},
 						},
 					},
 				},
@@ -295,6 +363,40 @@ var (
 				Image:           "coreos_production_ami_vmdk_image.vmdk.bz2",
 				Partitions:      awsPartitions,
 			},
+			OCI: ociSpec{
+				BaseName: "Container-Linux",
+				Image:    "coreos_production_oracle_oci_qcow_image.img.bz2",
+				Accounts: []ociAccountSpec{
+					ociAccountSpec{
+						ProfileName: "developer",
+						Regions: []ociRegionSpec{
+							ociRegionSpec{
+								Name: "us-phoenix-1",
+								Buckets: []ociBucketSpec{
+									ociBucketSpec{
+										Name:   "plume-prerelease",
+										Prefix: "",
+									},
+								},
+							},
+						},
+					},
+					ociAccountSpec{
+						ProfileName: "release",
+						Regions: []ociRegionSpec{
+							ociRegionSpec{
+								Name: "us-phoenix-1",
+								Buckets: []ociBucketSpec{
+									ociBucketSpec{
+										Name:   "CoreOS_Drop",
+										Prefix: "prerelease/",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		"beta": channelSpec{
 			BaseURL: "gs://builds.release.core-os.net/beta/boards",
@@ -350,6 +452,40 @@ var (
 				Image:           "coreos_production_ami_vmdk_image.vmdk.bz2",
 				Partitions:      awsPartitions,
 			},
+			OCI: ociSpec{
+				BaseName: "Container-Linux",
+				Image:    "coreos_production_oracle_oci_qcow_image.img.bz2",
+				Accounts: []ociAccountSpec{
+					ociAccountSpec{
+						ProfileName: "developer",
+						Regions: []ociRegionSpec{
+							ociRegionSpec{
+								Name: "us-phoenix-1",
+								Buckets: []ociBucketSpec{
+									ociBucketSpec{
+										Name:   "plume-prerelease",
+										Prefix: "",
+									},
+								},
+							},
+						},
+					},
+					ociAccountSpec{
+						ProfileName: "release",
+						Regions: []ociRegionSpec{
+							ociRegionSpec{
+								Name: "us-phoenix-1",
+								Buckets: []ociBucketSpec{
+									ociBucketSpec{
+										Name:   "CoreOS_Drop",
+										Prefix: "prerelease/",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		"stable": channelSpec{
 			BaseURL: "gs://builds.release.core-os.net/stable/boards",
@@ -394,6 +530,40 @@ var (
 				Prefix:          "coreos_production_ami_",
 				Image:           "coreos_production_ami_vmdk_image.vmdk.bz2",
 				Partitions:      awsPartitions,
+			},
+			OCI: ociSpec{
+				BaseName: "Container-Linux",
+				Image:    "coreos_production_oracle_oci_qcow_image.img.bz2",
+				Accounts: []ociAccountSpec{
+					ociAccountSpec{
+						ProfileName: "developer",
+						Regions: []ociRegionSpec{
+							ociRegionSpec{
+								Name: "us-phoenix-1",
+								Buckets: []ociBucketSpec{
+									ociBucketSpec{
+										Name:   "plume-prerelease",
+										Prefix: "",
+									},
+								},
+							},
+						},
+					},
+					ociAccountSpec{
+						ProfileName: "release",
+						Regions: []ociRegionSpec{
+							ociRegionSpec{
+								Name: "us-phoenix-1",
+								Buckets: []ociBucketSpec{
+									ociBucketSpec{
+										Name:   "CoreOS_Drop",
+										Prefix: "prerelease/",
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -469,6 +639,17 @@ func ChannelSpec() channelSpec {
 	}
 	if !awsOk {
 		spec.AWS = awsSpec{}
+	}
+
+	ociOk := false
+	for _, board := range ociBoards {
+		if specBoard == board {
+			ociOk = true
+			break
+		}
+	}
+	if !ociOk {
+		spec.OCI = ociSpec{}
 	}
 
 	return spec

--- a/platform/api/oci/image.go
+++ b/platform/api/oci/image.go
@@ -21,13 +21,22 @@ import (
 	"github.com/oracle/bmcs-go-sdk"
 )
 
-func (a *API) UploadImage(bucketName, name, filePath string) (*baremetal.Object, error) {
+func (a *API) getNamespace() (*baremetal.Namespace, error) {
 	namespace, err := a.client.GetNamespace()
 	if err != nil {
 		return nil, err
 	}
 	if namespace == nil {
 		return nil, fmt.Errorf("namespace was nil")
+	}
+
+	return namespace, nil
+}
+
+func (a *API) UploadImage(bucketName, name, filePath string) (*baremetal.Object, error) {
+	namespace, err := a.getNamespace()
+	if err != nil {
+		return nil, err
 	}
 
 	data, err := ioutil.ReadFile(filePath)
@@ -41,4 +50,22 @@ func (a *API) UploadImage(bucketName, name, filePath string) (*baremetal.Object,
 		ContentType: "application/octet-stream",
 	}
 	return a.client.PutObject(*namespace, bucketName, name, data, &opts)
+}
+
+func (a *API) HeadImage(bucketName, name string) (*baremetal.HeadObject, error) {
+	namespace, err := a.getNamespace()
+	if err != nil {
+		return nil, err
+	}
+
+	return a.client.HeadObject(*namespace, bucketName, name, nil)
+}
+
+func (a *API) RenameImage(bucketName, oldName, newName string) error {
+	namespace, err := a.getNamespace()
+	if err != nil {
+		return err
+	}
+
+	return a.client.RenameObject(*namespace, bucketName, oldName, newName)
 }

--- a/vendor/github.com/oracle/bmcs-go-sdk/object_storage_objects.go
+++ b/vendor/github.com/oracle/bmcs-go-sdk/object_storage_objects.go
@@ -229,3 +229,27 @@ func (c *Client) PutObject(
 	object.Body = content
 	return
 }
+
+func (c *Client) RenameObject(namespace Namespace, bucketName, sourceName, destName string) (e error) {
+	required := struct {
+		SourceName string `header:"-" json:"sourceName" url:"-"`
+		NewName    string `header:"-" json:"newName" url:"-"`
+	}{
+		SourceName: sourceName,
+		NewName:    destName,
+	}
+
+	details := &requestDetails{
+		ids: urlParts{
+			namespace,
+			resourceBuckets,
+			bucketName,
+			"actions",
+			"renameObject",
+		},
+		required: required,
+	}
+
+	_, e = c.objectStorageApi.request(http.MethodPost, details)
+	return
+}


### PR DESCRIPTION
Updates the `go-bmcs-sdk` to add a RenameObject call to objectstorage, adds OCI to plume prerelease & release, and adds a `rename` function to ore.

## Plume Actions

### Pre-Release:

Uploads the image into objectstorage. The account & buckets vary based on the channel being ran.

`user` Channel:
 * Upload image to `developer` account in the `plume-developer` bucket in `us-phoenix-1`

`developer` Channel:
 * Upload image to `developer` account in the `plume-user` bucket in `us-phoenix-1`

`alpha` / `beta` / `stable` Channels:
 * Upload image to `developer` account in the `plume-prerelease` bucket in `us-phoenix-1`
 * Upload image to `release` account in the `CoreOS_Drop` bucket in `us-phoenix-1` with the image name prefixed by `prerelease/`

### Release:

Renames previously created images to drop the prefix specified in the `ociBucketSpec`.