### PR TITLE
platform/machine/qemu/cluster: stop passing backing_fmt to qemu-img

### DIFF
--- a/platform/machine/qemu/cluster.go
+++ b/platform/machine/qemu/cluster.go
@@ -295,7 +295,7 @@ func setupPrimaryDisk(imageFile string) (*os.File, error) {
 		return nil, err
 	}
 
-	qcowOpts := fmt.Sprintf("backing_file=%s,backing_fmt=raw,lazy_refcounts=on", backingFile)
+	qcowOpts := fmt.Sprintf("backing_file=%s,lazy_refcounts=on", backingFile)
 	return setupDisk("-o", qcowOpts)
 }
 


### PR DESCRIPTION
qemu-img automatically detects the format of the backing image.