### PR TITLE
platform: perform CheckConsole against journal on all platforms

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -409,6 +409,11 @@ func runTest(h *harness.H, t *register.Test, pltfrm string) {
 				h.Errorf("Found %s on machine %s console", badness, id)
 			}
 		}
+		for id, output := range c.JournalOutput() {
+			for _, badness := range CheckConsole([]byte(output), t) {
+				h.Errorf("Found %s on machine %s journal", badness, id)
+			}
+		}
 	}()
 
 	if t.ClusterSize > 0 {

--- a/platform/base.go
+++ b/platform/base.go
@@ -248,3 +248,13 @@ func (bc *BaseCluster) ConsoleOutput() map[string]string {
 	}
 	return ret
 }
+
+func (bc *BaseCluster) JournalOutput() map[string]string {
+	ret := map[string]string{}
+	bc.machlock.Lock()
+	defer bc.machlock.Unlock()
+	for k, v := range bc.machmap {
+		ret[k] = v.JournalOutput()
+	}
+	return ret
+}

--- a/platform/machine/aws/machine.go
+++ b/platform/machine/aws/machine.go
@@ -145,3 +145,15 @@ func (am *machine) saveConsole(origConsole string) error {
 
 	return nil
 }
+
+func (am *machine) JournalOutput() string {
+	if am.journal == nil {
+		return ""
+	}
+
+	data, err := am.journal.Read()
+	if err != nil {
+		plog.Errorf("Reading journal for instance %v: %v", am.ID(), err)
+	}
+	return string(data)
+}

--- a/platform/machine/do/machine.go
+++ b/platform/machine/do/machine.go
@@ -78,7 +78,10 @@ func (dm *machine) Destroy() {
 
 func (dm *machine) ConsoleOutput() string {
 	// DigitalOcean provides no API for retrieving ConsoleOutput
-	// return the journal instead to allow for error checks to be run.
+	return ""
+}
+
+func (dm *machine) JournalOutput() string {
 	if dm.journal == nil {
 		return ""
 	}

--- a/platform/machine/esx/machine.go
+++ b/platform/machine/esx/machine.go
@@ -109,3 +109,15 @@ func (em *machine) saveConsole() error {
 
 	return nil
 }
+
+func (em *machine) JournalOutput() string {
+	if em.journal == nil {
+		return ""
+	}
+
+	data, err := em.journal.Read()
+	if err != nil {
+		plog.Errorf("Reading journal for device %v: %v", em.ID(), err)
+	}
+	return string(data)
+}

--- a/platform/machine/gcloud/machine.go
+++ b/platform/machine/gcloud/machine.go
@@ -102,3 +102,15 @@ func (gm *machine) saveConsole() error {
 
 	return nil
 }
+
+func (gm *machine) JournalOutput() string {
+	if gm.journal == nil {
+		return ""
+	}
+
+	data, err := gm.journal.Read()
+	if err != nil {
+		plog.Errorf("Reading journal for instance %v: %v", gm.ID(), err)
+	}
+	return string(data)
+}

--- a/platform/machine/packet/machine.go
+++ b/platform/machine/packet/machine.go
@@ -96,3 +96,15 @@ func (pm *machine) ConsoleOutput() string {
 	}
 	return output[grub+linux:]
 }
+
+func (pm *machine) JournalOutput() string {
+	if pm.journal == nil {
+		return ""
+	}
+
+	data, err := pm.journal.Read()
+	if err != nil {
+		plog.Errorf("Reading journal for device %v: %v", pm.ID(), err)
+	}
+	return string(data)
+}

--- a/platform/machine/qemu/machine.go
+++ b/platform/machine/qemu/machine.go
@@ -85,3 +85,15 @@ func (m *machine) Destroy() {
 func (m *machine) ConsoleOutput() string {
 	return m.console
 }
+
+func (m *machine) JournalOutput() string {
+	if m.journal == nil {
+		return ""
+	}
+
+	data, err := m.journal.Read()
+	if err != nil {
+		plog.Errorf("Reading journal for instance %v: %v", m.ID(), err)
+	}
+	return string(data)
+}

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -70,6 +70,10 @@ type Machine interface {
 	// ConsoleOutput returns the machine's console output if available,
 	// or an empty string.  Only expected to be valid after Destroy().
 	ConsoleOutput() string
+
+	// JournalOutput returns the machine's journal output if available,
+	// or an empty string.  Only expected to be valid after Destroy().
+	JournalOutput() string
 }
 
 // Cluster represents a cluster of Container Linux machines within a single platform.
@@ -94,6 +98,10 @@ type Cluster interface {
 	// ConsoleOutput returns a map of console output from destroyed
 	// cluster machines.
 	ConsoleOutput() map[string]string
+
+	// JournalOutput returns a map of journal output from destroyed
+	// cluster machines.
+	JournalOutput() map[string]string
 }
 
 // SystemdDropin is a userdata type agnostic struct representing a systemd dropin


### PR DESCRIPTION
Performs the CheckConsole function against journalctl output on all
platforms. This extends the Cluster & Machine interfaces with a new
function JournalOutput.