### PR TITLE
kola/tests/misc: check for listening ports in the docker stack

### DIFF
--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -20,8 +20,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
+
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
+	"github.com/coreos/mantle/platform/conf"
 	"github.com/coreos/mantle/util"
 )
 
@@ -31,6 +34,19 @@ func init() {
 		ClusterSize: 1,
 		Name:        "cl.network.listeners",
 		Distros:     []string{"cl"},
+		// be sure to notice listeners in the docker stack
+		UserData: conf.ContainerLinuxConfig(`systemd:
+  units:
+    - name: docker.service
+      enabled: true`),
+		MinVersion: semver.Version{Major: 1967},
+	})
+	register.Register(&register.Test{
+		Run:         NetworkListeners,
+		ClusterSize: 1,
+		Name:        "cl.network.listeners.legacy",
+		Distros:     []string{"cl"},
+		EndVersion:  semver.Version{Major: 1967},
 	})
 	register.Register(&register.Test{
 		Run:              NetworkInitramfsSecondBoot,


### PR DESCRIPTION
Starting with Docker 18.06, the containerd CRI plugin listens on a public port by default.  Enable dockerd so we'll detect this.