### PR TITLE
platform/machine/do: return journal output in ConsoleOutput

### DIFF
--- a/platform/machine/do/machine.go
+++ b/platform/machine/do/machine.go
@@ -77,6 +77,15 @@ func (dm *machine) Destroy() {
 }
 
 func (dm *machine) ConsoleOutput() string {
-	// DigitalOcean provides no API for this
-	return ""
+	// DigitalOcean provides no API for retrieving ConsoleOutput
+	// return the journal instead to allow for error checks to be run.
+	if dm.journal == nil {
+		return ""
+	}
+
+	data, err := dm.journal.Read()
+	if err != nil {
+		plog.Errorf("Reading journal for droplet %v: %v", dm.droplet.ID, err)
+	}
+	return string(data)
 }


### PR DESCRIPTION
DigitalOcean doesn't have a way in the SDK to get the console output so
we're currently returning an empty string. This avoids all console
checks some of which are present in the journal. Changes the function to
return the journal output to enable basic checking.