### PR TITLE
Log machine destruction and make Destroy() void

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -328,11 +328,7 @@ func getClusterSemver(pltfrm, outputDir string) (*semver.Version, error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating cluster for semver check: %v", err)
 	}
-	defer func() {
-		if err := cluster.Destroy(); err != nil {
-			plog.Errorf("cluster.Destroy(): %v", err)
-		}
-	}()
+	defer cluster.Destroy()
 
 	m, err := cluster.NewMachine(nil)
 	if err != nil {
@@ -376,9 +372,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string) {
 		h.Fatalf("Cluster failed: %v", err)
 	}
 	defer func() {
-		if err := c.Destroy(); err != nil {
-			plog.Errorf("cluster.Destroy(): %v", err)
-		}
+		c.Destroy()
 		for id, output := range c.ConsoleOutput() {
 			for _, badness := range CheckConsole([]byte(output), t) {
 				h.Errorf("Found %s on machine %s console", badness, id)

--- a/platform/journal.go
+++ b/platform/journal.go
@@ -112,19 +112,17 @@ func (j *Journal) Start(ctx context.Context, m Machine) error {
 	return nil
 }
 
-func (j *Journal) Destroy() error {
-	var err multierror.Error
+func (j *Journal) Destroy() {
 	if j.cancel != nil {
 		j.cancel()
-		if e := j.recorder.Wait(); e != nil {
-			err = append(err, e)
+		if err := j.recorder.Wait(); err != nil {
+			plog.Errorf("j.recorder.Wait() failed: %v", err)
 		}
 	}
-	if e := j.journal.Close(); e != nil {
-		err = append(err, e)
+	if err := j.journal.Close(); err != nil {
+		plog.Errorf("Failed to close journal: %v", err)
 	}
-	if e := j.journalRaw.Close(); e != nil {
-		err = append(err, e)
+	if err := j.journalRaw.Close(); err != nil {
+		plog.Errorf("Failed to close raw journal: %v", err)
 	}
-	return err.AsError()
 }

--- a/platform/local/dnsmasq.go
+++ b/platform/local/dnsmasq.go
@@ -221,6 +221,8 @@ func (dm *Dnsmasq) GetInterface(bridge string) (in *Interface) {
 	panic("Not a valid bridge!")
 }
 
-func (dm *Dnsmasq) Destroy() error {
-	return dm.dnsmasq.Kill()
+func (dm *Dnsmasq) Destroy() {
+	if err := dm.dnsmasq.Kill(); err != nil {
+		plog.Errorf("Error killing dnsmasq: %v", err)
+	}
 }

--- a/platform/local/etcd.go
+++ b/platform/local/etcd.go
@@ -97,16 +97,11 @@ func NewSimpleEtcd() (*SimpleEtcd, error) {
 	return se, nil
 }
 
-func (se *SimpleEtcd) Destroy() error {
-	var err error
-	firstErr := func(e error) {
-		if e != nil && err == nil {
-			err = e
-		}
-	}
-
+func (se *SimpleEtcd) Destroy() {
 	if se.listener != nil {
-		firstErr(se.listener.Close())
+		if err := se.listener.Close(); err != nil {
+			plog.Errorf("Error closing etcd listener: %v", err)
+		}
 	}
 
 	if se.server != nil {
@@ -114,10 +109,10 @@ func (se *SimpleEtcd) Destroy() error {
 	}
 
 	if se.dataDir != "" {
-		firstErr(os.RemoveAll(se.dataDir))
+		if err := os.RemoveAll(se.dataDir); err != nil {
+			plog.Errorf("Error removing etcd data dir: %v", err)
+		}
 	}
-
-	return err
 }
 
 // Generate all publishable URLs for a given HTTP port.

--- a/platform/local/omaha.go
+++ b/platform/local/omaha.go
@@ -1,0 +1,31 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package local
+
+import (
+	"github.com/coreos/go-omaha/omaha"
+)
+
+// OmahaWrapper wraps the omaha trivial server to log any errors returned by destroy
+// and doesn't return anything instead
+type OmahaWrapper struct {
+	*omaha.TrivialServer
+}
+
+func (o OmahaWrapper) Destroy() {
+	if err := o.TrivialServer.Destroy(); err != nil {
+		plog.Errorf("Error destroying omaha server: %v", err)
+	}
+}

--- a/platform/machine/aws/cluster.go
+++ b/platform/machine/aws/cluster.go
@@ -19,9 +19,15 @@ import (
 	"path/filepath"
 
 	ctplatform "github.com/coreos/container-linux-config-transpiler/config/platform"
+	"github.com/coreos/pkg/capnslog"
+
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/api/aws"
 	"github.com/coreos/mantle/platform/conf"
+)
+
+var (
+	plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "platform/machine/aws")
 )
 
 type cluster struct {
@@ -115,12 +121,12 @@ func (ac *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 	return mach, nil
 }
 
-func (ac *cluster) Destroy() error {
+func (ac *cluster) Destroy() {
 	if !ac.RuntimeConf().NoSSHKeyInMetadata {
 		if err := ac.api.DeleteKey(ac.Name()); err != nil {
-			return err
+			plog.Errorf("Error deleting key %v: %v", ac.Name(), err)
 		}
 	}
 
-	return ac.BaseCluster.Destroy()
+	ac.BaseCluster.Destroy()
 }

--- a/platform/machine/aws/machine.go
+++ b/platform/machine/aws/machine.go
@@ -60,25 +60,21 @@ func (am *machine) Reboot() error {
 	return platform.RebootMachine(am, am.journal, am.cluster.RuntimeConf())
 }
 
-func (am *machine) Destroy() error {
+func (am *machine) Destroy() {
 	if err := am.cluster.api.TerminateInstances([]string{am.ID()}); err != nil {
-		return err
+		plog.Errorf("Error terminating instance %v: %v", am.ID(), err)
 	}
 
 	if am.journal != nil {
-		if err := am.journal.Destroy(); err != nil {
-			return err
-		}
+		am.journal.Destroy()
 	}
 
 	// faster when run after termination
 	if err := am.saveConsole(); err != nil {
-		return err
+		plog.Errorf("Error saving console for instance %v: %v", am.ID(), err)
 	}
 
 	am.cluster.DelMach(am)
-
-	return nil
 }
 
 func (am *machine) ConsoleOutput() string {

--- a/platform/machine/do/cluster.go
+++ b/platform/machine/do/cluster.go
@@ -140,10 +140,10 @@ func (dc *cluster) vmname() string {
 	return fmt.Sprintf("%s-%x", dc.Name()[0:13], b)
 }
 
-func (dc *cluster) Destroy() error {
+func (dc *cluster) Destroy() {
 	if err := dc.api.DeleteKey(context.TODO(), dc.sshKeyID); err != nil {
-		return err
+		plog.Errorf("Error deleting key %v: %v", dc.sshKeyID, err)
 	}
 
-	return dc.BaseCluster.Destroy()
+	dc.BaseCluster.Destroy()
 }

--- a/platform/machine/do/machine.go
+++ b/platform/machine/do/machine.go
@@ -60,19 +60,16 @@ func (dm *machine) Reboot() error {
 	return platform.RebootMachine(dm, dm.journal, dm.cluster.RuntimeConf())
 }
 
-func (dm *machine) Destroy() error {
+func (dm *machine) Destroy() {
 	if err := dm.cluster.api.DeleteDroplet(context.TODO(), dm.droplet.ID); err != nil {
-		return err
+		plog.Errorf("Error deleting droplet %v: %v", dm.droplet.ID, err)
 	}
 
 	if dm.journal != nil {
-		if err := dm.journal.Destroy(); err != nil {
-			return err
-		}
+		dm.journal.Destroy()
 	}
 
 	dm.cluster.DelMach(dm)
-	return nil
 }
 
 func (dm *machine) ConsoleOutput() string {

--- a/platform/machine/esx/machine.go
+++ b/platform/machine/esx/machine.go
@@ -61,28 +61,24 @@ func (em *machine) Reboot() error {
 	return platform.RebootMachine(em, em.journal, em.cluster.RuntimeConf())
 }
 
-func (em *machine) Destroy() error {
+func (em *machine) Destroy() {
 	if err := em.cluster.api.TerminateDevice(em.ID()); err != nil {
-		return err
+		plog.Errorf("Error terminating device %v: %v", em.ID(), err)
 	}
 
 	if em.journal != nil {
-		if err := em.journal.Destroy(); err != nil {
-			return err
-		}
+		em.journal.Destroy()
 	}
 
 	if err := em.saveConsole(); err != nil {
-		return err
+		plog.Errorf("Error saving console for device %v: %v", em.ID(), err)
 	}
 
 	if err := em.cluster.api.CleanupDevice(em.ID()); err != nil {
-		return err
+		plog.Errorf("Error cleaning up device for device %v: %v", em.ID(), err)
 	}
 
 	em.cluster.DelMach(em)
-
-	return nil
 }
 
 func (em *machine) ConsoleOutput() string {

--- a/platform/machine/gcloud/machine.go
+++ b/platform/machine/gcloud/machine.go
@@ -61,25 +61,20 @@ func (gm *machine) Reboot() error {
 	return platform.RebootMachine(gm, gm.journal, gm.gc.RuntimeConf())
 }
 
-func (gm *machine) Destroy() error {
+func (gm *machine) Destroy() {
 	if err := gm.saveConsole(); err != nil {
-		// log error, but do not fail to terminate instance
-		plog.Error(err)
+		plog.Errorf("Error saving console for instance %v: %v", gm.ID(), err)
 	}
 
 	if err := gm.gc.api.TerminateInstance(gm.name); err != nil {
-		return err
+		plog.Errorf("Error terminating instance %v: %v", gm.ID(), err)
 	}
 
 	if gm.journal != nil {
-		if err := gm.journal.Destroy(); err != nil {
-			return err
-		}
+		gm.journal.Destroy()
 	}
 
 	gm.gc.DelMach(gm)
-
-	return nil
 }
 
 func (gm *machine) ConsoleOutput() string {

--- a/platform/machine/oci/machine.go
+++ b/platform/machine/oci/machine.go
@@ -61,25 +61,20 @@ func (om *machine) Reboot() error {
 	return platform.RebootMachine(om, om.journal, om.cluster.RuntimeConf())
 }
 
-func (om *machine) Destroy() error {
+func (om *machine) Destroy() {
 	if err := om.saveConsole(); err != nil {
-		// log error, but do not fail to terminate instance
-		plog.Error(err)
+		plog.Errorf("Error saving console for instance %v: %v", om.ID(), err)
 	}
 
 	if err := om.cluster.api.TerminateInstance(om.ID()); err != nil {
-		return fmt.Errorf("terminating instance: %v", err)
+		plog.Errorf("Error terminating instance %v: %v", om.ID(), err)
 	}
 
 	if om.journal != nil {
-		if err := om.journal.Destroy(); err != nil {
-			return err
-		}
+		om.journal.Destroy()
 	}
 
 	om.cluster.DelMach(om)
-
-	return nil
 }
 
 func (om *machine) ConsoleOutput() string {

--- a/platform/machine/packet/cluster.go
+++ b/platform/machine/packet/cluster.go
@@ -157,12 +157,12 @@ func (pc *cluster) vmname() string {
 	return fmt.Sprintf("%s-%x", pc.Name()[0:13], b)
 }
 
-func (pc *cluster) Destroy() error {
+func (pc *cluster) Destroy() {
 	if pc.sshKeyID != "" {
 		if err := pc.api.DeleteKey(pc.sshKeyID); err != nil {
-			return err
+			plog.Errorf("Error deleting key %v: %v", pc.sshKeyID, err)
 		}
 	}
 
-	return pc.BaseCluster.Destroy()
+	pc.BaseCluster.Destroy()
 }

--- a/platform/machine/packet/machine.go
+++ b/platform/machine/packet/machine.go
@@ -60,19 +60,16 @@ func (pm *machine) Reboot() error {
 	return platform.RebootMachine(pm, pm.journal, pm.cluster.RuntimeConf())
 }
 
-func (pm *machine) Destroy() error {
+func (pm *machine) Destroy() {
 	if err := pm.cluster.api.DeleteDevice(pm.ID()); err != nil {
-		return err
+		plog.Errorf("Error terminating device %v: %v", pm.ID(), err)
 	}
 
 	if pm.journal != nil {
-		if err := pm.journal.Destroy(); err != nil {
-			return err
-		}
+		pm.journal.Destroy()
 	}
 
 	pm.cluster.DelMach(pm)
-	return nil
 }
 
 func (pm *machine) ConsoleOutput() string {

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -56,8 +56,9 @@ type Machine interface {
 	// Reboot restarts the machine and waits for it to come back.
 	Reboot() error
 
-	// Destroy terminates the machine and frees associated resources.
-	Destroy() error
+	// Destroy terminates the machine and frees associated resources. It should log
+	// any failures; since they are not actionable, it does not return an error.
+	Destroy()
 
 	// ConsoleOutput returns the machine's console output if available,
 	// or an empty string.  Only expected to be valid after Destroy().
@@ -76,8 +77,9 @@ type Cluster interface {
 	GetDiscoveryURL(size int) (string, error)
 
 	// Destroy terminates each machine in the cluster and frees any other
-	// associated resources.
-	Destroy() error
+	// associated resources. It should log any failures; since they are not
+	// actionable, it does not return an error
+	Destroy()
 
 	// ConsoleOutput returns a map of console output from destroyed
 	// cluster machines.

--- a/update/generator/generator_test.go
+++ b/update/generator/generator_test.go
@@ -32,11 +32,8 @@ type testGenerator struct {
 }
 
 // Report errors to testing framework instead of return value.
-func (g *testGenerator) Destroy() error {
-	if err := g.Generator.Destroy(); err != nil {
-		g.t.Errorf("Generator.Destroy: %v", err)
-	}
-	return nil
+func (g *testGenerator) Destroy() {
+	g.Generator.Destroy()
 }
 
 func TestGenerateWithoutPartition(t *testing.T) {


### PR DESCRIPTION
Use multierror to keep trying to clean things up when destroying machines, even if part of it errors out. We should clean up as much as possible. Also log the errors in `Destroy()` itself, since the callers rarely look at the return value.