### PR TITLE
kola/tests/misc: Ignore dead links in all of /run/systemd

### DIFF
--- a/kola/tests/misc/files.go
+++ b/kola/tests/misc/files.go
@@ -75,7 +75,7 @@ func DeadLinks(c cluster.TestCluster) {
 	ignore := []string{
 		"/dev",
 		"/proc",
-		"/run/systemd/units",
+		"/run/systemd",
 		"/run/udev/watch",
 		"/sys",
 		"/var/lib/docker",


### PR DESCRIPTION
Since we previously had users defined in baselayout that were also marked as dynamic users, nss-systemd based its UIDs etc. off those.  When they were deleted from baselayout, more links were created to manage them under `/run/systemd/dynamic-uid`.

This just ignores all of `/run/systemd` in case future changes or different configuration results in more dead links.