### PR TITLE
Add --use-host-dns flag to cork enter

### DIFF
--- a/cmd/cork/create.go
+++ b/cmd/cork/create.go
@@ -49,6 +49,7 @@ var (
 
 	// only for `enter` command
 	bindGpgAgent bool
+	useHostDNS   bool
 
 	// only for `update` command
 	allowCreate      bool
@@ -125,6 +126,8 @@ func init() {
 	enterCmd.Flags().AddFlagSet(chrootFlags)
 	enterCmd.Flags().BoolVar(&bindGpgAgent,
 		"bind-gpg-agent", true, "bind mount the gpg agent socket directory")
+	enterCmd.Flags().BoolVar(&useHostDNS,
+		"use-host-dns", false, "Use the host's /etc/resolv.conf instead of 8.8.8.8 and 8.8.4.4")
 	root.AddCommand(enterCmd)
 
 	deleteCmd.Flags().AddFlagSet(chrootFlags)
@@ -262,7 +265,7 @@ func updateRepo() {
 }
 
 func runEnter(cmd *cobra.Command, args []string) {
-	err := sdk.Enter(chrootName, bindGpgAgent, args...)
+	err := sdk.Enter(chrootName, bindGpgAgent, useHostDNS, args...)
 	if err != nil && len(args) != 0 {
 		plog.Fatalf("Running %v failed: %v", args, err)
 	}
@@ -345,7 +348,7 @@ func runUpdate(cmd *cobra.Command, args []string) {
 
 	updateRepo()
 
-	if err := sdk.Enter(chrootName, false, updateCommand...); err != nil {
+	if err := sdk.Enter(chrootName, false, false, updateCommand...); err != nil {
 		plog.Fatalf("update_chroot failed: %v", err)
 	}
 }

--- a/cmd/cork/create.go
+++ b/cmd/cork/create.go
@@ -48,7 +48,6 @@ var (
 	allowReplace bool
 
 	// only for `enter` command
-	experimental bool
 	bindGpgAgent bool
 
 	// only for `update` command
@@ -124,9 +123,6 @@ func init() {
 	root.AddCommand(createCmd)
 
 	enterCmd.Flags().AddFlagSet(chrootFlags)
-	enterCmd.Flags().BoolVar(&experimental,
-		"experimental", false, "Use new enter implementation")
-	enterCmd.Flags().MarkDeprecated("experimental", "--experimental is deprecated and will be removed next release. Equivilent to --bind-gpg-agent=false")
 	enterCmd.Flags().BoolVar(&bindGpgAgent,
 		"bind-gpg-agent", true, "bind mount the gpg agent socket directory")
 	root.AddCommand(enterCmd)
@@ -266,10 +262,6 @@ func updateRepo() {
 }
 
 func runEnter(cmd *cobra.Command, args []string) {
-	if experimental {
-		bindGpgAgent = false
-	}
-
 	err := sdk.Enter(chrootName, bindGpgAgent, args...)
 	if err != nil && len(args) != 0 {
 		plog.Fatalf("Running %v failed: %v", args, err)

--- a/sdk/enter.go
+++ b/sdk/enter.go
@@ -526,7 +526,7 @@ func enterChroot(e enter) error {
 
 // Enter the chroot with a login shell, optionally invoking a command.
 // The command may be prefixed by environment variable assignments.
-func Enter(name string, bindGpgAgent bool, args ...string) error {
+func Enter(name string, bindGpgAgent, useHostDNS bool, args ...string) error {
 	// pass -i to sudo to invoke a login shell
 	cmd := []string{"-i", "--"}
 	if len(args) > 0 {
@@ -538,6 +538,7 @@ func Enter(name string, bindGpgAgent bool, args ...string) error {
 		Chroot:       name,
 		Cmd:          cmd,
 		BindGpgAgent: bindGpgAgent,
+		UseHostDNS:   useHostDNS,
 	}
 	return enterChroot(e)
 }


### PR DESCRIPTION
Change the default behavior or cork enter to use the 8.8.8.8 and 8.8.4.4 nameservers instead of copying the hosts's `/etc/resolv.conf`. Add the `--use-host-dns` flag to allow the old behavior.

Also remove the deprecated `---experimental` flag.