### PR TITLE
kola: Add FailFast flag to test registration

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -446,6 +446,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string) {
 		H:           h,
 		Cluster:     c,
 		NativeFuncs: names,
+		FailFast:    t.FailFast,
 	}
 
 	// drop kolet binary on machines

--- a/kola/register/register.go
+++ b/kola/register/register.go
@@ -49,6 +49,10 @@ type Test struct {
 	Architectures    []string // whitelist of machine architectures supported -- defaults to all
 	Flags            []Flag   // special-case options for this test
 
+	// FailFast skips any sub-test that occurs after a sub-test has
+	// failed.
+	FailFast bool
+
 	// MinVersion prevents the test from executing on CoreOS machines
 	// less than MinVersion. This will be ignored if the name fully
 	// matches without globbing.


### PR DESCRIPTION
Adds a new flag (`FailFast`) to test registration, when set to true any
sub-tests will be skipped if a previous sub-test has failed.