### PR TITLE
platform/aws: add Name tag to created images

### DIFF
--- a/platform/api/aws/images.go
+++ b/platform/api/aws/images.go
@@ -396,6 +396,15 @@ func (a *API) createImage(params *ec2.RegisterImageInput) (string, error) {
 		return "", fmt.Errorf("error creating AMI: %v", err)
 	}
 
+	// We do this even in the already-exists path in case the previous
+	// run was interrupted.
+	err = a.CreateTags([]string{imageID}, map[string]string{
+		"Name": *params.Name,
+	})
+	if err != nil {
+		return "", fmt.Errorf("couldn't tag image name: %v", err)
+	}
+
 	return imageID, nil
 }
 

--- a/platform/api/aws/images.go
+++ b/platform/api/aws/images.go
@@ -374,26 +374,29 @@ func (a *API) CreatePVImage(snapshotID string, name string, description string) 
 func (a *API) createImage(params *ec2.RegisterImageInput) (string, error) {
 	res, err := a.ec2.RegisterImage(params)
 
+	var imageID string
 	if err == nil {
-		return *res.ImageId, nil
-	}
-	if awserr, ok := err.(awserr.Error); ok && awserr.Code() == "InvalidAMIName.Duplicate" {
+		imageID = *res.ImageId
+	} else if awserr, ok := err.(awserr.Error); ok && awserr.Code() == "InvalidAMIName.Duplicate" {
 		// The AMI already exists. Get its ID. Due to races, this
 		// may take several attempts.
 		for {
-			imageID, err := a.FindImage(*params.Name)
+			imageID, err = a.FindImage(*params.Name)
 			if err != nil {
 				return "", err
 			}
 			if imageID != "" {
 				plog.Infof("found existing image %v, reusing", imageID)
-				return imageID, nil
+				break
 			}
 			plog.Debugf("failed to locate image %q, retrying...", *params.Name)
 			time.Sleep(10 * time.Second)
 		}
+	} else {
+		return "", fmt.Errorf("error creating AMI: %v", err)
 	}
-	return "", fmt.Errorf("error creating AMI: %v", err)
+
+	return imageID, nil
 }
 
 const diskSize = 8 // GB


### PR DESCRIPTION
When creating AMIs, in addition to setting an AMI name, let's also add
an explicit `Name` tag with the same value. This can make it more
convenient to search for AMIs when filtering by multiple tags.