### PR TITLE
cmd/kola: teach spawn to put local SSH keys into userdata

### DIFF
--- a/cmd/kola/spawn.go
+++ b/cmd/kola/spawn.go
@@ -43,6 +43,7 @@ var (
 
 	spawnNodeCount      int
 	spawnUserData       string
+	spawnDetach         bool
 	spawnShell          bool
 	spawnRemove         bool
 	spawnVerbose        bool
@@ -54,6 +55,7 @@ var (
 func init() {
 	cmdSpawn.Flags().IntVarP(&spawnNodeCount, "nodecount", "c", 1, "number of nodes to spawn")
 	cmdSpawn.Flags().StringVarP(&spawnUserData, "userdata", "u", "", "file containing userdata to pass to the instances")
+	cmdSpawn.Flags().BoolVarP(&spawnDetach, "detach", "t", false, "-kv --shell=false --remove=false")
 	cmdSpawn.Flags().BoolVarP(&spawnShell, "shell", "s", true, "spawn a shell in an instance before exiting")
 	cmdSpawn.Flags().BoolVarP(&spawnRemove, "remove", "r", true, "remove instances after shell exits")
 	cmdSpawn.Flags().BoolVarP(&spawnVerbose, "verbose", "v", false, "output information about spawned instances")
@@ -72,6 +74,13 @@ func runSpawn(cmd *cobra.Command, args []string) {
 
 func doSpawn(cmd *cobra.Command, args []string) error {
 	var err error
+
+	if spawnDetach {
+		spawnSetSSHKeys = true
+		spawnVerbose = true
+		spawnShell = false
+		spawnRemove = false
+	}
 
 	if spawnNodeCount <= 0 {
 		return fmt.Errorf("Cluster Failed: nodecount must be one or more")

--- a/cmd/kola/spawn.go
+++ b/cmd/kola/spawn.go
@@ -141,7 +141,7 @@ func doSpawn(cmd *cobra.Command, args []string) error {
 		}
 
 		if spawnVerbose {
-			fmt.Printf("Machine spawned at %v\n", mach.IP())
+			fmt.Printf("Machine %v spawned at %v\n", mach.ID(), mach.IP())
 		}
 
 		someMach = mach

--- a/platform/conf/conf.go
+++ b/platform/conf/conf.go
@@ -1,4 +1,4 @@
-// Copyright 2016 CoreOS, Inc.
+// Copyright 2016-2018 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -387,16 +387,32 @@ func (c *Conf) AddSystemdUnitDropin(service, name, contents string) {
 }
 
 func (c *Conf) copyKeysIgnitionV1(keys []*agent.Key) {
+	keyStrs := keysToStrings(keys)
+	for i := range c.ignitionV1.Passwd.Users {
+		user := &c.ignitionV1.Passwd.Users[i]
+		if user.Name == "core" {
+			user.SSHAuthorizedKeys = append(user.SSHAuthorizedKeys, keyStrs...)
+			return
+		}
+	}
 	c.ignitionV1.Passwd.Users = append(c.ignitionV1.Passwd.Users, v1types.User{
 		Name:              "core",
-		SSHAuthorizedKeys: keysToStrings(keys),
+		SSHAuthorizedKeys: keyStrs,
 	})
 }
 
 func (c *Conf) copyKeysIgnitionV2(keys []*agent.Key) {
+	keyStrs := keysToStrings(keys)
+	for i := range c.ignitionV2.Passwd.Users {
+		user := &c.ignitionV2.Passwd.Users[i]
+		if user.Name == "core" {
+			user.SSHAuthorizedKeys = append(user.SSHAuthorizedKeys, keyStrs...)
+			return
+		}
+	}
 	c.ignitionV2.Passwd.Users = append(c.ignitionV2.Passwd.Users, v2types.User{
 		Name:              "core",
-		SSHAuthorizedKeys: keysToStrings(keys),
+		SSHAuthorizedKeys: keyStrs,
 	})
 }
 
@@ -404,6 +420,13 @@ func (c *Conf) copyKeysIgnitionV21(keys []*agent.Key) {
 	var keyObjs []v21types.SSHAuthorizedKey
 	for _, key := range keys {
 		keyObjs = append(keyObjs, v21types.SSHAuthorizedKey(key.String()))
+	}
+	for i := range c.ignitionV21.Passwd.Users {
+		user := &c.ignitionV21.Passwd.Users[i]
+		if user.Name == "core" {
+			user.SSHAuthorizedKeys = append(user.SSHAuthorizedKeys, keyObjs...)
+			return
+		}
 	}
 	c.ignitionV21.Passwd.Users = append(c.ignitionV21.Passwd.Users, v21types.PasswdUser{
 		Name:              "core",


### PR DESCRIPTION
To use, run `kola spawn -k`.

Also add `kola spawn {-t,--detach}`, which is sugar for starting a machine, injecting local SSH keys, printing its ID and IP, and exiting.