### PR TITLE
kola/tests: add test to fetch urls using TLS

### DIFF
--- a/kola/tests/misc/tls.go
+++ b/kola/tests/misc/tls.go
@@ -1,0 +1,34 @@
+package misc
+
+import (
+	"fmt"
+
+	"github.com/coreos/mantle/kola/cluster"
+	"github.com/coreos/mantle/kola/register"
+)
+
+var (
+	urlsToFetch = []string{
+		"https://www.example.com/",
+		"https://www.wikipedia.org/",
+		"https://start.fedoraproject.org/",
+	}
+)
+
+func init() {
+	register.Register(&register.Test{
+		Run:              TestTLSFetchURLs,
+		ClusterSize:      1,
+		Name:             "coreos.tls.fetch-urls",
+		ExcludePlatforms: []string{"qemu"}, // Networking outside cluster required
+	})
+}
+
+func TestTLSFetchURLs(c cluster.TestCluster) {
+	m := c.Machines()[0]
+
+	for _, url := range urlsToFetch {
+		c.MustSSH(m, fmt.Sprintf("curl -s -S -m 30 --retry 2 %s", url))
+		c.MustSSH(m, fmt.Sprintf("wget -nv -T 30 -t 2 --delete-after %s", url))
+	}
+}


### PR DESCRIPTION
Uses curl and wget commands to query a list of
popular HTTPS URLs, to check that TLS works on
the CL image under test.

closes #571 

**Notes**
- This addition has been tested using AWS, after building the mantle tools on top of changes in #862 (along with the changes in this PR)
- Different URLs may be used - there is no particular reason for including the current URLs in `URLsToFetch`