### PR TITLE
kola/harness: update segfault regex

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -117,7 +117,7 @@ var (
 		},
 		{
 			desc:  "segfault",
-			match: regexp.MustCompile("SEGV"),
+			match: regexp.MustCompile("SIGSEGV|=11/SEGV"),
 		},
 		{
 			desc:  "core dump",


### PR DESCRIPTION
The current regex to check for segfaults looks for `SEGV` which
incorrectly triggered when an SSH key on the machine had SEGV in it.
This updates the regex to `SIGSEGV`.