### PR TITLE
kola/tests/misc/nfs: require 1618.0.0 or later

### DIFF
--- a/kola/tests/misc/nfs.go
+++ b/kola/tests/misc/nfs.go
@@ -19,6 +19,8 @@ import (
 	"path"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
+
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/platform/conf"
@@ -49,11 +51,13 @@ func init() {
 		Run:         NFSv3,
 		ClusterSize: 0,
 		Name:        "linux.nfs.v3",
+		MinVersion:  semver.Version{Major: 1618},
 	})
 	register.Register(&register.Test{
 		Run:         NFSv4,
 		ClusterSize: 0,
 		Name:        "linux.nfs.v4",
+		MinVersion:  semver.Version{Major: 1618},
 	})
 }
 


### PR DESCRIPTION
Versions prior to 1618.0.0 have a race between rpcbind and mountd that causes the test to fail. Do not run the test on these version.