### PR TITLE
ore/aws/upload: add tags to snapshots

### DIFF
--- a/platform/api/aws/ec2.go
+++ b/platform/api/aws/ec2.go
@@ -197,6 +197,10 @@ func (a *API) TerminateInstances(ids []string) error {
 }
 
 func (a *API) CreateTags(resources []string, tags map[string]string) error {
+	if len(tags) == 0 {
+		return nil
+	}
+
 	tagObjs := make([]*ec2.Tag, 0, len(tags))
 	for key, value := range tags {
 		tagObjs = append(tagObjs, &ec2.Tag{


### PR DESCRIPTION
Add tags to snapshots so there is still information about a snapshot
if an ami is deleted but the snapshot is not.

#869 must be merged first