### PR TITLE
Bump timeouts for packet, ec2

### DIFF
--- a/platform/api/aws/ec2.go
+++ b/platform/api/aws/ec2.go
@@ -107,8 +107,8 @@ func (a *API) CreateInstances(name, keyname, userdata string, count uint64) ([]*
 	// loop until all machines are online
 	var insts []*ec2.Instance
 
-	// 5 minutes is a pretty reasonable timeframe for AWS instances to work.
-	timeout := 5 * time.Minute
+	// 10 minutes is a pretty reasonable timeframe for AWS instances to work.
+	timeout := 10 * time.Minute
 	// don't make api calls too quickly, or we will hit the rate limit
 	delay := 10 * time.Second
 	err = util.WaitUntilReady(timeout, delay, func() (bool, error) {

--- a/platform/api/oci/instance.go
+++ b/platform/api/oci/instance.go
@@ -67,7 +67,7 @@ func (a *API) CreateInstance(name, userdata, sshKey string) (*Machine, error) {
 
 	id := inst.ID
 
-	err = util.WaitUntilReady(5*time.Minute, 10*time.Second, func() (bool, error) {
+	err = util.WaitUntilReady(10*time.Minute, 10*time.Second, func() (bool, error) {
 		inst, err = a.client.GetInstance(id)
 		if err != nil {
 			return false, err

--- a/platform/api/packet/api.go
+++ b/platform/api/packet/api.go
@@ -41,10 +41,10 @@ import (
 )
 
 const (
-	// Provisioning a VM is supposed to take < 8 minutes.
+	// Provisioning a VM is supposed to take < 8 minutes, but in practice can take longer.
 	launchTimeout       = 10 * time.Minute
 	launchPollInterval  = 30 * time.Second
-	installTimeout      = 10 * time.Minute
+	installTimeout      = 15 * time.Minute
 	installPollInterval = 5 * time.Second
 	apiRetries          = 3
 	apiRetryInterval    = 5 * time.Second


### PR DESCRIPTION
Let's have fewer test failures due to clouds being slow.