### PR TITLE
sdk/enter: make bind mount recursive.

### DIFF
--- a/sdk/enter.go
+++ b/sdk/enter.go
@@ -366,7 +366,7 @@ func enterChrootHelper(args []string) (err error) {
 		return err
 	}
 
-	if err := system.Bind(e.RepoRoot, newRepoRoot); err != nil {
+	if err := system.RecursiveBind(e.RepoRoot, newRepoRoot); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This is a break is compatibility between the legacy and new sdk enter
methods. Make them both recursive bind mounts.

Wait until after 1772.0.0 is released before merging.