### PR TITLE
kola/tests/misc/update: mask update-engine

### DIFF
--- a/kola/tests/misc/update.go
+++ b/kola/tests/misc/update.go
@@ -22,6 +22,18 @@ import (
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/platform"
+	"github.com/coreos/mantle/platform/conf"
+)
+
+var (
+	// prevents a race where update-engine sets the boot partition back to
+	// USR-A after the test sets it to USR-B
+	disableUpdateEngine = conf.ContainerLinuxConfig(`systemd:
+  units:
+    - name: update-engine.service
+      mask: true
+    - name: locksmithd.service
+      mask: true`)
 )
 
 func init() {
@@ -29,18 +41,21 @@ func init() {
 		Run:         RebootIntoUSRB,
 		ClusterSize: 1,
 		Name:        "coreos.update.reboot",
+		UserData:    disableUpdateEngine,
 	})
 	register.Register(&register.Test{
 		Run:         RecoverBadVerity,
 		ClusterSize: 1,
 		Name:        "coreos.update.badverity",
 		Flags:       []register.Flag{register.NoEmergencyShellCheck},
+		UserData:    disableUpdateEngine,
 	})
 	register.Register(&register.Test{
 		Run:         RecoverBadUsr,
 		ClusterSize: 1,
 		Name:        "coreos.update.badusr",
 		Flags:       []register.Flag{register.NoEmergencyShellCheck},
+		UserData:    disableUpdateEngine,
 	})
 }
 


### PR DESCRIPTION
This fixes a race where update-engine sets the boot partition back to USR-A after the test sets it to USR-B.

At least we think that's what going on. This seems to have fixed it locally, but the flakyness of the tests makes it hard to know.