### PR TITLE
kola/tests: tls test - direct wget failure output only to stderr

### DIFF
--- a/kola/tests/misc/tls.go
+++ b/kola/tests/misc/tls.go
@@ -29,6 +29,6 @@ func TestTLSFetchURLs(c cluster.TestCluster) {
 
 	for _, url := range urlsToFetch {
 		c.MustSSH(m, fmt.Sprintf("curl -s -S -m 30 --retry 2 %s", url))
-		c.MustSSH(m, fmt.Sprintf("wget -nv -T 30 -t 2 --delete-after %s", url))
+		c.MustSSH(m, fmt.Sprintf("wget -nv -T 30 -t 2 --delete-after %s 2> >(grep -v -- '->' >&2)", url))
 	}
 }


### PR DESCRIPTION
uses process subsitution and grep to filter stderr output,
so only failure messages are logged in stderr