### PR TITLE
kola/harness: don't fail if its not our fault

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -390,7 +390,11 @@ func runTest(h *harness.H, t *register.Test, pltfrm string) {
 		if userdata != nil && userdata.Contains("$discovery") {
 			url, err := c.GetDiscoveryURL(t.ClusterSize)
 			if err != nil {
-				h.Fatalf("Failed to create discovery endpoint: %v", err)
+				// Skip instead of failing since the harness not being able to
+				// get a discovery url is likely an outage (e.g
+				// 503 Service Unavailable: Back-end server is at capacity)
+				// not a problem with the OS
+				h.Skipf("Failed to create discovery endpoint: %v", err)
 			}
 			userdata = userdata.Subst("$discovery", url)
 		}


### PR DESCRIPTION
Skip the test if we can't get an etcd discovery url. If it's an outage
with etcd then we shouldn't fail, if it's a problem with the test suite
we should see a bunch of skips.

Lets have less test flakes.