### PR TITLE
kola: add support for debugging systemd units

### DIFF
--- a/platform/base.go
+++ b/platform/base.go
@@ -171,6 +171,10 @@ func (bc *BaseCluster) RenderUserData(userdata *conf.UserData, ignitionVars map[
 		return nil, err
 	}
 
+	for _, dropin := range bc.baseopts.SystemdDropins {
+		conf.AddSystemdUnitDropin(dropin.Unit, dropin.Name, dropin.Contents)
+	}
+
 	if !bc.rconf.NoSSHKeyInUserData {
 		keys, err := bc.Keys()
 		if err != nil {

--- a/platform/base.go
+++ b/platform/base.go
@@ -47,13 +47,14 @@ type BaseCluster struct {
 	rconf      *RuntimeConfig
 	platform   Name
 	ctPlatform string
+	baseopts   *Options
 }
 
-func NewBaseCluster(basename string, rconf *RuntimeConfig, platform Name, ctPlatform string) (*BaseCluster, error) {
-	return NewBaseClusterWithDialer(basename, rconf, platform, ctPlatform, network.NewRetryDialer())
+func NewBaseCluster(opts *Options, rconf *RuntimeConfig, platform Name, ctPlatform string) (*BaseCluster, error) {
+	return NewBaseClusterWithDialer(opts, rconf, platform, ctPlatform, network.NewRetryDialer())
 }
 
-func NewBaseClusterWithDialer(basename string, rconf *RuntimeConfig, platform Name, ctPlatform string, dialer network.Dialer) (*BaseCluster, error) {
+func NewBaseClusterWithDialer(opts *Options, rconf *RuntimeConfig, platform Name, ctPlatform string, dialer network.Dialer) (*BaseCluster, error) {
 	agent, err := network.NewSSHAgent(dialer)
 	if err != nil {
 		return nil, err
@@ -63,10 +64,11 @@ func NewBaseClusterWithDialer(basename string, rconf *RuntimeConfig, platform Na
 		agent:      agent,
 		machmap:    make(map[string]Machine),
 		consolemap: make(map[string]string),
-		name:       fmt.Sprintf("%s-%s", basename, uuid.NewV4()),
+		name:       fmt.Sprintf("%s-%s", opts.BaseName, uuid.NewV4()),
 		rconf:      rconf,
 		platform:   platform,
 		ctPlatform: ctPlatform,
+		baseopts:   opts,
 	}
 
 	return bc, nil

--- a/platform/local/cluster.go
+++ b/platform/local/cluster.go
@@ -44,7 +44,7 @@ type LocalCluster struct {
 	nshandle    netns.NsHandle
 }
 
-func NewLocalCluster(basename string, rconf *platform.RuntimeConfig, platformName platform.Name) (*LocalCluster, error) {
+func NewLocalCluster(opts *platform.Options, rconf *platform.RuntimeConfig, platformName platform.Name) (*LocalCluster, error) {
 	lc := &LocalCluster{}
 
 	var err error
@@ -55,7 +55,7 @@ func NewLocalCluster(basename string, rconf *platform.RuntimeConfig, platformNam
 	lc.AddCloser(&lc.nshandle)
 
 	nsdialer := network.NewNsDialer(lc.nshandle)
-	lc.BaseCluster, err = platform.NewBaseClusterWithDialer(basename, rconf, platformName, "", nsdialer)
+	lc.BaseCluster, err = platform.NewBaseClusterWithDialer(opts, rconf, platformName, "", nsdialer)
 	if err != nil {
 		lc.Destroy()
 		return nil, err

--- a/platform/machine/aws/cluster.go
+++ b/platform/machine/aws/cluster.go
@@ -51,7 +51,7 @@ func NewCluster(opts *aws.Options, rconf *platform.RuntimeConfig) (platform.Clus
 		return nil, err
 	}
 
-	bc, err := platform.NewBaseCluster(opts.BaseName, rconf, Platform, ctplatform.EC2)
+	bc, err := platform.NewBaseCluster(opts.Options, rconf, Platform, ctplatform.EC2)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/machine/do/cluster.go
+++ b/platform/machine/do/cluster.go
@@ -49,7 +49,7 @@ func NewCluster(opts *do.Options, rconf *platform.RuntimeConfig) (platform.Clust
 		return nil, err
 	}
 
-	bc, err := platform.NewBaseCluster(opts.BaseName, rconf, Platform, ctplatform.DO)
+	bc, err := platform.NewBaseCluster(opts.Options, rconf, Platform, ctplatform.DO)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/machine/esx/cluster.go
+++ b/platform/machine/esx/cluster.go
@@ -48,7 +48,7 @@ func NewCluster(opts *esx.Options, rconf *platform.RuntimeConfig) (platform.Clus
 		return nil, err
 	}
 
-	bc, err := platform.NewBaseCluster(opts.BaseName, rconf, Platform, "")
+	bc, err := platform.NewBaseCluster(opts.Options, rconf, Platform, "")
 	if err != nil {
 		return nil, err
 	}

--- a/platform/machine/gcloud/cluster.go
+++ b/platform/machine/gcloud/cluster.go
@@ -48,7 +48,7 @@ func NewCluster(opts *gcloud.Options, rconf *platform.RuntimeConfig) (platform.C
 		return nil, err
 	}
 
-	bc, err := platform.NewBaseCluster(opts.BaseName, rconf, Platform, ctplatform.GCE)
+	bc, err := platform.NewBaseCluster(opts.Options, rconf, Platform, ctplatform.GCE)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/machine/oci/cluster.go
+++ b/platform/machine/oci/cluster.go
@@ -47,7 +47,7 @@ func NewCluster(opts *oci.Options, rconf *platform.RuntimeConfig) (platform.Clus
 		return nil, err
 	}
 
-	bc, err := platform.NewBaseCluster(opts.BaseName, rconf, Platform, "")
+	bc, err := platform.NewBaseCluster(opts.Options, rconf, Platform, "")
 	if err != nil {
 		return nil, err
 	}

--- a/platform/machine/packet/cluster.go
+++ b/platform/machine/packet/cluster.go
@@ -48,7 +48,7 @@ func NewCluster(opts *packet.Options, rconf *platform.RuntimeConfig) (platform.C
 		return nil, err
 	}
 
-	bc, err := platform.NewBaseCluster(opts.BaseName, rconf, Platform, ctplatform.Packet)
+	bc, err := platform.NewBaseCluster(opts.Options, rconf, Platform, ctplatform.Packet)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/machine/qemu/cluster.go
+++ b/platform/machine/qemu/cluster.go
@@ -78,7 +78,7 @@ var (
 // NewCluster creates a Cluster instance, suitable for running virtual
 // machines in QEMU.
 func NewCluster(opts *Options, rconf *platform.RuntimeConfig) (platform.Cluster, error) {
-	lc, err := local.NewLocalCluster(opts.BaseName, rconf, Platform)
+	lc, err := local.NewLocalCluster(opts.Options, rconf, Platform)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -95,9 +95,17 @@ type Cluster interface {
 	ConsoleOutput() map[string]string
 }
 
+// SystemdDropin is a userdata type agnostic struct representing a systemd dropin
+type SystemdDropin struct {
+	Unit     string
+	Name     string
+	Contents string
+}
+
 // Options contains the base options for all clusters.
 type Options struct {
-	BaseName string
+	BaseName       string
+	SystemdDropins []SystemdDropin
 }
 
 // RuntimeConfig contains cluster-specific configuration.


### PR DESCRIPTION
Add support for enabling debug logging on `systemd-*.unittype` units. It
creates drop in units that sets the environment variable
`SYSTEMD_LOG_LEVEL=debug` for the listed units. It applies to both spawn
and run commands.

I'm not 100% this is the best interface for this. We could make it more generic and let users specify whatever dropins they want, but that makes it more verbose. Hell we could even let them supply a whole Ignition config to append. I think this is a good start though and we can add those things if we decide we want them. I'd like to enable this on the nightly with `systemd-networkd.service` and `systemd-networkd-wait-online.service` to hunt down that flake.