### PR TITLE
cmd/cork: switch enter default to new enter

### DIFF
--- a/cmd/cork/create.go
+++ b/cmd/cork/create.go
@@ -48,6 +48,8 @@ var (
 	allowReplace bool
 
 	// only for `enter` command
+	legacy bool
+	// only for `enter` command, deprecated.
 	experimental bool
 
 	// only for `update` command
@@ -123,8 +125,11 @@ func init() {
 	root.AddCommand(createCmd)
 
 	enterCmd.Flags().AddFlagSet(chrootFlags)
+	enterCmd.Flags().BoolVar(&legacy,
+		"legacy", false, "Use old enter implementation")
 	enterCmd.Flags().BoolVar(&experimental,
-		"experimental", false, "Use new enter implementation")
+		"experimental", true, "Do not use. Kept for compatibility")
+	enterCmd.Flags().MarkDeprecated("experimental", "--experimental is now default. This flag will be removed soon. Use --legacy for the old enter method.")
 	root.AddCommand(enterCmd)
 
 	deleteCmd.Flags().AddFlagSet(chrootFlags)
@@ -262,9 +267,9 @@ func updateRepo() {
 }
 
 func runEnter(cmd *cobra.Command, args []string) {
-	enter := sdk.OldEnter
-	if experimental {
-		enter = sdk.Enter
+	enter := sdk.Enter
+	if legacy || !experimental {
+		enter = sdk.OldEnter
 	}
 
 	if err := enter(chrootName, args...); err != nil && len(args) != 0 {


### PR DESCRIPTION
Change `cork enter`'s default to be what used to be the --experimental
flag. Rename the flag to --legacy and make that use the old enter
method.

Keep the experimental flag, but make it no-op and warn that it will go
away soon.

Doesn't strictly depend on https://github.com/coreos/mantle/pull/812 but that should probably be merged first.