### PR TITLE
platform/aws/images: make FindImage more verbose

### DIFF
--- a/platform/api/aws/images.go
+++ b/platform/api/aws/images.go
@@ -623,7 +623,7 @@ func (a *API) FindImage(name string) (string, error) {
 		return "", fmt.Errorf("couldn't describe images: %v", err)
 	}
 	if len(describeRes.Images) > 1 {
-		return "", fmt.Errorf("found multiple images with name %v", name)
+		return "", fmt.Errorf("found multiple images with name %v. DescribeImage output: %v", name, describeRes.Images)
 	}
 	if len(describeRes.Images) == 1 {
 		return *describeRes.Images[0].ImageId, nil


### PR DESCRIPTION
Include information about the duplicate images when erroring out that
there were multiple images.