### PR TITLE
cmd/kola: warn in PS1 if exiting shell will destroy spawned machine

### DIFF
--- a/cmd/kola/spawn.go
+++ b/cmd/kola/spawn.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
@@ -157,6 +158,12 @@ func doSpawn(cmd *cobra.Command, args []string) error {
 	}
 
 	if spawnShell {
+		if spawnRemove {
+			reader := strings.NewReader(`PS1="\033[0;31m[bound]\033[0m $PS1"` + "\n")
+			if err := platform.InstallFile(reader, someMach, "/etc/profile.d/kola-spawn-bound.sh"); err != nil {
+				return fmt.Errorf("Setting shell prompt failed: %v", err)
+			}
+		}
 		if err := platform.Manhole(someMach); err != nil {
 			return fmt.Errorf("Manhole failed: %v", err)
 		}


### PR DESCRIPTION
When running instances spawned with `kola spawn` alongside instances started in other ways (including `kola spawn -t`), it's easy to accidentally terminate a machine by exiting a shell. To avoid this, when starting a shell which is bound to the lifetime of its instance, add `[bound]` to its shell prompt. Ideally this marker would only appear in the affected shell (and not shells from other SSH connections) but there doesn't seem to be a good way to do that, so it will appear in every shell on that machine.