### PR TITLE
kola/tests: disable Ignition remote resource fetches on DO

### DIFF
--- a/kola/tests/docker/torcx_manifest_pkgs.go
+++ b/kola/tests/docker/torcx_manifest_pkgs.go
@@ -31,10 +31,12 @@ import (
 
 func init() {
 	register.Register(&register.Test{
-		Run:              dockerTorcxManifestPkgs,
-		ClusterSize:      0,
-		Name:             "docker.torcx-manifest-pkgs",
-		ExcludePlatforms: []string{"qemu"}, // Downloads torcx packages
+		Run:         dockerTorcxManifestPkgs,
+		ClusterSize: 0,
+		Name:        "docker.torcx-manifest-pkgs",
+		// Downloads torcx packages
+		// https://github.com/coreos/bugs/issues/2205 for DO
+		ExcludePlatforms: []string{"qemu", "do"},
 		// the first version torcx manifests were shipped
 		MinVersion: semver.Version{Major: 1520},
 	})

--- a/kola/tests/ignition/resource.go
+++ b/kola/tests/ignition/resource.go
@@ -73,12 +73,15 @@ func init() {
 		NativeFuncs: map[string]func() error{
 			"Serve": Serve,
 		},
+		// https://github.com/coreos/bugs/issues/2205
+		ExcludePlatforms: []string{"do"},
 	})
 	register.Register(&register.Test{
-		Name:             "coreos.ignition.v2_1.resource.remote",
-		Run:              resourceRemote,
-		ClusterSize:      1,
-		ExcludePlatforms: []string{"qemu"},
+		Name:        "coreos.ignition.v2_1.resource.remote",
+		Run:         resourceRemote,
+		ClusterSize: 1,
+		// https://github.com/coreos/bugs/issues/2205 for DO
+		ExcludePlatforms: []string{"qemu", "do"},
 		UserData: conf.Ignition(`{
 		  "ignition": {
 		      "version": "2.1.0"


### PR DESCRIPTION
DigitalOcean doesn't have proper networking in the initramfs. This is a known issue and there's no point cluttering our test logs.

cc @arithx @ajeddeloh 