### PR TITLE
kola/tests: add rpmostree package

### DIFF
--- a/kola/registry/registry.go
+++ b/kola/registry/registry.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/coreos/mantle/kola/tests/misc"
 	_ "github.com/coreos/mantle/kola/tests/packages"
 	_ "github.com/coreos/mantle/kola/tests/rkt"
+	_ "github.com/coreos/mantle/kola/tests/rpmostree"
 	_ "github.com/coreos/mantle/kola/tests/systemd"
 	_ "github.com/coreos/mantle/kola/tests/torcx"
 	_ "github.com/coreos/mantle/kola/tests/update"

--- a/kola/tests/rpmostree/deployments.go
+++ b/kola/tests/rpmostree/deployments.go
@@ -1,0 +1,302 @@
+// Copyright 2018 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpmostree
+
+import (
+	"reflect"
+	"regexp"
+
+	"github.com/coreos/mantle/kola/cluster"
+	"github.com/coreos/mantle/kola/register"
+	"github.com/coreos/mantle/platform/conf"
+)
+
+func init() {
+	register.Register(&register.Test{
+		Run:         rpmOstreeUpgradeRollback,
+		ClusterSize: 1,
+		Name:        "rhcos.rpmostree.upgrade-rollback",
+		Distros:     []string{"rhcos"},
+	})
+	register.Register(&register.Test{
+		Run:         rpmOstreeInstallUninstall,
+		ClusterSize: 1,
+		Name:        "rhcos.rpmostree.install-uninstall",
+		// this Ignition config lands the EPEL repo + key
+		UserData: conf.Ignition(`{
+  "ignition": {
+    "version": "2.2.0"
+  },
+  "storage": {
+    "files": [
+      {
+        "filesystem": "root",
+        "group": {
+          "name": "root"
+        },
+        "path": "/etc/yum.repos.d/epel.repo",
+        "user": {
+          "name": "root"
+        },
+        "contents": {
+          "source": "data:,%5Bepel%5D%0Aname%3DExtra%20Packages%20for%20Enterprise%20Linux%207%20-%20%24basearch%0Ametalink%3Dhttps%3A%2F%2Fmirrors.fedoraproject.org%2Fmetalink%3Frepo%3Depel-7%26arch%3D%24basearch%0Afailovermethod%3Dpriority%0Aenabled%3D1%0Agpgcheck%3D1%0Agpgkey%3Dfile%3A%2F%2F%2Fetc%2Fpki%2Frpm-gpg%2FRPM-GPG-KEY-EPEL-7%0A"
+        },
+        "mode": 420
+      },
+      {
+        "filesystem": "root",
+        "group": {
+          "name": "root"
+        },
+        "path": "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7",
+        "user": {
+          "name": "root"
+        },
+        "contents": {
+          "source": "data:,-----BEGIN%20PGP%20PUBLIC%20KEY%20BLOCK-----%0AVersion%3A%20GnuPG%20v1.4.11%20(GNU%2FLinux)%0A%0AmQINBFKuaIQBEAC1UphXwMqCAarPUH%2FZsOFslabeTVO2pDk5YnO96f%2BrgZB7xArB%0AOSeQk7B90iqSJ85%2Fc72OAn4OXYvT63gfCeXpJs5M7emXkPsNQWWSju99lW%2BAqSNm%0AjYWhmRlLRGl0OO7gIwj776dIXvcMNFlzSPj00N2xAqjMbjlnV2n2abAE5gq6VpqP%0AvFXVyfrVa%2FualogDVmf6h2t4Rdpifq8qTHsHFU3xpCz%2BT6%2FdGWKGQ42ZQfTaLnDM%0AjToAsmY0AyevkIbX6iZVtzGvanYpPcWW4X0RDPcpqfFNZk643xI4lsZ%2BY2Er9Yu5%0AS%2F8x0ly%2BtmmIokaE0wwbdUu740YTZjCesroYWiRg5zuQ2xfKxJoV5E%2BEh%2BtYwGDJ%0An6HfWhRgnudRRwvuJ45ztYVtKulKw8QQpd2STWrcQQDJaRWmnMooX%2FPATTjCBExB%0A9dkz38Druvk7IkHMtsIqlkAOQMdsX1d3Tov6BE2XDjIG0zFxLduJGbVwc%2F6rIc95%0AT055j36Ez0HrjxdpTGOOHxRqMK5m9flFbaxxtDnS7w77WqzW7HjFrD0VeTx2vnjj%0AGqchHEQpfDpFOzb8LTFhgYidyRNUflQY35WLOzLNV%2BpV3eQ3Jg11UFwelSNLqfQf%0AuFRGc%2BzcwkNjHh5yPvm9odR1BIfqJ6sKGPGbtPNXo7ERMRypWyRz0zi0twARAQAB%0AtChGZWRvcmEgRVBFTCAoNykgPGVwZWxAZmVkb3JhcHJvamVjdC5vcmc%2BiQI4BBMB%0AAgAiBQJSrmiEAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAKCRBqL66iNSxk%0A5cfGD%2F4spqpsTjtDM7qpytKLHKruZtvuWiqt5RfvT9ww9GUUFMZ4ZZGX4nUXg49q%0AixDLayWR8ddG%2Fs5kyOi3C0uX%2F6inzaYyRg%2BBh70brqKUK14F1BrrPi29eaKfG%2BGu%0AMFtXdBG2a7OtPmw3yuKmq9Epv6B0mP6E5KSdvSRSqJWtGcA6wRS%2FwDzXJENHp5re%0A9Ism3CYydpy0GLRA5wo4fPB5uLdUhLEUDvh2KK%2F%2FfMjja3o0L%2BSNz8N0aDZyn5Ax%0ACU9RB3EHcTecFgoy5umRj99BZrebR1NO%2B4gBrivIfdvD4fJNfNBHXwhSH9ACGCNv%0AHnXVjHQF9iHWApKkRIeh8Fr2n5dtfJEF7SEX8GbX7FbsWo29kXMrVgNqHNyDnfAB%0AVoPubgQdtJZJkVZAkaHrMu8AytwT62Q4eNqmJI1aWbZQNI5jWYqc6RKuCK6%2FF99q%0AthFT9gJO17%2ByRuL6Uv2%2FvgzVR1RGdwVLKwlUjGPAjYflpCQwWMAASxiv9uPyYPHc%0AErSrbRG0wjIfAR3vus1OSOx3xZHZpXFfmQTsDP7zVROLzV98R3JwFAxJ4%2FxqeON4%0AvCPFU6OsT3lWQ8w7il5ohY95wmujfr6lk89kEzJdOTzcn7DBbUru33CQMGKZ3Evt%0ARjsC7FDbL017qxS%2BZVA%2FHGkyfiu4cpgV8VUnbql5eAZ%2B1Ll6Dw%3D%3D%0A%3DhdPa%0A-----END%20PGP%20PUBLIC%20KEY%20BLOCK-----%0A"
+        },
+        "mode": 420
+      }
+    ]
+  }
+}`),
+
+		Distros:          []string{"rhcos"},
+		ExcludePlatforms: []string{"qemu"}, // these need network to retrieve bits
+	})
+}
+
+// rpmOstreeUpgradeRollback simulates an upgrade by creating a local branch, making
+// a commit to the branch, and rebases the host to said commit.  After a successful
+// "upgrade", the host is rolled back to the original deployment.
+func rpmOstreeUpgradeRollback(c cluster.TestCluster) {
+	var newBranch string = "local-branch"
+	var newVersion string = "kola-test-1.0"
+
+	m := c.Machines()[0]
+
+	originalStatus, err := getRpmOstreeStatusJSON(c, m)
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	if len(originalStatus.Deployments) < 1 {
+		c.Fatalf(`Unexpected results from "rpm-ostree status"; received: %v`, originalStatus)
+	}
+
+	// create a local branch to act as our upgrade target
+	originalCsum := originalStatus.Deployments[0].Checksum
+	createBranch := "sudo ostree refs --create " + newBranch + " " + originalCsum
+	c.MustSSH(m, createBranch)
+
+	// make a commit to the new branch
+	createCommit := "sudo ostree commit -b " + newBranch + " --tree ref=" + originalCsum + " --add-metadata-string version=" + newVersion
+	newCommit := c.MustSSH(m, createCommit)
+
+	// use "rpm-ostree rebase" to get to the "new" commit
+	c.MustSSH(m, "sudo rpm-ostree rebase :"+newBranch)
+
+	// get latest rpm-ostree status output to check validity
+	postUpgradeStatus, err := getRpmOstreeStatusJSON(c, m)
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	// should have two deployments
+	if len(postUpgradeStatus.Deployments) != 2 {
+		c.Fatalf("Expected two deployments; found %d deployments", len(postUpgradeStatus.Deployments))
+	}
+
+	// reboot into new deployment
+	rebootErr := m.Reboot()
+	if rebootErr != nil {
+		c.Fatalf("Failed to reboot machine: %v", err)
+	}
+
+	// get latest rpm-ostree status output
+	postRebootStatus, err := getRpmOstreeStatusJSON(c, m)
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	// should still have 2 deployments
+	if len(postRebootStatus.Deployments) != 2 {
+		c.Fatalf("Expected two deployments; found %d deployment", len(postRebootStatus.Deployments))
+	}
+
+	// origin should be new branch
+	if postRebootStatus.Deployments[0].Origin != newBranch {
+		c.Fatalf(`New deployment origin is incorrect; expected %q, got %q`, newBranch, postRebootStatus.Deployments[0].Origin)
+	}
+
+	// new deployment should be booted
+	if !postRebootStatus.Deployments[0].Booted {
+		c.Fatalf("New deployment is not reporting as booted")
+	}
+
+	// checksum should be new commit
+	if postRebootStatus.Deployments[0].Checksum != string(newCommit) {
+		c.Fatalf(`New deployment checksum is incorrect; expected %q, got %q`, newCommit, postRebootStatus.Deployments[0].Checksum)
+	}
+
+	// version should be new version string
+	if postRebootStatus.Deployments[0].Version != newVersion {
+		c.Fatalf(`New deployment version is incorrect; expected %q, got %q`, newVersion, postRebootStatus.Deployments[0].Checksum)
+	}
+
+	// rollback to original deployment
+	c.MustSSH(m, "sudo rpm-ostree rollback")
+
+	newRebootErr := m.Reboot()
+	if newRebootErr != nil {
+		c.Fatalf("Failed to reboot machine: %v", err)
+	}
+
+	rollbackStatus, err := getRpmOstreeStatusJSON(c, m)
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	// still 2 deployments...
+	if len(rollbackStatus.Deployments) != 2 {
+		c.Fatalf("Expected two deployments; found %d deployments", len(rollbackStatus.Deployments))
+	}
+
+	// validate we are back to the original deployment by comparing the
+	// the two rpmOstreeDeployment structs
+	if !reflect.DeepEqual(originalStatus.Deployments[0], rollbackStatus.Deployments[0]) {
+		c.Fatalf(`Differences found in "rpm-ostree status"; original %v, current: %v`, originalStatus.Deployments[0], rollbackStatus.Deployments[0])
+	}
+
+	// cleanup our mess
+	cleanupErr := rpmOstreeCleanup(c, m)
+	if cleanupErr != nil {
+		c.Fatal(cleanupErr)
+	}
+}
+
+// rpmOstreeInstallUninstall verifies that we can install a package
+// and then uninstall it
+func rpmOstreeInstallUninstall(c cluster.TestCluster) {
+	m := c.Machines()[0]
+
+	originalStatus, err := getRpmOstreeStatusJSON(c, m)
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	if len(originalStatus.Deployments) < 1 {
+		c.Fatal(`Unexpected results from "rpm-ostree status"; no deployments?`)
+	}
+
+	originalCsum := originalStatus.Deployments[0].Checksum
+	// install fpaste and reboot
+	c.MustSSH(m, "sudo rpm-ostree install fpaste")
+
+	installRebootErr := m.Reboot()
+	if installRebootErr != nil {
+		c.Fatalf("Failed to reboot machine: %v", installRebootErr)
+	}
+
+	postInstallStatus, err := getRpmOstreeStatusJSON(c, m)
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	if len(postInstallStatus.Deployments) != 2 {
+		c.Fatalf(`Expected two deployments, found %d deployments`, len(postInstallStatus.Deployments))
+	}
+
+	// check the command is present, in the rpmdb, and usable
+	cmdOut := c.MustSSH(m, "command -v fpaste")
+	if string(cmdOut) != "/bin/fpaste" {
+		c.Fatalf(`fpaste binary in unexpected location. expectd %q, got %q`, "/bin/fpaste", string(cmdOut))
+	}
+
+	// e.g. fpaste-0.3.7.4.1-2.el7.noarch
+	rpmOut := c.MustSSH(m, "rpm -q fpaste")
+	rpmMatch := regexp.MustCompile("^fpaste.*noarch").MatchString(string(rpmOut))
+	if !rpmMatch {
+		c.Fatalf(`Output from "rpm -q" was unexpected: %q`, string(rpmOut))
+	}
+
+	// just verify the command runs
+	c.MustSSH(m, "fpaste --version")
+
+	// package should be in the metadata
+	var reqPkg bool = false
+	for _, pkg := range postInstallStatus.Deployments[0].RequestedPackages {
+		if pkg == "fpaste" {
+			reqPkg = true
+			break
+		}
+	}
+	if !reqPkg {
+		c.Fatalf(`Unable to find "fpaste" in requested-packages: %v`, postInstallStatus.Deployments[0].RequestedPackages)
+	}
+
+	var installPkg bool = false
+	for _, pkg := range postInstallStatus.Deployments[0].Packages {
+		if pkg == "fpaste" {
+			installPkg = true
+			break
+		}
+	}
+	if !installPkg {
+		c.Fatalf(`Unable to find "fpaste" in packages: %v`, postInstallStatus.Deployments[0].Packages)
+	}
+
+	// checksum should be different
+	if postInstallStatus.Deployments[0].Checksum == originalCsum {
+		c.Fatalf(`Commit IDs incorrectly matched after package install`)
+	}
+
+	// uninstall the package
+	c.MustSSH(m, "sudo rpm-ostree uninstall fpaste")
+
+	uninstallRebootErr := m.Reboot()
+	if uninstallRebootErr != nil {
+		c.Fatalf("Failed to reboot machine: %v", uninstallRebootErr)
+	}
+
+	postUninstallStatus, err := getRpmOstreeStatusJSON(c, m)
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	// check the metadata to make sure everything went well
+	if len(postUninstallStatus.Deployments) != 2 {
+		c.Fatal("Expected two deployments, got %d", len(postUninstallStatus.Deployments))
+	}
+
+	if postUninstallStatus.Deployments[0].Checksum != originalCsum {
+		c.Fatalf(`Checksum is incorrect; expected %q, got %q`, originalCsum, postUninstallStatus.Deployments[0].Checksum)
+	}
+
+	if len(postUninstallStatus.Deployments[0].RequestedPackages) != 0 {
+		c.Fatalf(`Found unexpected requested-packages: %q`, postUninstallStatus.Deployments[0].RequestedPackages)
+	}
+
+	if len(postUninstallStatus.Deployments[0].Packages) != 0 {
+		c.Fatalf(`Found unexpected packages: %q`, postUninstallStatus.Deployments[0].Packages)
+	}
+
+	// cleanup our mess
+	cleanupErr := rpmOstreeCleanup(c, m)
+	if cleanupErr != nil {
+		c.Fatal(cleanupErr)
+	}
+
+}

--- a/kola/tests/rpmostree/status.go
+++ b/kola/tests/rpmostree/status.go
@@ -1,0 +1,157 @@
+// Copyright 2018 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpmostree
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/coreos/mantle/kola/cluster"
+	"github.com/coreos/mantle/kola/register"
+	"github.com/coreos/mantle/platform"
+)
+
+func init() {
+	register.Register(&register.Test{
+		Run:         rpmOstreeStatus,
+		ClusterSize: 1,
+		Name:        "rhcos.rpmostree.status",
+		Distros:     []string{"rhcos"},
+	})
+}
+
+var (
+	// hard code the osname for RHCOS
+	// TODO: should this also support FCOS?
+	rhcosOsname string = "rhcos"
+
+	// Regex to extract version number from "rpm-ostree status"
+	rpmOstreeVersionRegex string = `^Version: (\d+\.\d+\.\d+).*`
+)
+
+// rpmOstreeDeployment represents some of the data of an rpm-ostree deployment
+type rpmOstreeDeployment struct {
+	Booted            bool     `json:"booted"`
+	Checksum          string   `json:"checksum"`
+	Origin            string   `json:"origin"`
+	Osname            string   `json:"osname"`
+	Packages          []string `json:"packages"`
+	RequestedPackages []string `json:"requested-packages"`
+	Version           string   `json:"version"`
+}
+
+// simplifiedRpmOstreeStatus contains deployments from rpm-ostree status
+type simplifiedRpmOstreeStatus struct {
+	Deployments []rpmOstreeDeployment
+}
+
+// getRpmOstreeStatusJSON returns an unmarshal'ed JSON object that contains
+// a limited representation of the output of `rpm-ostree status --json`
+func getRpmOstreeStatusJSON(c cluster.TestCluster, m platform.Machine) (simplifiedRpmOstreeStatus, error) {
+	target := simplifiedRpmOstreeStatus{}
+	rpmOstreeJSON, err := c.SSH(m, "rpm-ostree status --json")
+	if err != nil {
+		return target, fmt.Errorf("Could not get rpm-ostree status: %v", err)
+	}
+
+	err = json.Unmarshal(rpmOstreeJSON, &target)
+	if err != nil {
+		return target, fmt.Errorf("Couldn't umarshal the rpm-ostree status JSON data: %v", err)
+	}
+
+	return target, nil
+}
+
+// rpmOstreeCleanup calls 'rpm-ostree cleanup -rpmb' on a host and verifies
+// that only one deployment remains
+func rpmOstreeCleanup(c cluster.TestCluster, m platform.Machine) error {
+	c.MustSSH(m, "sudo rpm-ostree cleanup -rpmb")
+
+	// one last check to make sure we are back to the original state
+	cleanupStatus, err := getRpmOstreeStatusJSON(c, m)
+	if err != nil {
+		return fmt.Errorf(`Failed to get status JSON: %v`, err)
+	}
+
+	if len(cleanupStatus.Deployments) != 1 {
+		return fmt.Errorf(`Cleanup left more than one deployment`)
+	}
+	return nil
+}
+
+// rpmOstreeStatus does some sanity checks on the output from
+// `rpm-ostree status` and `rpm-ostree status --json`
+func rpmOstreeStatus(c cluster.TestCluster) {
+	m := c.Machines()[0]
+
+	// check that rpm-ostreed is static?
+	enabledOut := c.MustSSH(m, "systemctl is-enabled rpm-ostreed")
+	if string(enabledOut) != "static" {
+		c.Fatalf(`The "rpm-ostreed" service is not "static": got %v`, string(enabledOut))
+	}
+
+	status, err := getRpmOstreeStatusJSON(c, m)
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	// after running an 'rpm-ostree' command the daemon should be active
+	statusOut := c.MustSSH(m, "systemctl is-active rpm-ostreed")
+	if string(statusOut) != "active" {
+		c.Fatalf(`The "rpm-ostreed" service is not active: got %v`, string(statusOut))
+	}
+
+	// should only have one deployment
+	if len(status.Deployments) != 1 {
+		c.Fatalf("Expected one deployment; found %d deployments", len(status.Deployments))
+	}
+
+	// the osname should only be RHCOS
+	// TODO: perhaps this should also support FCOS?
+	if status.Deployments[0].Osname != rhcosOsname {
+		c.Fatalf(`"osname" has incorrect value: want %q, got %q`, rhcosOsname, status.Deployments[0].Osname)
+	}
+
+	// deployment should be booted (duh!)
+	if !status.Deployments[0].Booted {
+		c.Fatalf(`Deployment does not report as being booted`)
+	}
+
+	// let's validate that the version from the JSON matches the normal output
+	var rpmOstreeVersion string
+	rpmOstreeStatusOut := c.MustSSH(m, "rpm-ostree status")
+	reVersion, err := regexp.Compile(rpmOstreeVersionRegex)
+	statusArray := strings.Split(string(rpmOstreeStatusOut), "\n")
+	for _, line := range statusArray {
+		versionMatch := reVersion.FindStringSubmatch(strings.Trim(line, " "))
+		if versionMatch != nil {
+			// versionMatch should be like `[Version: 4.0.5516 (2018-09-12 17:22:06) 4.0.5516]`
+			// i.e. the full match and the group we want
+			// `versionMatch[len(versionMatch)-1]` gets the last element in the array
+			rpmOstreeVersion = versionMatch[len(versionMatch)-1]
+		}
+	}
+
+	if rpmOstreeVersion == "" {
+		c.Fatalf(`Unable to determine version from "rpm-ostree status"`)
+	}
+
+	if rpmOstreeVersion != status.Deployments[0].Version {
+		c.Fatalf(`The version numbers did not match -> from JSON: %q; from stdout: %q`, status.Deployments[0].Version, rpmOstreeVersion)
+
+	}
+}


### PR DESCRIPTION
Adds tests for the following `rpm-ostree` commands:
  - status
  - upgrade
  - rollback
  - cleanup
  - install
  - uninstall

The `install-uninstall` test requires network access to fetch an RPM
from EPEL.

Signed-off-by: Micah Abbott <miabbott@redhat.com>