### PR TITLE
Don't create PV AMIs in regions that don't support them

### DIFF
--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -402,7 +402,9 @@ func doAWS(ctx context.Context, client *http.Client, src *storage.Bucket, spec *
 					}
 				}
 			}
-			publish(imageName)
+			if aws.RegionSupportsPV(region) {
+				publish(imageName)
+			}
 			publish(imageName + "-hvm")
 		}
 	}

--- a/cmd/plume/specs.go
+++ b/cmd/plume/specs.go
@@ -126,6 +126,7 @@ var (
 				"us-west-2",
 				"eu-west-1",
 				"eu-west-2",
+				"eu-west-3",
 				"eu-central-1",
 				"ap-south-1",
 				"ap-southeast-1",
@@ -152,6 +153,7 @@ var (
 			BucketRegion: "cn-north-1",
 			Regions: []string{
 				"cn-north-1",
+				"cn-northwest-1",
 			},
 		},
 	}
@@ -188,6 +190,7 @@ var (
 						Regions: []string{
 							"us-west-1",
 							"us-west-2",
+							"eu-west-3", // no PV
 						},
 					},
 					awsPartitionSpec{

--- a/platform/api/aws/images.go
+++ b/platform/api/aws/images.go
@@ -15,6 +15,7 @@
 package aws
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -27,6 +28,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/iam"
+)
+
+var (
+	NoRegionPVSupport = errors.New("Region does not support PV")
 )
 
 type EC2ImageType string
@@ -63,6 +68,11 @@ var akis = map[string]string{
 
 	"us-gov-west-1": "aki-1de98d3e",
 	"cn-north-1":    "aki-9e8f1da7",
+}
+
+func RegionSupportsPV(region string) bool {
+	_, ok := akis[region]
+	return ok
 }
 
 func (e *EC2ImageFormat) Set(s string) error {
@@ -353,6 +363,9 @@ func (a *API) CreateHVMImage(snapshotID string, name string, description string)
 }
 
 func (a *API) CreatePVImage(snapshotID string, name string, description string) (string, error) {
+	if !RegionSupportsPV(a.opts.Region) {
+		return "", NoRegionPVSupport
+	}
 	params := registerImageParams(snapshotID, name, description, "sd", EC2ImageTypePV)
 	params.KernelId = aws.String(akis[a.opts.Region])
 	return a.createImage(params)
@@ -438,6 +451,14 @@ func (a *API) CopyImage(sourceImageID string, regions []string) (map[string]stri
 	image, err := a.describeImage(sourceImageID)
 	if err != nil {
 		return nil, err
+	}
+
+	if *image.VirtualizationType == ec2.VirtualizationTypeParavirtual {
+		for _, region := range regions {
+			if !RegionSupportsPV(region) {
+				return nil, NoRegionPVSupport
+			}
+		}
 	}
 
 	describeSnapshotRes, err := a.ec2.DescribeSnapshots(&ec2.DescribeSnapshotsInput{

--- a/platform/api/aws/images.go
+++ b/platform/api/aws/images.go
@@ -62,6 +62,7 @@ var akis = map[string]string{
 	"ca-central-1":   "aki-320ebd56",
 
 	"us-gov-west-1": "aki-1de98d3e",
+	"cn-north-1":    "aki-9e8f1da7",
 }
 
 func (e *EC2ImageFormat) Set(s string) error {


### PR DESCRIPTION
Add `eu-west-3` and `cn-northwest-1`, which don't, to plume.  Add PV AKI ID for `cn-north-1`, which does.