### PR TITLE
platform/qemu: don't try to mangle qcow disk images

### DIFF
--- a/cmd/kola/kola.go
+++ b/cmd/kola/kola.go
@@ -155,7 +155,8 @@ func writeProps() error {
 		ImageURL              string `json:"image"`
 	}
 	type QEMU struct {
-		Image string `json:"image"`
+		Image   string `json:"image"`
+		Mangled bool   `json:"mangled"`
 	}
 	return enc.Encode(&struct {
 		Cmdline  []string `json:"cmdline"`
@@ -198,7 +199,8 @@ func writeProps() error {
 			ImageURL:              kola.PacketOptions.ImageURL,
 		},
 		QEMU: QEMU{
-			Image: kola.QEMUOptions.DiskImage,
+			Image:   kola.QEMUOptions.DiskImage,
+			Mangled: !kola.QEMUOptions.UseVanillaImage,
 		},
 	})
 }

--- a/util/image.go
+++ b/util/image.go
@@ -1,0 +1,38 @@
+// Copyright 2018 Red Hat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"encoding/json"
+	"os/exec"
+)
+
+type ImageInfo struct {
+	Format string `json:"format"`
+}
+
+func GetImageInfo(path string) (*ImageInfo, error) {
+	out, err := exec.Command("qemu-img", "info", "--output=json", path).Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var info ImageInfo
+	err = json.Unmarshal(out, &info)
+	if err != nil {
+		return nil, err
+	}
+	return &info, nil
+}


### PR DESCRIPTION
Fixes `kola spawn` on RHCOS images without `-b rhcos`, which isn't otherwise necessary.

cc @miabbott 