### PR TITLE
kola/options/do: increase default droplet size

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -70,7 +70,7 @@ func init() {
 	sv(&kola.DOOptions.Profile, "do-profile", "", "DigitalOcean profile (default \"default\")")
 	sv(&kola.DOOptions.AccessToken, "do-token", "", "DigitalOcean access token (overrides config file)")
 	sv(&kola.DOOptions.Region, "do-region", "sfo2", "DigitalOcean region slug")
-	sv(&kola.DOOptions.Size, "do-size", "512mb", "DigitalOcean size slug")
+	sv(&kola.DOOptions.Size, "do-size", "1gb", "DigitalOcean size slug")
 	sv(&kola.DOOptions.Image, "do-image", "alpha", "DigitalOcean image ID, {alpha, beta, stable}, or user image name")
 
 	// esx-specific options


### PR DESCRIPTION
DigitalOcean recently upped the ram in all the droplets for free. Use
beefier instances becuase it costs the same. This should also fix the
coreos.toolbox.dnf-install test that previously failed due to being
OOM-killed