### PR TITLE
platform/qemu: cleanup and extend disk handling

### DIFF
--- a/kola/tests/misc/raid.go
+++ b/kola/tests/misc/raid.go
@@ -107,7 +107,7 @@ systemd:
 func RootOnRaid(c cluster.TestCluster) {
 	options := qemu.MachineOptions{
 		AdditionalDisks: []qemu.Disk{
-			{Size: "520M", Serial: "secondary"},
+			{Size: "520M", DeviceOpts: []string{"serial=secondary"}},
 		},
 	}
 	m, err := c.Cluster.(*qemu.Cluster).NewMachineWithOptions(raidRootUserData, options)


### PR DESCRIPTION
Cleanup qemu disk creation and handling. Unify the additionalDisks and
the primary disk to be the same case. Allow passing arbitary options to
qemu for the disk. Axe a closure that just made things more complicated.

Update the root on raid test to use the new mechanism.