### PR TITLE
Add cork enter --legacy and --bind-gpg-agent

### DIFF
--- a/cmd/cork/create.go
+++ b/cmd/cork/create.go
@@ -49,6 +49,8 @@ var (
 
 	// only for `enter` command
 	experimental bool
+	legacy       bool
+	bindGpgAgent bool
 
 	// only for `update` command
 	allowCreate      bool
@@ -125,6 +127,11 @@ func init() {
 	enterCmd.Flags().AddFlagSet(chrootFlags)
 	enterCmd.Flags().BoolVar(&experimental,
 		"experimental", false, "Use new enter implementation")
+	enterCmd.Flags().MarkDeprecated("experimental", "--experimental is now default and the flag will be removed soon. Implies --bind-gpg-agent=false")
+	enterCmd.Flags().BoolVar(&legacy,
+		"legacy", false, "Use the old enter implementation")
+	enterCmd.Flags().BoolVar(&bindGpgAgent,
+		"bind-gpg-agent", true, "bind mount the gpg agent socket directory")
 	root.AddCommand(enterCmd)
 
 	deleteCmd.Flags().AddFlagSet(chrootFlags)
@@ -262,12 +269,19 @@ func updateRepo() {
 }
 
 func runEnter(cmd *cobra.Command, args []string) {
-	enter := sdk.OldEnter
 	if experimental {
-		enter = sdk.Enter
+		bindGpgAgent = false
+		legacy = false
 	}
 
-	if err := enter(chrootName, args...); err != nil && len(args) != 0 {
+	var err error
+	if legacy {
+		err = sdk.OldEnter(chrootName, args...)
+	} else {
+		err = sdk.Enter(chrootName, bindGpgAgent, args...)
+	}
+
+	if err != nil && len(args) != 0 {
 		plog.Fatalf("Running %v failed: %v", args, err)
 	}
 }
@@ -349,7 +363,7 @@ func runUpdate(cmd *cobra.Command, args []string) {
 
 	updateRepo()
 
-	if err := sdk.Enter(chrootName, updateCommand...); err != nil {
+	if err := sdk.Enter(chrootName, false, updateCommand...); err != nil {
 		plog.Fatalf("update_chroot failed: %v", err)
 	}
 }

--- a/sdk/repo.go
+++ b/sdk/repo.go
@@ -129,12 +129,15 @@ func BuildImageDir(board, version string) string {
 }
 
 func RepoInit(chroot, url, branch, name string) error {
-	return enterChroot(
-		chroot, chrootRepoRoot, "--",
-		"repo", "init",
-		"--manifest-url", url,
-		"--manifest-branch", branch,
-		"--manifest-name", name)
+	return enterChroot(enter{
+		Chroot: chroot,
+		CmdDir: chrootRepoRoot,
+		Cmd: []string{"--",
+			"repo", "init",
+			"--manifest-url", url,
+			"--manifest-branch", branch,
+			"--manifest-name", name,
+		}})
 }
 
 func RepoVerifyTag(branch string) error {
@@ -153,5 +156,9 @@ func RepoSync(chroot string, force bool) error {
 	if force {
 		args = append(args, "--force-sync")
 	}
-	return enterChroot(chroot, chrootRepoRoot, args...)
+	return enterChroot(enter{
+		Chroot: chroot,
+		CmdDir: chrootRepoRoot,
+		Cmd:    args,
+	})
 }


### PR DESCRIPTION
Add cork enter `--legacy` and `--bind-gpg-agent`. Additionally refactor the enter code to make adding new similar options easier and more clear.

The changes in `sdk/repo` are untested at the moment and should be tested with Jenkins before we attempt a release with these changes, although I don't _think_ they should cause any problems.