### PR TITLE
kola: add output messages in run and check-console

### DIFF
--- a/cmd/kola/console.go
+++ b/cmd/kola/console.go
@@ -24,14 +24,24 @@ import (
 	"github.com/coreos/mantle/kola"
 )
 
-var cmdCheckConsole = &cobra.Command{
-	Use:    "check-console [input-file...]",
-	Run:    runCheckConsole,
-	PreRun: preRun,
-	Short:  "Check console output for badness.",
-}
+var (
+	cmdCheckConsole = &cobra.Command{
+		Use:    "check-console [input-file...]",
+		Run:    runCheckConsole,
+		PreRun: preRun,
+		Short:  "Check console output for badness.",
+		Long: `
+Check console output for expressions matching failure messages logged
+by a Container Linux instance.
+
+If no files are specified as arguments, stdin is checked.
+`}
+
+	checkConsoleVerbose bool
+)
 
 func init() {
+	cmdCheckConsole.Flags().BoolVarP(&checkConsoleVerbose, "verbose", "v", false, "output user input prompts")
 	root.AddCommand(cmdCheckConsole)
 }
 
@@ -48,6 +58,9 @@ func runCheckConsole(cmd *cobra.Command, args []string) {
 		sourceName := arg
 		if arg == "-" {
 			sourceName = "stdin"
+			if checkConsoleVerbose {
+				fmt.Printf("Reading input from %s...\n", sourceName)
+			}
 			console, err = ioutil.ReadAll(os.Stdin)
 		} else {
 			console, err = ioutil.ReadFile(arg)

--- a/harness/harness.go
+++ b/harness/harness.go
@@ -424,7 +424,7 @@ func tRunner(t *H, fn func(t *H)) {
 		t.report() // Report after all subtests have finished.
 
 		// Do not lock t.done to allow race detector to detect race in case
-		// the user does not appropriately synchronizes a goroutine.
+		// the user does not appropriately synchronize a goroutine.
 		t.done = true
 		if t.parent != nil && !t.hasSub {
 			t.setRan()

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -178,7 +178,7 @@ func filterTests(tests map[string]*register.Test, pattern, platform string, vers
 			continue
 		}
 
-		// Check the test's min and end versions when running more then one test
+		// Check the test's min and end versions when running more than one test
 		if t.Name != pattern && versionOutsideRange(version, t.MinVersion, t.EndVersion) {
 			continue
 		}
@@ -280,6 +280,7 @@ func RunTests(pattern, pltfrm, outputDir string) error {
 	}
 
 	if !skipGetVersion {
+		plog.Info("Creating cluster to check semver...")
 		version, err := getClusterSemver(pltfrm, outputDir)
 		if err != nil {
 			plog.Fatal(err)


### PR DESCRIPTION
This adds a verbose option and a Long description to check-console.
A message to indicate a cluster is being created to check the semver
is also given during kola run, since this can be a long wait time.

**Notes**
These are some minor edits I made while reading the cmd/kola and /kola code. Overall there is not much I felt needed changing after getting better practice in general with the command line - the main takeaway was learning how the tests are run, how command line options are added, and the policy on logging (with https://github.com/coreos/mantle/pull/861 as a guide).

Enhancements that could be made in future are:
- Running count of the tests remaining (possibly in addition to a progress bar which updates based on a rating we give for how long the test takes to run). The data in `t.suite.waiting` and `t.suite.running` could be utilized for this in `tRunner` in `harness/harness.go`. Running tests in parallel would need to be considered.
- Messages to indicate why a test was excluded during `filterTests`. Right now `no tests to run` gets printed, but this could be more specific by saying `incorrect version`, `excluded platform` for example. However, doing this would add a lot of output to the console, by printing out every time a test is excluded.
- `man` pages for the commands which sync with the current usage. Cobra can do this (https://github.com/spf13/cobra/blob/master/doc/man_examples_test.go).