### PR TITLE
platform/platform: update check in CheckMachine

### DIFF
--- a/platform/platform.go
+++ b/platform/platform.go
@@ -266,7 +266,8 @@ func NewMachines(c Cluster, userdata *conf.UserData, n int) ([]Machine, error) {
 
 // CheckMachine tests a machine for various error conditions such as ssh
 // being available and no systemd units failing at the time ssh is reachable.
-// It also ensures the remote system is running Container Linux by CoreOS.
+// It also ensures the remote system is running Container Linux by CoreOS or
+// Red Hat CoreOS.
 //
 // TODO(mischief): better error messages.
 func CheckMachine(ctx context.Context, m Machine) error {
@@ -295,8 +296,8 @@ func CheckMachine(ctx context.Context, m Machine) error {
 		return fmt.Errorf("no /etc/os-release file: %v: %s", err, stderr)
 	}
 
-	if !bytes.Equal(out, []byte("ID=coreos")) {
-		return fmt.Errorf("not a Container Linux instance")
+	if !bytes.Equal(out, []byte("ID=coreos")) && !bytes.Equal(out, []byte(`ID="rhcos"`)) {
+		return fmt.Errorf("not a supported instance")
 	}
 
 	if !m.RuntimeConf().AllowFailedUnits {


### PR DESCRIPTION
Adds an addijtional valid value for the `ID` check of `/etc/os-release`
(`ID="rhcos"`).