### PR TITLE
kola/tests: disable systemd.* tests on RHCOS

### DIFF
--- a/kola/tests/systemd/journald.go
+++ b/kola/tests/systemd/journald.go
@@ -58,7 +58,7 @@ func init() {
 		Run:         journalRemote,
 		ClusterSize: 0,
 		Name:        "systemd.journal.remote",
-		Distros:     []string{"cl", "rhcos"},
+		Distros:     []string{"cl"},
 	})
 }
 

--- a/kola/tests/systemd/sysusers.go
+++ b/kola/tests/systemd/sysusers.go
@@ -24,7 +24,7 @@ func init() {
 		Run:         gshadowParser,
 		ClusterSize: 1,
 		Name:        "systemd.sysusers.gshadow",
-		Distros:     []string{"cl", "rhcos"},
+		Distros:     []string{"cl"},
 	})
 }
 


### PR DESCRIPTION
These tests shouldn't have been enabled on RHCOS initially as the
binaries required for them are not shipped.