### PR TITLE
ore/aws: fix up S3 object name calculation

### DIFF
--- a/cmd/ore/aws/upload.go
+++ b/cmd/ore/aws/upload.go
@@ -62,14 +62,14 @@ After a successful run, the final line of output will be a line of JSON describi
 func init() {
 	AWS.AddCommand(cmdUpload)
 	cmdUpload.Flags().StringVar(&uploadSourceObject, "source-object", "", "'s3://' URI pointing to image data (default: same as upload)")
-	cmdUpload.Flags().StringVar(&uploadBucket, "bucket", "", "s3://bucket/prefix/ (defaults to a regional bucket and prefix defaults to $USER)")
+	cmdUpload.Flags().StringVar(&uploadBucket, "bucket", "", "s3://bucket/prefix/ (defaults to a regional bucket and prefix defaults to $USER/board/name)")
 	cmdUpload.Flags().StringVar(&uploadImageName, "name", "", "name of uploaded image (default COREOS_VERSION)")
 	cmdUpload.Flags().StringVar(&uploadBoard, "board", "amd64-usr", "board used for naming with default prefix only")
 	cmdUpload.Flags().StringVar(&uploadFile, "file",
 		defaultUploadFile(),
 		"path to CoreOS image (build with: ./image_to_vm.sh --format=ami_vmdk ...)")
 	cmdUpload.Flags().BoolVar(&uploadDeleteObject, "delete-object", true, "delete uploaded S3 object after snapshot is created")
-	cmdUpload.Flags().BoolVar(&uploadForce, "force", false, "overwrite existing S3 object without prompt")
+	cmdUpload.Flags().BoolVar(&uploadForce, "force", false, "overwrite existing S3 object rather than reusing")
 	cmdUpload.Flags().StringVar(&uploadSourceSnapshot, "source-snapshot", "", "the snapshot ID to base this AMI on (default: create new snapshot)")
 	cmdUpload.Flags().Var(&uploadObjectFormat, "object-format", fmt.Sprintf("object format: %s or %s (default: %s)", aws.EC2ImageFormatVmdk, aws.EC2ImageFormatRaw, aws.EC2ImageFormatVmdk))
 	cmdUpload.Flags().StringVar(&uploadAMIName, "ami-name", "", "name of the AMI to create (default: Container-Linux-$USER-$VERSION)")

--- a/cmd/ore/aws/upload.go
+++ b/cmd/ore/aws/upload.go
@@ -106,17 +106,15 @@ func defaultBucketURL(urlPrefix, imageName, board, file, region string) (*url.UR
 		return nil, fmt.Errorf("URL missing bucket name %v\n", urlPrefix)
 	}
 
-	// if prefix not specified default name to s3://bucket/$USER/$BOARD/$VERSION
+	// if prefix not specified, default to /$USER/$BOARD/$VERSION
 	if s3URL.Path == "" {
-		user := os.Getenv("USER")
-
-		s3URL.Path = "/" + os.Getenv("USER")
-		s3URL.Path += "/" + board
-
-		fileName := filepath.Base(file)
-
-		s3URL.Path = fmt.Sprintf("/%s/%s/%s/%s", user, board, imageName, fileName)
+		s3URL.Path = fmt.Sprintf("/%s/%s/%s", os.Getenv("USER"), board, imageName)
 	}
+
+	if s3URL.Path[len(s3URL.Path)-1] != '/' {
+		s3URL.Path += "/"
+	}
+	s3URL.Path += filepath.Base(file)
 
 	return s3URL, nil
 }


### PR DESCRIPTION
Remember to append the source filename when the bucket prefix is specified. Also drop some dead code and correct some help strings.