### PR TITLE
cmd/kola: switch default AWS instance type to m4.large

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -61,7 +61,7 @@ func init() {
 	sv(&kola.AWSOptions.Region, "aws-region", defaultRegion, "AWS region")
 	sv(&kola.AWSOptions.Profile, "aws-profile", "default", "AWS profile name")
 	sv(&kola.AWSOptions.AMI, "aws-ami", "alpha", `AWS AMI ID, or (alpha|beta|stable) to use the latest image`)
-	sv(&kola.AWSOptions.InstanceType, "aws-type", "t2.small", "AWS instance type")
+	sv(&kola.AWSOptions.InstanceType, "aws-type", "m4.large", "AWS instance type")
 	sv(&kola.AWSOptions.SecurityGroup, "aws-sg", "kola", "AWS security group name")
 	sv(&kola.AWSOptions.IAMInstanceProfile, "aws-iam-profile", "kola", "AWS IAM instance profile name")
 


### PR DESCRIPTION
Only the first 100 `t2` instances per region per account per day receive launch CPU credits. Now that AWS has per-second instance billing and we have automatic instance GC, it's safe to switch to a type without this limitation.