### PR TITLE
coreos.locksmith.cluster: switch to using util.Timeout

### DIFF
--- a/kola/tests/misc/update.go
+++ b/kola/tests/misc/update.go
@@ -19,6 +19,8 @@ import (
 	"regexp"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/platform"
@@ -159,7 +161,7 @@ func rebootWithEmergencyShellTimeout(c cluster.TestCluster, m platform.Machine) 
 		c.Fatal(err)
 	}
 	time.Sleep(5 * time.Minute)
-	if err := platform.CheckMachine(m); err != nil {
+	if err := platform.CheckMachine(context.TODO(), m); err != nil {
 		c.Fatal(err)
 	}
 }

--- a/platform/util.go
+++ b/platform/util.go
@@ -117,7 +117,7 @@ func StartMachine(m Machine, j *Journal) error {
 	if err := j.Start(context.TODO(), m); err != nil {
 		return fmt.Errorf("machine %q failed to start: %v", m.ID(), err)
 	}
-	if err := CheckMachine(m); err != nil {
+	if err := CheckMachine(context.TODO(), m); err != nil {
 		return fmt.Errorf("machine %q failed basic checks: %v", m.ID(), err)
 	}
 	if !m.RuntimeConf().NoEnableSelinux {


### PR DESCRIPTION
Adds a new utility function `Timeout` and uses it in `coreos.locksmith.cluster` to prevent the test from spinning for extended durations.