### PR TITLE
platform/api/do: fix GetUserImage returning wrong image

### DIFF
--- a/platform/api/do/api.go
+++ b/platform/api/do/api.go
@@ -245,6 +245,7 @@ func (a *API) GetUserImage(ctx context.Context, imageName string, inRegion bool)
 			return nil, err
 		}
 		for _, image := range images {
+			image := image
 			if image.Name != imageName {
 				continue
 			}


### PR DESCRIPTION
This affected image selection when launching images by name, and when deleting them using `ore do delete-image`.