### PR TITLE
kola/tests: disable coreos.etcd-member.v2-backup-restore on OCI

### DIFF
--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -72,7 +72,7 @@ etcd:
   initial_advertise_peer_urls: http://{PRIVATE_IPV4}:2380
   discovery:                   $discovery
 `),
-		ExcludePlatforms: []string{"qemu", "esx"}, // etcd-member requires networking and ct rendering
+		ExcludePlatforms: []string{"qemu", "esx", "oci"}, // etcd-member requires networking and ct rendering
 	})
 
 	register.Register(&register.Test{


### PR DESCRIPTION
The test requires ct rendering which is not available for the OCI
platform.