### PR TITLE
kola/tests: disable ignition security.tls test on packet & qemu

### DIFF
--- a/kola/tests/ignition/security.go
+++ b/kola/tests/ignition/security.go
@@ -59,8 +59,9 @@ func init() {
 		NativeFuncs: map[string]func() error{
 			"TLSServe": TLSServe,
 		},
-		// https://github.com/coreos/bugs/issues/2205
-		ExcludePlatforms: []string{"do"},
+		// DO: https://github.com/coreos/bugs/issues/2205
+		// Packet & QEMU: https://github.com/coreos/ignition/issues/645
+		ExcludePlatforms: []string{"do", "packet", "qemu"},
 		Distros:          []string{"cl", "rhcos", "fcos"},
 	})
 }


### PR DESCRIPTION
TLS requests in Ignition require system entropy when none may be
available (coreos/ignition#645 ). This seems to be causing flakes in our
CI on qemu_uefi & packet with this test.