### PR TITLE
platform/aws: check for missing Description before deref

### DIFF
--- a/platform/api/aws/images.go
+++ b/platform/api/aws/images.go
@@ -139,7 +139,7 @@ func (a *API) FindSnapshot(imageName string) (*Snapshot, error) {
 		return nil, fmt.Errorf("unable to describe import tasks: %v", err)
 	}
 	for _, task := range taskRes.ImportSnapshotTasks {
-		if *task.Description != imageName {
+		if task.Description == nil || *task.Description != imageName {
 			continue
 		}
 		switch *task.SnapshotTaskDetail.Status {


### PR DESCRIPTION
I'm trying to use `ore` and hit a `SIGSEGV` because we're expecting all
the snapshot import tasks to have a description. Unfortunately, that is
not the case on the account I'm targeting. Since we ourselves always add
a description, we can safely skip those tasks since they can't be one of
ours anyway.