### PR TITLE
platform/api/aws: add AmazonS3ReadOnlyAccess to Role

### DIFF
--- a/platform/api/aws/ec2.go
+++ b/platform/api/aws/ec2.go
@@ -17,9 +17,11 @@ package aws
 import (
 	"encoding/base64"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"github.com/coreos/mantle/util"
@@ -105,7 +107,19 @@ func (a *API) CreateInstances(name, keyname, userdata string, count uint64) ([]*
 		},
 	}
 
-	reservations, err := a.ec2.RunInstances(&inst)
+	var reservations *ec2.Reservation
+	err = util.RetryConditional(5, 5*time.Second, func(err error) bool {
+		// due to AWS' eventual consistency despite ensuring that the IAM Instance
+		// Profile has been created it may not be available to ec2 yet.
+		if awsErr, ok := err.(awserr.Error); ok && (awsErr.Code() == "InvalidParameterValue" && strings.Contains(awsErr.Message(), "iamInstanceProfile.name")) {
+			return true
+		}
+		return false
+	}, func() error {
+		var ierr error
+		reservations, ierr = a.ec2.RunInstances(&inst)
+		return ierr
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error running instances: %v", err)
 	}


### PR DESCRIPTION
When running kola on a root account that does not own the S3 objects
that are being fetched for tests the AmazonS3ReadOnlyAccess policy needs
to be added to the role (and the corresponding Instance Profile).

This also adds a conditional retry on machine creation to avoid errors
caused by the eventual consistency nature of AWS in relation to the
Instance Profile creation and subsequent use in machine creation.