### PR TITLE
platform/api/packet: fix ImageURL containing % characters

### DIFF
--- a/platform/api/packet/api.go
+++ b/platform/api/packet/api.go
@@ -295,6 +295,7 @@ func (a *API) wrapUserData(conf *conf.Conf) (string, error) {
 		// metadata endpoint.
 		userDataOption = "-i /noop.ign -c"
 	}
+	escapedImageURL := strings.Replace(a.opts.ImageURL, "%", "%%", -1)
 
 	// make systemd units
 	discardSocketUnit := `
@@ -346,7 +347,7 @@ StandardError=journal+console
 
 [Install]
 RequiredBy=multi-user.target
-`, a.opts.ImageURL, userDataOption)
+`, escapedImageURL, userDataOption)
 
 	// make workarounds
 	noopIgnitionConfig := base64.StdEncoding.EncodeToString([]byte(`{"ignition": {"version": "2.1.0"}}`))


### PR DESCRIPTION
Escape `%` characters before embedding `ImageURL` in `coreos-install.service` so systemd doesn't treat them as the start of a unit specifier.

Fixes error on stderr:

    kola: creating new machine for semver check: timed out waiting for coreos-install: dial tcp [ip]:9: i/o timeout

and corresponding error in `console.txt`:

    systemd[1]: /etc/systemd/system/coreos-install.service:16: Failed to resolve unit specifiers on [url]: Invalid slot