### PR TITLE
platform/machine/do: retry creating droplets

### DIFF
--- a/platform/machine/do/cluster.go
+++ b/platform/machine/do/cluster.go
@@ -20,13 +20,16 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/coreos/pkg/capnslog"
+	"github.com/digitalocean/godo"
 
 	ctplatform "github.com/coreos/container-linux-config-transpiler/config/platform"
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/api/do"
 	"github.com/coreos/mantle/platform/conf"
+	"github.com/coreos/mantle/util"
 )
 
 var (
@@ -87,8 +90,15 @@ func (dc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 		return nil, err
 	}
 
-	droplet, err := dc.api.CreateDroplet(context.TODO(), dc.vmname(), dc.sshKeyID, conf.String())
-	if err != nil {
+	var droplet *godo.Droplet
+	// DO frequently gives us 422 errors saying "Please try again"
+	if err := util.RetryConditional(6, 10*time.Second, shouldRetry, func() error {
+		droplet, err = dc.api.CreateDroplet(context.TODO(), dc.vmname(), dc.sshKeyID, conf.String())
+		if err != nil {
+			plog.Errorf("Error creating droplet: %v, retrying...", err)
+		}
+		return err
+	}); err != nil {
 		return nil, err
 	}
 
@@ -146,4 +156,15 @@ func (dc *cluster) Destroy() {
 	}
 
 	dc.BaseCluster.Destroy()
+}
+
+// shouldRetry returns if the error is from DigitalOcean and we should
+// retry the request which generated it
+func shouldRetry(err error) bool {
+	errResp, ok := err.(*godo.ErrorResponse)
+	if !ok {
+		return false
+	}
+	status := errResp.Response.StatusCode
+	return status == 422 || status >= 500
 }

--- a/util/retry.go
+++ b/util/retry.go
@@ -23,11 +23,20 @@ import (
 // Retry delays for delay between calls of f. If f does not succeed after
 // attempts calls, the error from the last call is returned.
 func Retry(attempts int, delay time.Duration, f func() error) error {
+	return RetryConditional(attempts, delay, func(_ error) bool { return true }, f)
+}
+
+// RetryConditional calls function f until it has been called attemps times, or succeeds.
+// Retry delays for delay between calls of f. If f does not succeed after
+// attempts calls, the error from the last call is returned.
+// If shouldRetry returns false on the error generated, RetryConditional stops immediately
+// and returns the error
+func RetryConditional(attempts int, delay time.Duration, shouldRetry func(err error) bool, f func() error) error {
 	var err error
 
 	for i := 0; i < attempts; i++ {
 		err = f()
-		if err == nil {
+		if err == nil || !shouldRetry(err) {
 			break
 		}
 


### PR DESCRIPTION
Droplet creation frequently fails because DO returns a error 422 and
says try again. Take their advice and try again if droplet creation
fails.