### PR TITLE
kola/harness: only obtain discovery URL if needed

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -375,15 +375,15 @@ func runTest(h *harness.H, t *register.Test, pltfrm string) {
 	}()
 
 	if t.ClusterSize > 0 {
-		url, err := c.GetDiscoveryURL(t.ClusterSize)
-		if err != nil {
-			h.Fatalf("Failed to create discovery endpoint: %v", err)
-		}
-
 		userdata := t.UserData
-		if userdata != nil {
+		if userdata != nil && userdata.Contains("$discovery") {
+			url, err := c.GetDiscoveryURL(t.ClusterSize)
+			if err != nil {
+				h.Fatalf("Failed to create discovery endpoint: %v", err)
+			}
 			userdata = userdata.Subst("$discovery", url)
 		}
+
 		if _, err := platform.NewMachines(c, userdata, t.ClusterSize); err != nil {
 			h.Fatalf("Cluster failed starting machines: %v", err)
 		}

--- a/platform/conf/conf.go
+++ b/platform/conf/conf.go
@@ -125,6 +125,11 @@ func Unknown(data string) *UserData {
 	return u
 }
 
+// Contains returns true if the UserData contains the specified string.
+func (u *UserData) Contains(substr string) bool {
+	return strings.Contains(u.data, substr)
+}
+
 // Performs a string substitution and returns a new UserData.
 func (u *UserData) Subst(old, new string) *UserData {
 	ret := *u


### PR DESCRIPTION
Prevent discovery service problems from causing test failures for tests that don't use it.