### PR TITLE
cmd/plume: stop granting AWS launch permissions to coreosdev

### DIFF
--- a/cmd/plume/specs.go
+++ b/cmd/plume/specs.go
@@ -117,7 +117,6 @@ var (
 			Bucket:       "coreos-prod-ami-import-us-west-2",
 			BucketRegion: "us-west-2",
 			LaunchPermissions: []string{
-				"477645798544", // coreosdev
 				"017021077683", // coreos-cl
 			},
 			Regions: []string{
@@ -198,7 +197,7 @@ var (
 						Bucket:       "coreos-dev-ami-import-us-east-2",
 						BucketRegion: "us-east-2",
 						LaunchPermissions: []string{
-							"477645798544",
+							"595879546273", // prod account, to test LaunchPermissions
 						},
 						Regions: []string{
 							"us-east-2",
@@ -229,9 +228,6 @@ var (
 						Profile:      "coreos-cl",
 						Bucket:       "coreos-dev-ami-import-us-west-2",
 						BucketRegion: "us-west-2",
-						LaunchPermissions: []string{
-							"477645798544",
-						},
 						Regions: []string{
 							"us-west-2",
 						},


### PR DESCRIPTION
The coreosdev account is defunct. Drop its LaunchPermissions from all channels. Add LaunchPermissions for the prod account on the user channel so we're still testing this functionality in plume.