### PR TITLE
glide.*: remove subpackages

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 1ed796d34ee34858f1651209ecd07a85b2c20a43f59a375c5fc65043852259c3
-updated: 2018-08-22T15:12:37.293892299-07:00
+hash: 25572b299dc1ddba3eec789e849da346c8ae56aa84cb40dc2bd4d5e09cbcca9d
+updated: 2018-09-05T16:36:44.568478534-07:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -134,10 +134,8 @@ imports:
 - name: github.com/coreos/ignition
   version: f7079129b8651ac51dba14c3af65692bb413c1dd
   subpackages:
-  - config
   - config/shared/errors
   - config/shared/validations
-  - config/types
   - config/util
   - config/v1
   - config/v1/types

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,31 +4,8 @@ import:
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
 - package: github.com/Azure/azure-sdk-for-go
   version: f8b0607613f19ae9509b5ed6fbfda56caf06d59d
-  subpackages:
-  - management
-  - management/location
-  - management/storageservice
-  - storage
 - package: github.com/Microsoft/azure-vhd-utils
   version: 43293b8d76460dd25093d216c95abc79342e1657
-  subpackages:
-  - upload
-  - upload/concurrent
-  - upload/metadata
-  - upload/progress
-  - vhdcore
-  - vhdcore/bat
-  - vhdcore/block
-  - vhdcore/block/bitmap
-  - vhdcore/common
-  - vhdcore/diskstream
-  - vhdcore/footer
-  - vhdcore/header
-  - vhdcore/header/parentlocator
-  - vhdcore/reader
-  - vhdcore/validator
-  - vhdcore/vhdfile
-  - vhdcore/writer
 - package: github.com/ajeddeloh/go-json
   version: 73d058cf8437a1989030afe571eeab9f90eebbbd
 - package: github.com/ajeddeloh/yaml
@@ -37,163 +14,44 @@ import:
   version: 2efee857e7cfd4f3d0138cc3cbb1b4966962b93a
 - package: github.com/aws/aws-sdk-go
   version: 40bc7761a9f06daa574d20f2ad5454db02a05953
-  subpackages:
-  - aws
-  - aws/awserr
-  - aws/awsutil
-  - aws/client
-  - aws/client/metadata
-  - aws/corehandlers
-  - aws/credentials
-  - aws/credentials/ec2rolecreds
-  - aws/credentials/endpointcreds
-  - aws/credentials/stscreds
-  - aws/defaults
-  - aws/ec2metadata
-  - aws/endpoints
-  - aws/request
-  - aws/session
-  - aws/signer/v4
-  - private/protocol
-  - private/protocol/ec2query
-  - private/protocol/query
-  - private/protocol/query/queryutil
-  - private/protocol/rest
-  - private/protocol/restxml
-  - private/protocol/xml/xmlutil
-  - service/ec2
-  - service/iam
-  - service/s3
-  - service/s3/s3iface
-  - service/s3/s3manager
-  - service/sts
 - package: github.com/beorn7/perks
   version: b965b613227fddccbfffe13eae360ed3fa822f8d
-  subpackages:
-  - quantile
 - package: github.com/boltdb/bolt
   version: v1.2.1
 - package: github.com/coreos/container-linux-config-transpiler
   version: v0.8.0
-  subpackages:
-  - config
-  - config/platform
-  - config/templating
-  - config/types
-  - config/types/util
 - package: github.com/coreos/coreos-cloudinit
   version: v1.11.0
-  subpackages:
-  - config
 - package: github.com/coreos/etcd
   version: v3.0.3
-  subpackages:
-  - alarm
-  - auth
-  - auth/authpb
-  - client
-  - compactor
-  - discovery
-  - error
-  - etcdserver
-  - etcdserver/api
-  - etcdserver/api/v2http
-  - etcdserver/api/v2http/httptypes
-  - etcdserver/auth
-  - etcdserver/etcdserverpb
-  - etcdserver/membership
-  - etcdserver/stats
-  - lease
-  - lease/leasehttp
-  - lease/leasepb
-  - mvcc
-  - mvcc/backend
-  - mvcc/mvccpb
-  - pkg/adt
-  - pkg/contention
-  - pkg/crc
-  - pkg/fileutil
-  - pkg/httputil
-  - pkg/idutil
-  - pkg/ioutil
-  - pkg/logutil
-  - pkg/netutil
-  - pkg/pathutil
-  - pkg/pbutil
-  - pkg/runtime
-  - pkg/schedule
-  - pkg/tlsutil
-  - pkg/transport
-  - pkg/types
-  - pkg/wait
-  - raft
-  - raft/raftpb
-  - rafthttp
-  - snap
-  - snap/snappb
-  - store
-  - version
-  - wal
-  - wal/walpb
 - package: github.com/coreos/go-omaha
   version: f8acb2d7b76c4156223538ca1806a888e764af3d
-  subpackages:
-  - omaha
 - package: github.com/coreos/go-semver
   version: 5e3acbb5668c4c3deb4842615c4098eb61fb6b1e
-  subpackages:
-  - semver
 - package: github.com/coreos/go-systemd
   version: cba16237846b83be98d25d8392b1520b7bc40b5a
-  subpackages:
-  - journal
-  - unit
 - package: github.com/coreos/ignition
   version: v0.28.0
-  subpackages:
-  - config
-  - config/types
-  - config/v1
-  - config/v1/types
-  - config/v2_0
-  - config/v2_0/types
-  - config/validate
-  - config/validate/astjson
-  - config/validate/report
 - package: github.com/coreos/ioprogress
   version: 4637e494fd9b23c5565ee193e89f91fdc1639bc0
 - package: github.com/coreos/pkg
   version: 447b7ec906e523386d9c53be15b55a8ae86ea944
-  subpackages:
-  - capnslog
-  - multierror
 - package: github.com/coreos/yaml
   version: 6b16a5714269b2f70720a45406b1babd947a17ef
 - package: github.com/cpuguy83/go-md2man
   version: v1.0.4
-  subpackages:
-  - md2man
 - package: github.com/digitalocean/godo
   version: v1.1.3
 - package: github.com/gengo/grpc-gateway
   version: dcb844349dc5d2cb0300fdc4d2d374839d0d2e13
-  subpackages:
-  - runtime
-  - runtime/internal
-  - utilities
 - package: github.com/go-ini/ini
   version: v1.28.2
 - package: github.com/godbus/dbus
   version: a5942dec6340eb0d57f43f2003c190ce06e43dea
 - package: github.com/gogo/protobuf
   version: c3995ae437bb78d1189f4f147dfe5f87ad3596e4
-  subpackages:
-  - proto
 - package: github.com/golang/protobuf
   version: 8616e8ee5e20a1704615e6c8d7afcdac06087a67
-  subpackages:
-  - jsonpb
-  - proto
 - package: github.com/google/btree
   version: 7d79101e329e5a3adf994758c578dab82b90c017
 - package: github.com/inconshreveable/mousetrap
@@ -206,30 +64,18 @@ import:
   version: d8ec1a69a250a17bb0e419c386eac1f3711dc142
 - package: github.com/kylelemons/godebug
   version: 21cb3784d9bda523911b96719efba02b7e983256
-  subpackages:
-  - diff
-  - pretty
 - package: github.com/matttproud/golang_protobuf_extensions
   version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
-  subpackages:
-  - pbutil
 - package: github.com/packethost/packngo
   version: 80f62d78849dba04e42d8812329ee00558e37c5b
 - package: github.com/pin/tftp
   version: v2.1.0
 - package: github.com/prometheus/client_golang
   version: e51041b3fa41cece0dca035740ba6411905be473
-  subpackages:
-  - prometheus
 - package: github.com/prometheus/client_model
   version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
-  subpackages:
-  - go
 - package: github.com/prometheus/common
   version: ffe929a3f4c4faeaa10f2b9535c2b1be3ad15650
-  subpackages:
-  - expfmt
-  - model
 - package: github.com/prometheus/procfs
   version: 454a56f35412459b5e684fd5ec0f9211b94f002a
 - package: github.com/russross/blackfriday
@@ -244,14 +90,10 @@ import:
   version: 7f60f83a2c81bc3c3c0d5297f61ddfa68da9d3b7
 - package: github.com/ugorji/go
   version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
-  subpackages:
-  - codec
 - package: github.com/vincent-petithory/dataurl
   version: 9a301d65acbb728fcc3ace14f45f511a4cfeea9c
 - package: github.com/vishvananda/netlink
   version: 2e9d285a7160e1c65e1eab8238faf2d6a0dc9a4a
-  subpackages:
-  - nl
 - package: github.com/vishvananda/netns
   version: 604eaf189ee867d8c147fafc28def2394e878d25
 - package: github.com/xiang90/probing
@@ -259,82 +101,21 @@ import:
 - package: go4.org
   repo: https://github.com/go4org/go4
   version: 03efcb870d84809319ea509714dd6d19a1498483
-  subpackages:
-  - errorutil
 - package: golang.org/x/crypto
   version: 119f50887f8fe324fe2386421c27a11af014b64e
-  subpackages:
-  - bcrypt
-  - blowfish
-  - cast5
-  - curve25519
-  - ed25519
-  - ed25519/internal/edwards25519
-  - openpgp
-  - openpgp/armor
-  - openpgp/elgamal
-  - openpgp/errors
-  - openpgp/packet
-  - openpgp/s2k
-  - pkcs12
-  - pkcs12/internal/rc2
-  - ssh
-  - ssh/agent
-  - ssh/terminal
 - package: golang.org/x/net
   version: d4c55e66d8c3a2f3382d264b08e3e3454a66355a
-  subpackages:
-  - context
-  - context/ctxhttp
-  - http2
-  - http2/hpack
-  - internal/timeseries
-  - lex/httplex
-  - trace
 - package: golang.org/x/oauth2
   version: 045497edb6234273d67dbc25da3f2ddbc4c4cacf
-  subpackages:
-  - google
-  - internal
-  - jws
-  - jwt
 - package: golang.org/x/sys
   version: 9ccfe848b9db8435a24c424abbc07a921adf1df5
-  subpackages:
-  - unix
 - package: google.golang.org/api
   version: c858ef4400610cbfd097ffc5f5c6e4a1a51eac86
-  subpackages:
-  - compute/v1
-  - gensupport
-  - googleapi
-  - googleapi/internal/uritemplates
-  - storage/v1
 - package: google.golang.org/appengine
   version: 12d5545dc1cfa6047a286d5e853841b6471f4c19
-  subpackages:
-  - internal
-  - internal/app_identity
-  - internal/base
-  - internal/datastore
-  - internal/log
-  - internal/modules
-  - internal/remote_api
 - package: google.golang.org/cloud
   version: ab6762587120f590adf808437a5819b991ac2d20
-  subpackages:
-  - compute/metadata
-  - internal
 - package: google.golang.org/grpc
   version: 02fca896ff5f50c6bbbee0860345a49344b37a03
-  subpackages:
-  - codes
-  - credentials
-  - grpclog
-  - internal
-  - metadata
-  - naming
-  - peer
-  - transport
 - package: github.com/vmware/govmomi
   version: v0.15.0


### PR DESCRIPTION
We use glide-vc which does a much better job at cleaning up unused
packages. As far as I can tell the subpackages don't do anything and
just cause confusion and make the glide.yaml file harder to read.