### PR TITLE
cmd/ore/packet: add fields required to instantiate API

### DIFF
--- a/cmd/ore/packet/create-device.go
+++ b/cmd/ore/packet/create-device.go
@@ -44,9 +44,6 @@ func init() {
 	cmdCreateDevice.Flags().StringVar(&options.Board, "board", "amd64-usr", "Container Linux board")
 	cmdCreateDevice.Flags().StringVar(&options.InstallerImageBaseURL, "installer-image-base-url", "", "installer image base URL, non-https (default board-dependent, e.g. \"http://stable.release.core-os.net/amd64-usr/current\")")
 	cmdCreateDevice.Flags().StringVar(&options.ImageURL, "image-url", "", "image base URL (default board-dependent, e.g. \"https://alpha.release.core-os.net/amd64-usr/current/coreos_production_packet_image.bin.bz2\")")
-	cmdCreateDevice.Flags().StringVar(&options.StorageURL, "storage-url", "gs://users.developer.core-os.net/"+os.Getenv("USER")+"/mantle", "Google Storage base URL for temporary uploads")
-	cmdCreateDevice.Flags().StringVar(&gsOptions.JSONKeyFile, "gs-json-key", "", "use a Google service account's JSON key to authenticate to Google Storage")
-	cmdCreateDevice.Flags().BoolVar(&gsOptions.ServiceAuth, "gs-service-auth", false, "use non-interactive Google auth when running within GCE")
 	cmdCreateDevice.Flags().StringVar(&hostname, "hostname", "", "hostname to assign to device")
 	cmdCreateDevice.Flags().StringVar(&userDataPath, "userdata-file", "", "path to file containing userdata")
 }

--- a/cmd/ore/packet/packet.go
+++ b/cmd/ore/packet/packet.go
@@ -16,6 +16,7 @@ package packet
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/coreos/mantle/auth"
 	"github.com/coreos/mantle/cli"
@@ -40,6 +41,9 @@ var (
 
 func init() {
 	options.GSOptions = &gsOptions
+	Packet.PersistentFlags().StringVar(&options.StorageURL, "storage-url", "gs://users.developer.core-os.net/"+os.Getenv("USER")+"/mantle", "Google Storage base URL for temporary uploads")
+	Packet.PersistentFlags().StringVar(&gsOptions.JSONKeyFile, "gs-json-key", "", "use a Google service account's JSON key to authenticate to Google Storage")
+	Packet.PersistentFlags().BoolVar(&gsOptions.ServiceAuth, "gs-service-auth", false, "use non-interactive Google auth when running within GCE")
 	Packet.PersistentFlags().StringVar(&options.ConfigPath, "config-file", "", "config file (default \"~/"+auth.PacketConfigPath+"\")")
 	Packet.PersistentFlags().StringVar(&options.Profile, "profile", "", "profile (default \"default\")")
 	Packet.PersistentFlags().StringVar(&options.ApiKey, "api-key", "", "API key (overrides config file)")


### PR DESCRIPTION
To instantiate a Packet API you're required to provide a working
gcloud JSON key & bucket storage URL. To be able to run ore for
Packet on things like Jenkins where we don't have these in the
pre-configured locations we need to add these options and plumb
them through.