### PR TITLE
kola/tests: cleanup rpmostree tests + related funcs

### DIFF
--- a/kola/tests/rpmostree/deployments.go
+++ b/kola/tests/rpmostree/deployments.go
@@ -28,13 +28,13 @@ func init() {
 	register.Register(&register.Test{
 		Run:         rpmOstreeUpgradeRollback,
 		ClusterSize: 1,
-		Name:        "rhcos.rpmostree.upgrade-rollback",
+		Name:        "rpmostree.upgrade-rollback",
 		Distros:     []string{"rhcos", "fcos"},
 	})
 	register.Register(&register.Test{
 		Run:         rpmOstreeInstallUninstall,
 		ClusterSize: 1,
-		Name:        "rhcos.rpmostree.install-uninstall",
+		Name:        "rpmostree.install-uninstall",
 		// this Ignition config lands the EPEL repo + key
 		UserData: conf.Ignition(`{
   "ignition": {

--- a/kola/tests/rpmostree/deployments.go
+++ b/kola/tests/rpmostree/deployments.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
+	"github.com/coreos/mantle/kola/tests/util"
 	"github.com/coreos/mantle/platform/conf"
 )
 
@@ -87,7 +88,7 @@ func rpmOstreeUpgradeRollback(c cluster.TestCluster) {
 
 	m := c.Machines()[0]
 
-	originalStatus, err := getRpmOstreeStatusJSON(c, m)
+	originalStatus, err := util.GetRpmOstreeStatusJSON(c, m)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -109,7 +110,7 @@ func rpmOstreeUpgradeRollback(c cluster.TestCluster) {
 	c.MustSSH(m, "sudo rpm-ostree rebase :"+newBranch)
 
 	// get latest rpm-ostree status output to check validity
-	postUpgradeStatus, err := getRpmOstreeStatusJSON(c, m)
+	postUpgradeStatus, err := util.GetRpmOstreeStatusJSON(c, m)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -126,7 +127,7 @@ func rpmOstreeUpgradeRollback(c cluster.TestCluster) {
 	}
 
 	// get latest rpm-ostree status output
-	postRebootStatus, err := getRpmOstreeStatusJSON(c, m)
+	postRebootStatus, err := util.GetRpmOstreeStatusJSON(c, m)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -164,7 +165,7 @@ func rpmOstreeUpgradeRollback(c cluster.TestCluster) {
 		c.Fatalf("Failed to reboot machine: %v", err)
 	}
 
-	rollbackStatus, err := getRpmOstreeStatusJSON(c, m)
+	rollbackStatus, err := util.GetRpmOstreeStatusJSON(c, m)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -192,7 +193,7 @@ func rpmOstreeUpgradeRollback(c cluster.TestCluster) {
 func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
-	originalStatus, err := getRpmOstreeStatusJSON(c, m)
+	originalStatus, err := util.GetRpmOstreeStatusJSON(c, m)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -210,7 +211,7 @@ func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 		c.Fatalf("Failed to reboot machine: %v", installRebootErr)
 	}
 
-	postInstallStatus, err := getRpmOstreeStatusJSON(c, m)
+	postInstallStatus, err := util.GetRpmOstreeStatusJSON(c, m)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -271,7 +272,7 @@ func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 		c.Fatalf("Failed to reboot machine: %v", uninstallRebootErr)
 	}
 
-	postUninstallStatus, err := getRpmOstreeStatusJSON(c, m)
+	postUninstallStatus, err := util.GetRpmOstreeStatusJSON(c, m)
 	if err != nil {
 		c.Fatal(err)
 	}

--- a/kola/tests/rpmostree/deployments.go
+++ b/kola/tests/rpmostree/deployments.go
@@ -30,6 +30,7 @@ func init() {
 		ClusterSize: 1,
 		Name:        "rpmostree.upgrade-rollback",
 		Distros:     []string{"rhcos", "fcos"},
+		FailFast:    true,
 	})
 	register.Register(&register.Test{
 		Run:         rpmOstreeInstallUninstall,
@@ -97,99 +98,106 @@ func rpmOstreeUpgradeRollback(c cluster.TestCluster) {
 		c.Fatalf(`Unexpected results from "rpm-ostree status"; received: %v`, originalStatus)
 	}
 
-	// create a local branch to act as our upgrade target
-	originalCsum := originalStatus.Deployments[0].Checksum
-	createBranch := "sudo ostree refs --create " + newBranch + " " + originalCsum
-	c.MustSSH(m, createBranch)
+	c.Run("upgrade", func(c cluster.TestCluster) {
+		// create a local branch to act as our upgrade target
+		originalCsum := originalStatus.Deployments[0].Checksum
+		createBranch := "sudo ostree refs --create " + newBranch + " " + originalCsum
+		c.MustSSH(m, createBranch)
 
-	// make a commit to the new branch
-	createCommit := "sudo ostree commit -b " + newBranch + " --tree ref=" + originalCsum + " --add-metadata-string version=" + newVersion
-	newCommit := c.MustSSH(m, createCommit)
+		// make a commit to the new branch
+		createCommit := "sudo ostree commit -b " + newBranch + " --tree ref=" + originalCsum + " --add-metadata-string version=" + newVersion
+		newCommit := c.MustSSH(m, createCommit)
 
-	// use "rpm-ostree rebase" to get to the "new" commit
-	c.MustSSH(m, "sudo rpm-ostree rebase :"+newBranch)
+		// use "rpm-ostree rebase" to get to the "new" commit
+		c.MustSSH(m, "sudo rpm-ostree rebase :"+newBranch)
 
-	// get latest rpm-ostree status output to check validity
-	postUpgradeStatus, err := util.GetRpmOstreeStatusJSON(c, m)
-	if err != nil {
-		c.Fatal(err)
-	}
+		// get latest rpm-ostree status output to check validity
+		postUpgradeStatus, err := util.GetRpmOstreeStatusJSON(c, m)
+		if err != nil {
+			c.Fatal(err)
+		}
 
-	// should have two deployments
-	if len(postUpgradeStatus.Deployments) != 2 {
-		c.Fatalf("Expected two deployments; found %d deployments", len(postUpgradeStatus.Deployments))
-	}
+		// should have two deployments
+		if len(postUpgradeStatus.Deployments) != 2 {
+			c.Fatalf("Expected two deployments; found %d deployments", len(postUpgradeStatus.Deployments))
+		}
 
-	// reboot into new deployment
-	rebootErr := m.Reboot()
-	if rebootErr != nil {
-		c.Fatalf("Failed to reboot machine: %v", err)
-	}
+		// reboot into new deployment
+		rebootErr := m.Reboot()
+		if rebootErr != nil {
+			c.Fatalf("Failed to reboot machine: %v", err)
+		}
 
-	// get latest rpm-ostree status output
-	postRebootStatus, err := util.GetRpmOstreeStatusJSON(c, m)
-	if err != nil {
-		c.Fatal(err)
-	}
+		// get latest rpm-ostree status output
+		postRebootStatus, err := util.GetRpmOstreeStatusJSON(c, m)
+		if err != nil {
+			c.Fatal(err)
+		}
 
-	// should still have 2 deployments
-	if len(postRebootStatus.Deployments) != 2 {
-		c.Fatalf("Expected two deployments; found %d deployment", len(postRebootStatus.Deployments))
-	}
+		// should still have 2 deployments
+		if len(postRebootStatus.Deployments) != 2 {
+			c.Fatalf("Expected two deployments; found %d deployment", len(postRebootStatus.Deployments))
+		}
 
-	// origin should be new branch
-	if postRebootStatus.Deployments[0].Origin != newBranch {
-		c.Fatalf(`New deployment origin is incorrect; expected %q, got %q`, newBranch, postRebootStatus.Deployments[0].Origin)
-	}
+		// origin should be new branch
+		if postRebootStatus.Deployments[0].Origin != newBranch {
+			c.Fatalf(`New deployment origin is incorrect; expected %q, got %q`, newBranch, postRebootStatus.Deployments[0].Origin)
+		}
 
-	// new deployment should be booted
-	if !postRebootStatus.Deployments[0].Booted {
-		c.Fatalf("New deployment is not reporting as booted")
-	}
+		// new deployment should be booted
+		if !postRebootStatus.Deployments[0].Booted {
+			c.Fatalf("New deployment is not reporting as booted")
+		}
 
-	// checksum should be new commit
-	if postRebootStatus.Deployments[0].Checksum != string(newCommit) {
-		c.Fatalf(`New deployment checksum is incorrect; expected %q, got %q`, newCommit, postRebootStatus.Deployments[0].Checksum)
-	}
+		// checksum should be new commit
+		if postRebootStatus.Deployments[0].Checksum != string(newCommit) {
+			c.Fatalf(`New deployment checksum is incorrect; expected %q, got %q`, newCommit, postRebootStatus.Deployments[0].Checksum)
+		}
 
-	// version should be new version string
-	if postRebootStatus.Deployments[0].Version != newVersion {
-		c.Fatalf(`New deployment version is incorrect; expected %q, got %q`, newVersion, postRebootStatus.Deployments[0].Checksum)
-	}
+		// version should be new version string
+		if postRebootStatus.Deployments[0].Version != newVersion {
+			c.Fatalf(`New deployment version is incorrect; expected %q, got %q`, newVersion, postRebootStatus.Deployments[0].Checksum)
+		}
+	})
 
-	// rollback to original deployment
-	c.MustSSH(m, "sudo rpm-ostree rollback")
+	c.Run("rollback", func(c cluster.TestCluster) {
+		// rollback to original deployment
+		c.MustSSH(m, "sudo rpm-ostree rollback")
 
-	newRebootErr := m.Reboot()
-	if newRebootErr != nil {
-		c.Fatalf("Failed to reboot machine: %v", err)
-	}
+		newRebootErr := m.Reboot()
+		if newRebootErr != nil {
+			c.Fatalf("Failed to reboot machine: %v", err)
+		}
 
-	rollbackStatus, err := util.GetRpmOstreeStatusJSON(c, m)
-	if err != nil {
-		c.Fatal(err)
-	}
+		rollbackStatus, err := util.GetRpmOstreeStatusJSON(c, m)
+		if err != nil {
+			c.Fatal(err)
+		}
 
-	// still 2 deployments...
-	if len(rollbackStatus.Deployments) != 2 {
-		c.Fatalf("Expected two deployments; found %d deployments", len(rollbackStatus.Deployments))
-	}
+		// still 2 deployments...
+		if len(rollbackStatus.Deployments) != 2 {
+			c.Fatalf("Expected two deployments; found %d deployments", len(rollbackStatus.Deployments))
+		}
 
-	// validate we are back to the original deployment by comparing the
-	// the two rpmOstreeDeployment structs
-	if !reflect.DeepEqual(originalStatus.Deployments[0], rollbackStatus.Deployments[0]) {
-		c.Fatalf(`Differences found in "rpm-ostree status"; original %v, current: %v`, originalStatus.Deployments[0], rollbackStatus.Deployments[0])
-	}
+		// validate we are back to the original deployment by comparing the
+		// the two rpmOstreeDeployment structs
+		if !reflect.DeepEqual(originalStatus.Deployments[0], rollbackStatus.Deployments[0]) {
+			c.Fatalf(`Differences found in "rpm-ostree status"; original %v, current: %v`, originalStatus.Deployments[0], rollbackStatus.Deployments[0])
+		}
 
-	// cleanup our mess
-	cleanupErr := rpmOstreeCleanup(c, m)
-	if cleanupErr != nil {
-		c.Fatal(cleanupErr)
-	}
+		// cleanup our mess
+		cleanupErr := rpmOstreeCleanup(c, m)
+		if cleanupErr != nil {
+			c.Fatal(cleanupErr)
+		}
+	})
 }
 
 // rpmOstreeInstallUninstall verifies that we can install a package
 // and then uninstall it
+// we've hardcoded 'fpaste' throughout the test because it should be
+// a package that a) will be around a long time and b) is small +
+// well-defined
 func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
@@ -203,101 +211,105 @@ func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 	}
 
 	originalCsum := originalStatus.Deployments[0].Checksum
-	// install fpaste and reboot
-	c.MustSSH(m, "sudo rpm-ostree install fpaste")
 
-	installRebootErr := m.Reboot()
-	if installRebootErr != nil {
-		c.Fatalf("Failed to reboot machine: %v", installRebootErr)
-	}
+	c.Run("install", func(c cluster.TestCluster) {
+		// install fpaste and reboot
+		c.MustSSH(m, "sudo rpm-ostree install fpaste")
 
-	postInstallStatus, err := util.GetRpmOstreeStatusJSON(c, m)
-	if err != nil {
-		c.Fatal(err)
-	}
-
-	if len(postInstallStatus.Deployments) != 2 {
-		c.Fatalf(`Expected two deployments, found %d deployments`, len(postInstallStatus.Deployments))
-	}
-
-	// check the command is present, in the rpmdb, and usable
-	cmdOut := c.MustSSH(m, "command -v fpaste")
-	if string(cmdOut) != "/bin/fpaste" {
-		c.Fatalf(`fpaste binary in unexpected location. expectd %q, got %q`, "/bin/fpaste", string(cmdOut))
-	}
-
-	// e.g. fpaste-0.3.7.4.1-2.el7.noarch
-	rpmOut := c.MustSSH(m, "rpm -q fpaste")
-	rpmMatch := regexp.MustCompile("^fpaste.*noarch").MatchString(string(rpmOut))
-	if !rpmMatch {
-		c.Fatalf(`Output from "rpm -q" was unexpected: %q`, string(rpmOut))
-	}
-
-	// just verify the command runs
-	c.MustSSH(m, "fpaste --version")
-
-	// package should be in the metadata
-	var reqPkg bool = false
-	for _, pkg := range postInstallStatus.Deployments[0].RequestedPackages {
-		if pkg == "fpaste" {
-			reqPkg = true
-			break
+		installRebootErr := m.Reboot()
+		if installRebootErr != nil {
+			c.Fatalf("Failed to reboot machine: %v", installRebootErr)
 		}
-	}
-	if !reqPkg {
-		c.Fatalf(`Unable to find "fpaste" in requested-packages: %v`, postInstallStatus.Deployments[0].RequestedPackages)
-	}
 
-	var installPkg bool = false
-	for _, pkg := range postInstallStatus.Deployments[0].Packages {
-		if pkg == "fpaste" {
-			installPkg = true
-			break
+		postInstallStatus, err := util.GetRpmOstreeStatusJSON(c, m)
+		if err != nil {
+			c.Fatal(err)
 		}
-	}
-	if !installPkg {
-		c.Fatalf(`Unable to find "fpaste" in packages: %v`, postInstallStatus.Deployments[0].Packages)
-	}
 
-	// checksum should be different
-	if postInstallStatus.Deployments[0].Checksum == originalCsum {
-		c.Fatalf(`Commit IDs incorrectly matched after package install`)
-	}
+		if len(postInstallStatus.Deployments) != 2 {
+			c.Fatalf(`Expected two deployments, found %d deployments`, len(postInstallStatus.Deployments))
+		}
+
+		// check the command is present, in the rpmdb, and usable
+		cmdOut := c.MustSSH(m, "command -v fpaste")
+		if string(cmdOut) != "/bin/fpaste" {
+			c.Fatalf(`fpaste binary in unexpected location. expectd %q, got %q`, "/bin/fpaste", string(cmdOut))
+		}
+
+		// e.g. fpaste-0.3.7.4.1-2.el7.noarch
+		rpmOut := c.MustSSH(m, "rpm -q fpaste")
+		rpmMatch := regexp.MustCompile("^fpaste.*noarch").MatchString(string(rpmOut))
+		if !rpmMatch {
+			c.Fatalf(`Output from "rpm -q" was unexpected: %q`, string(rpmOut))
+		}
+
+		// just verify the command runs
+		c.MustSSH(m, "fpaste --version")
+
+		// package should be in the metadata
+		var reqPkg bool = false
+		for _, pkg := range postInstallStatus.Deployments[0].RequestedPackages {
+			if pkg == "fpaste" {
+				reqPkg = true
+				break
+			}
+		}
+		if !reqPkg {
+			c.Fatalf(`Unable to find "fpaste" in requested-packages: %v`, postInstallStatus.Deployments[0].RequestedPackages)
+		}
+
+		var installPkg bool = false
+		for _, pkg := range postInstallStatus.Deployments[0].Packages {
+			if pkg == "fpaste" {
+				installPkg = true
+				break
+			}
+		}
+		if !installPkg {
+			c.Fatalf(`Unable to find "fpaste" in packages: %v`, postInstallStatus.Deployments[0].Packages)
+		}
+
+		// checksum should be different
+		if postInstallStatus.Deployments[0].Checksum == originalCsum {
+			c.Fatalf(`Commit IDs incorrectly matched after package install`)
+		}
+	})
 
 	// uninstall the package
-	c.MustSSH(m, "sudo rpm-ostree uninstall fpaste")
+	c.Run("uninstall", func(c cluster.TestCluster) {
+		c.MustSSH(m, "sudo rpm-ostree uninstall fpaste")
 
-	uninstallRebootErr := m.Reboot()
-	if uninstallRebootErr != nil {
-		c.Fatalf("Failed to reboot machine: %v", uninstallRebootErr)
-	}
+		uninstallRebootErr := m.Reboot()
+		if uninstallRebootErr != nil {
+			c.Fatalf("Failed to reboot machine: %v", uninstallRebootErr)
+		}
 
-	postUninstallStatus, err := util.GetRpmOstreeStatusJSON(c, m)
-	if err != nil {
-		c.Fatal(err)
-	}
+		postUninstallStatus, err := util.GetRpmOstreeStatusJSON(c, m)
+		if err != nil {
+			c.Fatal(err)
+		}
 
-	// check the metadata to make sure everything went well
-	if len(postUninstallStatus.Deployments) != 2 {
-		c.Fatal("Expected two deployments, got %d", len(postUninstallStatus.Deployments))
-	}
+		// check the metadata to make sure everything went well
+		if len(postUninstallStatus.Deployments) != 2 {
+			c.Fatal("Expected two deployments, got %d", len(postUninstallStatus.Deployments))
+		}
 
-	if postUninstallStatus.Deployments[0].Checksum != originalCsum {
-		c.Fatalf(`Checksum is incorrect; expected %q, got %q`, originalCsum, postUninstallStatus.Deployments[0].Checksum)
-	}
+		if postUninstallStatus.Deployments[0].Checksum != originalCsum {
+			c.Fatalf(`Checksum is incorrect; expected %q, got %q`, originalCsum, postUninstallStatus.Deployments[0].Checksum)
+		}
 
-	if len(postUninstallStatus.Deployments[0].RequestedPackages) != 0 {
-		c.Fatalf(`Found unexpected requested-packages: %q`, postUninstallStatus.Deployments[0].RequestedPackages)
-	}
+		if len(postUninstallStatus.Deployments[0].RequestedPackages) != 0 {
+			c.Fatalf(`Found unexpected requested-packages: %q`, postUninstallStatus.Deployments[0].RequestedPackages)
+		}
 
-	if len(postUninstallStatus.Deployments[0].Packages) != 0 {
-		c.Fatalf(`Found unexpected packages: %q`, postUninstallStatus.Deployments[0].Packages)
-	}
+		if len(postUninstallStatus.Deployments[0].Packages) != 0 {
+			c.Fatalf(`Found unexpected packages: %q`, postUninstallStatus.Deployments[0].Packages)
+		}
 
-	// cleanup our mess
-	cleanupErr := rpmOstreeCleanup(c, m)
-	if cleanupErr != nil {
-		c.Fatal(cleanupErr)
-	}
-
+		// cleanup our mess
+		cleanupErr := rpmOstreeCleanup(c, m)
+		if cleanupErr != nil {
+			c.Fatal(cleanupErr)
+		}
+	})
 }

--- a/kola/tests/rpmostree/status.go
+++ b/kola/tests/rpmostree/status.go
@@ -15,13 +15,13 @@
 package rpmostree
 
 import (
-	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
+	"github.com/coreos/mantle/kola/tests/util"
 	"github.com/coreos/mantle/platform"
 )
 
@@ -29,7 +29,7 @@ func init() {
 	register.Register(&register.Test{
 		Run:         rpmOstreeStatus,
 		ClusterSize: 1,
-		Name:        "rhcos.rpmostree.status",
+		Name:        "rpmostree.status",
 		Distros:     []string{"rhcos", "fcos"},
 	})
 }

--- a/kola/tests/util/rpmostree.go
+++ b/kola/tests/util/rpmostree.go
@@ -1,0 +1,58 @@
+// Copyright 2018 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/coreos/mantle/kola/cluster"
+	"github.com/coreos/mantle/platform"
+)
+
+// rpmOstreeDeployment represents some of the data of an rpm-ostree deployment
+type rpmOstreeDeployment struct {
+	Booted            bool     `json:"booted"`
+	Checksum          string   `json:"checksum"`
+	Origin            string   `json:"origin"`
+	Osname            string   `json:"osname"`
+	Packages          []string `json:"packages"`
+	RequestedPackages []string `json:"requested-packages"`
+	Timestamp         int64    `json:"timestamp"`
+	Unlocked          string   `json:"unlocked"`
+	Version           string   `json:"version"`
+}
+
+// simplifiedRpmOstreeStatus contains deployments from rpm-ostree status
+type simplifiedRpmOstreeStatus struct {
+	Deployments []rpmOstreeDeployment
+}
+
+// GetRpmOstreeStatusJSON returns an unmarshal'ed JSON object that contains
+// a limited representation of the output of `rpm-ostree status --json`
+func GetRpmOstreeStatusJSON(c cluster.TestCluster, m platform.Machine) (simplifiedRpmOstreeStatus, error) {
+	target := simplifiedRpmOstreeStatus{}
+	rpmOstreeJSON, err := c.SSH(m, "rpm-ostree status --json")
+	if err != nil {
+		return target, fmt.Errorf("Could not get rpm-ostree status: %v", err)
+	}
+
+	err = json.Unmarshal(rpmOstreeJSON, &target)
+	if err != nil {
+		return target, fmt.Errorf("Couldn't umarshal the rpm-ostree status JSON data: %v", err)
+	}
+
+	return target, nil
+}


### PR DESCRIPTION
This started with just moving `GetRpmOstreeStatusJSON` to the `util` package, but grew into re-working the `rpmostree` tests too.

I moved the `rpmostree` tests into their own namespace to be more compliant with the [kola test namespacing policy](https://github.com/coreos/mantle/blob/master/README.md#kola-test-namespacing).

Additionally, I opted to make some of the `rpmostree` tests use the `FailFast` capability.