### PR TITLE
ore/upload: Add --size-gib and --size-inspect

### DIFF
--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -407,12 +407,12 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imageName, 
 
 	plog.Printf("Creating AMIs from %v...", snapshot.SnapshotID)
 
-	hvmImageID, err := api.CreateHVMImage(snapshot.SnapshotID, imageName+"-hvm", imageDescription+" (HVM)")
+	hvmImageID, err := api.CreateHVMImage(snapshot.SnapshotID, imageName+"-hvm", 0, imageDescription+" (HVM)")
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to create HVM image: %v", err)
 	}
 
-	pvImageID, err := api.CreatePVImage(snapshot.SnapshotID, imageName, imageDescription+" (PV)")
+	pvImageID, err := api.CreatePVImage(snapshot.SnapshotID, imageName, 0, imageDescription+" (PV)")
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to create PV image: %v", err)
 	}

--- a/util/image.go
+++ b/util/image.go
@@ -20,7 +20,8 @@ import (
 )
 
 type ImageInfo struct {
-	Format string `json:"format"`
+	Format      string `json:"format"`
+	VirtualSize uint64 `json:"virtual-size"`
 }
 
 func GetImageInfo(path string) (*ImageInfo, error) {


### PR DESCRIPTION
We want to expand the disk size of Red Hat CoreOS; previously
there was a hardcoded 8GiB size for Container Linux which
(I believe entirely coincidentally) matched RHCOS.

See https://github.com/coreos/mantle/pull/948
and https://github.com/coreos/mantle/pull/944