### PR TITLE
kola/tests: update rhcos.basic to check crio over docker

### DIFF
--- a/kola/tests/coretest/core.go
+++ b/kola/tests/coretest/core.go
@@ -239,7 +239,7 @@ func TestServicesActive() error {
 func TestServicesActiveRHCOS() error {
 	return servicesActive([]string{
 		"multi-user.target",
-		"docker.service",
+		"crio.service",
 	})
 }
 


### PR DESCRIPTION
When the patch initially merged crio wasn't enabled by default, now that
it is switch to checking it over docker.