### PR TITLE
kola/tests: add ostree tests

### DIFF
--- a/kola/registry/registry.go
+++ b/kola/registry/registry.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/coreos/mantle/kola/tests/locksmith"
 	_ "github.com/coreos/mantle/kola/tests/metadata"
 	_ "github.com/coreos/mantle/kola/tests/misc"
+	_ "github.com/coreos/mantle/kola/tests/ostree"
 	_ "github.com/coreos/mantle/kola/tests/packages"
 	_ "github.com/coreos/mantle/kola/tests/podman"
 	_ "github.com/coreos/mantle/kola/tests/rkt"

--- a/kola/tests/ostree/basic.go
+++ b/kola/tests/ostree/basic.go
@@ -1,0 +1,292 @@
+// Copyright 2018 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ostree
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/coreos/mantle/kola/cluster"
+	"github.com/coreos/mantle/kola/register"
+	"github.com/coreos/mantle/kola/tests/util"
+	"github.com/coreos/mantle/platform"
+)
+
+// the "basic" test is only supported on 'rhcos' for now because of how
+// the refs are defined. if 'fcos' goes in the same direction, we can
+// expand support there.
+func init() {
+	register.Register(&register.Test{
+		Run:         ostreeBasicTest,
+		ClusterSize: 1,
+		Name:        "ostree.basic",
+		Distros:     []string{"rhcos"},
+		FailFast:    true,
+	})
+
+	register.Register(&register.Test{
+		Run:              ostreeRemoteTest,
+		ClusterSize:      1,
+		Name:             "ostree.remote",
+		Distros:          []string{"rhcos", "fcos"},
+		ExcludePlatforms: []string{"qemu"}, // need network to contact remote
+		FailFast:         true,
+	})
+}
+
+type ostreeAdminStatus struct {
+	Checksum string
+	Origin   string
+	Version  string
+}
+
+// getOstreeAdminStatus stuffs the important output of `ostree admin status`
+// into an `ostreeAdminStatus` struct
+func getOstreeAdminStatus(c cluster.TestCluster, m platform.Machine) (ostreeAdminStatus, error) {
+	oaStatus := ostreeAdminStatus{}
+
+	oasOutput, err := c.SSH(m, "ostree admin status")
+	if err != nil {
+		return oaStatus, fmt.Errorf(`Could not get "ostree admin status": %v`, err)
+	}
+
+	oasSplit := strings.Split(string(oasOutput), "\n")
+	if len(oasSplit) != 3 {
+		return oaStatus, fmt.Errorf(`Unexpected output from "ostree admin status": %v`, string(oasOutput))
+	}
+
+	// we use a bunch of regexps to find the content in each line of output
+	// from "ostree admin status".  the `match` for each line sticks the
+	// captured group as the last element of the array; that is used as the
+	// value for each field of the struct
+	reCsum, _ := regexp.Compile(`^\* [\w\-]+ ([0-9a-f]+)\.\d`)
+	csumMatch := reCsum.FindStringSubmatch(oasSplit[0])
+	if csumMatch == nil {
+		return oaStatus, fmt.Errorf(`Could not parse first line from "ostree admin status": %q`, oasSplit[0])
+	}
+	oaStatus.Checksum = csumMatch[len(csumMatch)-1]
+
+	reVersion, _ := regexp.Compile(`^Version: (.*)`)
+	versionMatch := reVersion.FindStringSubmatch(strings.TrimSpace(oasSplit[1]))
+	if versionMatch == nil {
+		return oaStatus, fmt.Errorf(`Could not parse second line from "ostree admin status": %q`, oasSplit[1])
+	}
+	oaStatus.Version = versionMatch[len(versionMatch)-1]
+
+	reOrigin, _ := regexp.Compile(`^origin refspec: (.*)`)
+	originMatch := reOrigin.FindStringSubmatch(strings.TrimSpace(oasSplit[2]))
+	if originMatch == nil {
+		return oaStatus, fmt.Errorf(`Could not parse third line from "ostree admin status": %q`, oasSplit[2])
+	}
+	oaStatus.Origin = originMatch[len(originMatch)-1]
+
+	return oaStatus, nil
+}
+
+// ostreeBasicTest performs sanity checks on the output from `ostree admin status`,
+// `ostree rev-parse`, and `ostree show` by comparing to the output from `rpm-ostree status`
+func ostreeBasicTest(c cluster.TestCluster) {
+	m := c.Machines()[0]
+
+	ros, err := util.GetRpmOstreeStatusJSON(c, m)
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	oas, err := getOstreeAdminStatus(c, m)
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	if len(ros.Deployments) < 1 {
+		c.Fatalf(`Did not find any deployments?!`)
+	}
+
+	// verify the output from `ostree admin status`
+	c.Run("admin status", func(c cluster.TestCluster) {
+		if oas.Checksum != ros.Deployments[0].Checksum {
+			c.Fatalf(`Checksums do not match; expected %q, got %q`, ros.Deployments[0].Checksum, oas.Checksum)
+		}
+		if oas.Version != ros.Deployments[0].Version {
+			c.Fatalf(`Versions do not match; expected %q, got %q`, ros.Deployments[0].Version, oas.Version)
+		}
+		if oas.Origin != ros.Deployments[0].Origin {
+			c.Fatalf(`Origins do not match; expected %q, got %q`, ros.Deployments[0].Origin, oas.Origin)
+		}
+	})
+
+	// verify the output from `ostree rev-parse`
+	// this is kind of moot since the origin for RHCOS is just
+	// the checksum now
+	c.Run("rev-parse", func(c cluster.TestCluster) {
+		// check the output of `ostree rev-parse`
+		oRevParseOut := c.MustSSH(m, ("ostree rev-parse " + oas.Origin))
+
+		if string(oRevParseOut) != oas.Checksum {
+			c.Fatalf(`Checksum from "ostree rev-parse" does not match; expected %q, got %q`, oas.Checksum, string(oRevParseOut))
+		}
+	})
+
+	// verify the output of 'ostree show'
+	c.Run("show", func(c cluster.TestCluster) {
+		oShowOut := c.MustSSH(m, ("ostree show " + oas.Checksum))
+		oShowOutSplit := strings.Split(string(oShowOut), "\n")
+		// we need at least the first 4 lines (commit, ContentChecksum, Date, Version)
+		// to proceed safely
+		if len(oShowOutSplit) < 4 {
+			c.Fatalf(`Unexpected output from "ostree show": %q`, string(oShowOut))
+		}
+
+		// convert the 'timestamp' from `rpm-ostree status` into a date that
+		// we can compare to the date in `ostree admin status`
+		// also, wtf is up with formatting date/time in golang?!
+		timeFormat := "2006-01-02 15:04:05 +0000"
+		tsUnix := time.Unix(ros.Deployments[0].Timestamp, 0).UTC()
+		tsFormatted := tsUnix.Format(timeFormat)
+		oShowDate := strings.TrimPrefix(oShowOutSplit[2], "Date:  ")
+
+		if oShowDate != tsFormatted {
+			c.Fatalf(`Dates do not match; expected %q, got %q`, tsFormatted, oShowDate)
+		}
+
+		oVersionSplit := strings.Fields(oShowOutSplit[3])
+		if len(oVersionSplit) < 2 {
+			c.Fatalf(`Unexpected content in "Version" field of "ostree show" output: %q`, oShowOutSplit[3])
+		}
+		if oVersionSplit[1] != ros.Deployments[0].Version {
+			c.Fatalf(`Versions do not match; expected %q, got %q`, ros.Deployments[0].Version, oVersionSplit[1])
+		}
+	})
+}
+
+// ostreeRemoteTest verifies the `ostree remote` functionality;
+// specifically:  `add`, `delete`, `list`, `refs`, `show-url`, `summary`
+func ostreeRemoteTest(c cluster.TestCluster) {
+	m := c.Machines()[0]
+
+	// TODO: if this remote ever changes, update the `refMatch` regexp
+	// in the `ostree remote summary` test below
+	remoteName := "custom"
+	remoteUrl := "https://dl.fedoraproject.org/atomic/repo/"
+
+	// verify `ostree remote add` is successful
+	c.Run("add", func(c cluster.TestCluster) {
+		osRemoteAddCmd := "sudo ostree remote add --no-gpg-verify " + remoteName + " " + remoteUrl
+		c.MustSSH(m, osRemoteAddCmd)
+	})
+
+	// verify `ostree remote list`
+	c.Run("list", func(c cluster.TestCluster) {
+		osRemoteListOut := c.MustSSH(m, "ostree remote list -u")
+
+		osRemoteListSplit := strings.Split(string(osRemoteListOut), "\n")
+		// should have original remote + newly added remote
+		if len(osRemoteListSplit) != 2 {
+			c.Fatalf(`Did not find expected amount of ostree remotes: %q`, string(osRemoteListOut))
+		}
+
+		var remoteFound bool = false
+		for _, v := range osRemoteListSplit {
+			lSplit := strings.Fields(v)
+			if len(lSplit) != 2 {
+				c.Fatalf(`Unexpected format of ostree remote entry: %q`, v)
+			}
+			if lSplit[0] == remoteName && lSplit[1] == remoteUrl {
+				remoteFound = true
+			}
+		}
+		if !remoteFound {
+			c.Fatalf(`Added remote was not found: %v`, string(osRemoteListOut))
+		}
+	})
+
+	// verify `ostree remote show-url`
+	c.Run("show-url", func(c cluster.TestCluster) {
+		osRemoteShowUrlOut := c.MustSSH(m, ("ostree remote show-url " + remoteName))
+		if string(osRemoteShowUrlOut) != remoteUrl {
+			c.Fatalf(`URLs don't match; expected %q, got %q`, remoteName, string(osRemoteShowUrlOut))
+		}
+	})
+
+	// verify `ostree remote refs`
+	c.Run("refs", func(c cluster.TestCluster) {
+		osRemoteRefsOut := c.MustSSH(m, ("ostree remote refs " + remoteName))
+		if len(strings.Split(string(osRemoteRefsOut), "\n")) < 1 {
+			c.Fatalf(`Did not receive expected amount of refs from remote: %v`, string(osRemoteRefsOut))
+		}
+	})
+
+	// verify `ostree remote summary`
+	c.Run("summary", func(c cluster.TestCluster) {
+		remoteRefsOut := c.MustSSH(m, ("ostree remote refs " + remoteName))
+		remoteRefsOutSplit := strings.Split(string(remoteRefsOut), "\n")
+		remoteRefsCount := len(remoteRefsOutSplit)
+		if remoteRefsCount < 1 {
+			c.Fatalf(`Did not find any refs on ostree remote: %q`, string(remoteRefsOut))
+		}
+
+		osRemoteSummaryOut := c.MustSSH(m, ("ostree remote summary " + remoteName))
+		if len(strings.Split(string(osRemoteSummaryOut), "\n")) < 1 {
+			c.Fatalf(`Did not receive expected summary content from remote: %v`, string(osRemoteSummaryOut))
+		}
+
+		// the remote summary *should* include the same amount of
+		// refs as found in `ostree remote refs`
+		var refCount int = 0
+
+		// this matches the line from the output that includes the name of the ref.
+		// the original remote used in this test is a Fedora remote, so we are checking
+		// for refs particular to that remote.
+		// TODO: if the remote ever changes, we'll have to change this regexp too.
+		refMatch := regexp.MustCompile(`^\* fedora.*`)
+		remoteSummaryOutSplit := strings.Split(string(osRemoteSummaryOut), "\n")
+		// the remote should have at least one ref in the summary
+		if len(remoteSummaryOutSplit) < 4 {
+			c.Fatalf(`Did not find any refs in the remote summary: %q`, string(osRemoteSummaryOut))
+		}
+		for _, v := range remoteSummaryOutSplit {
+			if refMatch.MatchString(v) {
+				refCount += 1
+			}
+		}
+
+		if refCount == 0 {
+			c.Fatalf(`Did not find any refs in the remote summary that matched!`)
+		}
+
+		if refCount != remoteRefsCount {
+			c.Fatalf(`Did not find correct number of refs in remote summary; expected %q, got %q`, remoteRefsCount, refCount)
+		}
+	})
+
+	// verify `ostree remote delete`
+	c.Run("delete", func(c cluster.TestCluster) {
+		preRemotesOut := c.MustSSH(m, "ostree remote list")
+		preNumRemotes := len(strings.Split(string(preRemotesOut), "\n"))
+		if preNumRemotes < 1 {
+			c.Fatalf(`No remotes configured on host: %q`, string(preRemotesOut))
+		}
+
+		c.MustSSH(m, ("sudo ostree remote delete " + remoteName))
+
+		delRemoteListOut := c.MustSSH(m, "ostree remote list")
+		delNumRemotes := len(strings.Split(string(delRemoteListOut), "\n"))
+		if delNumRemotes >= preNumRemotes {
+			c.Fatalf(`Number of remotes did not decrease after "ostree delete": %v`, string(delRemoteListOut))
+		}
+	})
+}

--- a/kola/tests/ostree/unlock.go
+++ b/kola/tests/ostree/unlock.go
@@ -1,0 +1,269 @@
+// Copyright 2018 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ostree
+
+import (
+	"fmt"
+
+	"github.com/coreos/mantle/kola/cluster"
+	"github.com/coreos/mantle/kola/register"
+	"github.com/coreos/mantle/kola/tests/util"
+	"github.com/coreos/mantle/platform"
+)
+
+func init() {
+	register.Register(&register.Test{
+		Run:              ostreeUnlockTest,
+		ClusterSize:      1,
+		Name:             "ostree.unlock",
+		Distros:          []string{"rhcos", "fcos"},
+		ExcludePlatforms: []string{"qemu"}, // need network to pull RPM
+		FailFast:         true,
+	})
+	register.Register(&register.Test{
+		Run:              ostreeHotfixTest,
+		ClusterSize:      1,
+		Name:             "ostree.hotfix",
+		Distros:          []string{"rhcos", "fcos"},
+		ExcludePlatforms: []string{"qemu"}, // need network to pull RPM
+		FailFast:         true,
+	})
+
+}
+
+var (
+	rpmUrl  string = "https://raw.githubusercontent.com/projectatomic/atomic-host-tests/master/rpm/aht-dummy-1.0-1.noarch.rpm"
+	rpmName string = "aht-dummy"
+)
+
+// ostreeAdminUnlock will unlock the deployment and verify the success of the operation
+func ostreeAdminUnlock(c cluster.TestCluster, m platform.Machine, hotfix bool) error {
+	var unlockCmd string = "sudo ostree admin unlock"
+	if hotfix {
+		unlockCmd = "sudo ostree admin unlock --hotfix"
+	}
+
+	_, unlockCmdErr := c.SSH(m, unlockCmd)
+	if unlockCmdErr != nil {
+		return fmt.Errorf(`Failed to unlock deployment: %v`, unlockCmdErr)
+	}
+
+	status, err := util.GetRpmOstreeStatusJSON(c, m)
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	if len(status.Deployments) < 1 {
+		c.Fatalf(`Did not find any deployments`)
+	}
+
+	// verify that the unlock was successful
+	if hotfix && status.Deployments[0].Unlocked != "hotfix" {
+		return fmt.Errorf(`Hotfix mode is not reflected in "rpm-ostree status"; got: %q`, status.Deployments[0].Unlocked)
+	}
+
+	if !hotfix && status.Deployments[0].Unlocked != "development" {
+		return fmt.Errorf(`Unlocked mode is not reflected in "rpm-ostree status"; got: %q`, status.Deployments[0].Unlocked)
+	}
+
+	return nil
+}
+
+// rpmInstallVerify is a small utility func to handle installing an RPM
+// and verifying the install was successful
+// NOTE: RPM name and binary name must match
+func rpmInstallVerify(c cluster.TestCluster, m platform.Machine, rpmFile string, rpmName string) error {
+	_, installErr := c.SSH(m, ("sudo rpm -i " + rpmFile))
+	if installErr != nil {
+		return fmt.Errorf(`Failed to install RPM: %v`, installErr)
+	}
+
+	_, cmdErr := c.SSH(m, ("command -v " + rpmName))
+	if cmdErr != nil {
+		return fmt.Errorf(`Failed to find binary: %v`, cmdErr)
+	}
+
+	_, rpmErr := c.SSH(m, ("rpm -q " + rpmName))
+	if rpmErr != nil {
+		return fmt.Errorf(`Failed to find RPM in rpmdb: %v`, rpmErr)
+	}
+
+	return nil
+}
+
+// rpmUninstallVerify is a small utility func to handle uninstalling an RPM
+// and verifying the uninstall was successful
+// NOTE: RPM name and binary name must match
+func rpmUninstallVerify(c cluster.TestCluster, m platform.Machine, rpmName string) error {
+	_, uninstallErr := c.SSH(m, ("sudo rpm -e " + rpmName))
+	if uninstallErr != nil {
+		return fmt.Errorf(`Failed to uninstall RPM: %v`, uninstallErr)
+	}
+
+	_, missCmdErr := c.SSH(m, ("command -v " + rpmName))
+	if missCmdErr == nil {
+		return fmt.Errorf(`Found a binary that should not be there: %v`, missCmdErr)
+	}
+
+	_, missRpmErr := c.SSH(m, ("rpm -q " + rpmName))
+	if missRpmErr == nil {
+		return fmt.Errorf(`RPM incorrectly in rpmdb after RPM uninstall: %v`, missRpmErr)
+	}
+
+	return nil
+}
+
+// ostreeUnlockTest verifies the simplest use of `ostree admin unlock` by
+// trying to install a dummy RPM on the host, rebooting, and ensuring
+// the RPM is gone after reboot
+func ostreeUnlockTest(c cluster.TestCluster) {
+	m := c.Machines()[0]
+
+	// unlock the deployment
+	c.Run("unlock", func(c cluster.TestCluster) {
+		unlockErr := ostreeAdminUnlock(c, m, false)
+		if unlockErr != nil {
+			c.Fatal(unlockErr)
+		}
+	})
+
+	// try to install an RPM via HTTP
+	c.Run("install", func(c cluster.TestCluster) {
+		rpmInstallErr := rpmInstallVerify(c, m, rpmUrl, rpmName)
+		if rpmInstallErr != nil {
+			c.Fatal(rpmInstallErr)
+		}
+	})
+
+	// try to uninstall RPM
+	c.Run("uninstall", func(c cluster.TestCluster) {
+		rpmUninstallErr := rpmUninstallVerify(c, m, rpmName)
+		if rpmUninstallErr != nil {
+			c.Fatal(rpmUninstallErr)
+		}
+	})
+
+	// re-install the RPM and verify the unlocked deployment is discarded
+	// after reboot
+	c.Run("discard", func(c cluster.TestCluster) {
+		c.MustSSH(m, ("sudo rpm -i " + rpmUrl))
+
+		unlockRebootErr := m.Reboot()
+		if unlockRebootErr != nil {
+			c.Fatalf("Failed to reboot machine: %v", unlockRebootErr)
+		}
+
+		ros, err := util.GetRpmOstreeStatusJSON(c, m)
+		if err != nil {
+			c.Fatal(err)
+		}
+
+		if ros.Deployments[0].Unlocked != "none" {
+			c.Fatalf(`Deployment was incorrectly unlocked; got: %q`, ros.Deployments[0].Unlocked)
+		}
+
+		_, secCmdErr := c.SSH(m, ("command -v " + rpmName))
+		if secCmdErr == nil {
+			c.Fatalf(`Binary was incorrectly found after reboot`)
+		}
+		_, secRpmErr := c.SSH(m, ("rpm -q " + rpmName))
+		if secRpmErr == nil {
+			c.Fatalf(`RPM incorrectly in rpmdb after reboot`)
+		}
+	})
+}
+
+// ostreeHotfixTest verifies that the deployment can be put into "hotfix"
+// mode, where the RPMs installed will persist across reboots.  A rollback will
+// return the host to the original state
+func ostreeHotfixTest(c cluster.TestCluster) {
+	m := c.Machines()[0]
+
+	// unlock the deployment into "hotfix" mode
+	c.Run("unlock", func(c cluster.TestCluster) {
+		unlockErr := ostreeAdminUnlock(c, m, true)
+		if unlockErr != nil {
+			c.Fatal(unlockErr)
+		}
+	})
+
+	// try to install an RPM via HTTP
+	c.Run("install", func(c cluster.TestCluster) {
+		rpmInstallErr := rpmInstallVerify(c, m, rpmUrl, rpmName)
+		if rpmInstallErr != nil {
+			c.Fatal(rpmInstallErr)
+		}
+	})
+
+	// uninstall the RPM
+	c.Run("uninstall", func(c cluster.TestCluster) {
+		rpmUninstallErr := rpmUninstallVerify(c, m, rpmName)
+		if rpmUninstallErr != nil {
+			c.Fatal(rpmUninstallErr)
+		}
+	})
+
+	// install the RPM again, reboot, verify it the "hotfix" deployment
+	// and RPM have persisted
+	c.Run("persist", func(c cluster.TestCluster) {
+		c.MustSSH(m, ("sudo rpm -i " + rpmUrl))
+
+		unlockRebootErr := m.Reboot()
+		if unlockRebootErr != nil {
+			c.Fatalf("Failed to reboot machine: %v", unlockRebootErr)
+		}
+
+		ros, err := util.GetRpmOstreeStatusJSON(c, m)
+		if err != nil {
+			c.Fatal(err)
+		}
+
+		if ros.Deployments[0].Unlocked != "hotfix" {
+			c.Fatalf(`Hotfix mode was not detected; got: %q`, ros.Deployments[0].Unlocked)
+		}
+
+		c.MustSSH(m, ("command -v " + rpmName))
+
+		c.MustSSH(m, ("rpm -q " + rpmName))
+	})
+
+	// roll back the deployment and verify the "hotfix" is no longer present
+	c.Run("rollback", func(c cluster.TestCluster) {
+		c.MustSSH(m, "sudo rpm-ostree rollback")
+
+		rollbackRebootErr := m.Reboot()
+		if rollbackRebootErr != nil {
+			c.Fatalf("Failed to reboot machine: %v", rollbackRebootErr)
+		}
+
+		rollbackStatus, err := util.GetRpmOstreeStatusJSON(c, m)
+		if err != nil {
+			c.Fatal(err)
+		}
+
+		if rollbackStatus.Deployments[0].Unlocked != "none" {
+			c.Fatalf(`Rollback did not remove hotfix mode; got: $q`, rollbackStatus.Deployments[0].Unlocked)
+		}
+
+		_, secCmdErr := c.SSH(m, ("command -v " + rpmName))
+		if secCmdErr == nil {
+			c.Fatalf(`Binary was incorrectly found after reboot`)
+		}
+		_, secRpmErr := c.SSH(m, ("rpm -q " + rpmName))
+		if secRpmErr == nil {
+			c.Fatalf(`RPM incorrectly in rpmdb after reboot`)
+		}
+	})
+}


### PR DESCRIPTION
This adds some simple tests to validate basic `ostree` functionality.  It should cover some of the most common use cases that a FCOS/RHCOS user would encounter.

I used the tests from `atomic-host-tests` as a guide, but did not port the full complement of `ostree` related tests from there.