### PR TITLE
kola: check for disk failure on console

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -93,6 +93,10 @@ var (
 			match: regexp.MustCompile(`WARNING: CPU: \d+ PID: \d+ at (.+)`),
 		},
 		{
+			desc:  "failure of disk under I/O",
+			match: regexp.MustCompile("rejecting I/O to offline device"),
+		},
+		{
 			// https://github.com/coreos/bugs/issues/2065
 			desc:  "excessive bonding link status messages",
 			match: regexp.MustCompile("(?s:link status up for interface [^,]+, enabling it in [0-9]+ ms.*?){10}"),


### PR DESCRIPTION
Detects e.g. failure of iSCSI session recovery when `iscsid` is started on OCI. This is not necessarily an OS problem, but will cause the test to fail anyway.