### PR TITLE
*: add distro flag

### DIFF
--- a/cmd/kola/kola.go
+++ b/cmd/kola/kola.go
@@ -160,6 +160,7 @@ func writeProps() error {
 	return enc.Encode(&struct {
 		Cmdline  []string `json:"cmdline"`
 		Platform string   `json:"platform"`
+		Distro   string   `json:"distro"`
 		Board    string   `json:"board"`
 		AWS      AWS      `json:"aws"`
 		DO       DO       `json:"do"`
@@ -170,6 +171,7 @@ func writeProps() error {
 	}{
 		Cmdline:  os.Args,
 		Platform: kolaPlatform,
+		Distro:   kola.Options.Distribution,
 		Board:    kola.QEMUOptions.Board,
 		AWS: AWS{
 			Region:       kola.AWSOptions.Region,

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -30,6 +30,7 @@ var (
 	kolaPlatform       string
 	defaultTargetBoard = sdk.DefaultBoard()
 	kolaPlatforms      = []string{"aws", "do", "esx", "gce", "packet", "qemu"}
+	kolaDistros        = []string{"cl", "rhcos"}
 	kolaDefaultImages  = map[string]string{
 		"amd64-usr": sdk.BuildRoot() + "/images/amd64-usr/latest/coreos_production_image.bin",
 		"arm64-usr": sdk.BuildRoot() + "/images/arm64-usr/latest/coreos_production_image.bin",
@@ -50,6 +51,7 @@ func init() {
 	sv(&outputDir, "output-dir", "", "Temporary output directory for test data and logs")
 	sv(&kola.TorcxManifestFile, "torcx-manifest", "", "Path to a torcx manifest that should be made available to tests")
 	root.PersistentFlags().StringVarP(&kolaPlatform, "platform", "p", "qemu", "VM platform: "+strings.Join(kolaPlatforms, ", "))
+	root.PersistentFlags().StringVarP(&kola.Options.Distribution, "distro", "b", "cl", "Distribution: "+strings.Join(kolaDistros, ", "))
 	root.PersistentFlags().IntVarP(&kola.TestParallelism, "parallel", "j", 1, "number of tests to run in parallel")
 	sv(&kola.TAPFile, "tapfile", "", "file to write TAP results to")
 	sv(&kola.Options.BaseName, "basename", "kola", "Cluster name prefix")
@@ -115,15 +117,21 @@ func syncOptions() error {
 	kola.PacketOptions.Board = kola.QEMUOptions.Board
 	kola.PacketOptions.GSOptions = &kola.GCEOptions
 
-	ok := false
-	for _, platform := range kolaPlatforms {
-		if platform == kolaPlatform {
-			ok = true
-			break
+	validateOption := func(name, item string, valid []string) error {
+		for _, v := range valid {
+			if v == item {
+				return nil
+			}
 		}
+		return fmt.Errorf("unsupported %v %q", name, item)
 	}
-	if !ok {
-		return fmt.Errorf("unsupport platform %q", kolaPlatform)
+
+	if err := validateOption("platform", kolaPlatform, kolaPlatforms); err != nil {
+		return err
+	}
+
+	if err := validateOption("distro", kola.Options.Distribution, kolaDistros); err != nil {
+		return err
 	}
 
 	image, ok := kolaDefaultImages[kola.QEMUOptions.Board]

--- a/kola/register/register.go
+++ b/kola/register/register.go
@@ -44,6 +44,8 @@ type Test struct {
 	ClusterSize      int
 	Platforms        []string // whitelist of platforms to run test against -- defaults to all
 	ExcludePlatforms []string // blacklist of platforms to ignore -- defaults to none
+	Distros          []string // whitelist of distributions to run test against -- defaults to all
+	ExcludeDistros   []string // blacklist of distributions to ignore -- defaults to none
 	Architectures    []string // whitelist of machine architectures supported -- defaults to all
 	Flags            []Flag   // special-case options for this test
 

--- a/platform/base.go
+++ b/platform/base.go
@@ -223,6 +223,10 @@ func (bc *BaseCluster) GetDiscoveryURL(size int) (string, error) {
 	return result, err
 }
 
+func (bc *BaseCluster) Distribution() string {
+	return bc.baseopts.Distribution
+}
+
 func (bc *BaseCluster) Platform() Name {
 	return bc.platform
 }

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -106,6 +106,7 @@ type SystemdDropin struct {
 // Options contains the base options for all clusters.
 type Options struct {
 	BaseName       string
+	Distribution   string
 	SystemdDropins []SystemdDropin
 }
 


### PR DESCRIPTION
Adds `-l`/`--distribution` to `kola` which allows the distribution to be
specified. Two new test flags are also added: `Distros` &
`ExcludeDistros`.