### PR TITLE
ore/aws/upload: --disk-size-gib and --disk-size-inspect, revisited

### DIFF
--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -407,12 +407,12 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imageName, 
 
 	plog.Printf("Creating AMIs from %v...", snapshot.SnapshotID)
 
-	hvmImageID, err := api.CreateHVMImage(snapshot.SnapshotID, imageName+"-hvm", imageDescription+" (HVM)")
+	hvmImageID, err := api.CreateHVMImage(snapshot.SnapshotID, aws.ContainerLinuxDiskSizeGiB, imageName+"-hvm", imageDescription+" (HVM)")
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to create HVM image: %v", err)
 	}
 
-	pvImageID, err := api.CreatePVImage(snapshot.SnapshotID, imageName, imageDescription+" (PV)")
+	pvImageID, err := api.CreatePVImage(snapshot.SnapshotID, aws.ContainerLinuxDiskSizeGiB, imageName, imageDescription+" (PV)")
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to create PV image: %v", err)
 	}

--- a/platform/api/aws/images.go
+++ b/platform/api/aws/images.go
@@ -30,6 +30,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 )
 
+// The default size of Container Linux disks on AWS, in GiB. See discussion in
+// https://github.com/coreos/mantle/pull/944
+const ContainerLinuxDiskSizeGiB = 8
+
 var (
 	NoRegionPVSupport = errors.New("Region does not support PV")
 )
@@ -350,18 +354,18 @@ func (a *API) CreateImportRole(bucket string) error {
 	return nil
 }
 
-func (a *API) CreateHVMImage(snapshotID string, name string, description string) (string, error) {
-	params := registerImageParams(snapshotID, name, description, "xvd", EC2ImageTypeHVM)
+func (a *API) CreateHVMImage(snapshotID string, diskSizeGiB uint, name string, description string) (string, error) {
+	params := registerImageParams(snapshotID, diskSizeGiB, name, description, "xvd", EC2ImageTypeHVM)
 	params.EnaSupport = aws.Bool(true)
 	params.SriovNetSupport = aws.String("simple")
 	return a.createImage(params)
 }
 
-func (a *API) CreatePVImage(snapshotID string, name string, description string) (string, error) {
+func (a *API) CreatePVImage(snapshotID string, diskSizeGiB uint, name string, description string) (string, error) {
 	if !RegionSupportsPV(a.opts.Region) {
 		return "", NoRegionPVSupport
 	}
-	params := registerImageParams(snapshotID, name, description, "sd", EC2ImageTypePV)
+	params := registerImageParams(snapshotID, diskSizeGiB, name, description, "sd", EC2ImageTypePV)
 	params.KernelId = aws.String(akis[a.opts.Region])
 	return a.createImage(params)
 }
@@ -403,9 +407,7 @@ func (a *API) createImage(params *ec2.RegisterImageInput) (string, error) {
 	return imageID, nil
 }
 
-const diskSize = 8 // GB
-
-func registerImageParams(snapshotID, name, description string, diskBaseName string, imageType EC2ImageType) *ec2.RegisterImageInput {
+func registerImageParams(snapshotID string, diskSizeGiB uint, name, description string, diskBaseName string, imageType EC2ImageType) *ec2.RegisterImageInput {
 	return &ec2.RegisterImageInput{
 		Name:               aws.String(name),
 		Description:        aws.String(description),
@@ -418,7 +420,7 @@ func registerImageParams(snapshotID, name, description string, diskBaseName stri
 				Ebs: &ec2.EbsBlockDevice{
 					SnapshotId:          aws.String(snapshotID),
 					DeleteOnTermination: aws.Bool(true),
-					VolumeSize:          aws.Int64(diskSize),
+					VolumeSize:          aws.Int64(int64(diskSizeGiB)),
 					VolumeType:          aws.String("gp2"),
 				},
 			},

--- a/util/image.go
+++ b/util/image.go
@@ -20,7 +20,8 @@ import (
 )
 
 type ImageInfo struct {
-	Format string `json:"format"`
+	Format      string `json:"format"`
+	VirtualSize uint64 `json:"virtual-size"`
 }
 
 func GetImageInfo(path string) (*ImageInfo, error) {


### PR DESCRIPTION
We were uploading the full disk image (4.5 GiB for CL) but hardcoding an 8 GiB disk size in AMI metadata.  This worked until RHCOS images became larger than 8 GiB.  Continue defaulting `ore aws upload` and plume to an 8 GiB AMI disk, but allow overriding from the ore command line, and add an ore option to autodetect the size from a local image file.

Based on, and obsoletes, https://github.com/coreos/mantle/pull/954.  Tested with a CL image and:

- `ore aws upload`, autodetected file
- `ore aws upload --disk-size-gib`, autodetected file
- `ore aws upload --disk-size-inspect`, autodetected file
- `ore aws upload --disk-size-inspect --file`
- `ore aws upload --disk-size-inspect --source-object` (fails)
- `ore aws upload --disk-size-inspect --source-snapshot` (fails)
- `bin/plume pre-release --platform aws -C user`

cc @cgwalters for review (GitHub isn't letting me request one from you directly)