### PR TITLE
make: default to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
-.PHONY: vendor
+.PHONY: build test vendor
+build:
+	./build
+
+test:
+	./test
+
 vendor:
 	@glide update --strip-vendor
 	@glide-vc --use-lock-file --no-tests --only-code


### PR DESCRIPTION
A passerby who sees a makefile is likely to type make and expect it to
build the thing, not to redo the vendor folder.

For completeness, I tossed in a test target as well.

I've had this diff locally for a while, and it's saved me from many an accidental re-vendor already.