### PR TITLE
cmd/plume: switch user channel from us-east-2 to us-east-1

### DIFF
--- a/cmd/plume/specs.go
+++ b/cmd/plume/specs.go
@@ -197,13 +197,13 @@ var (
 						// partition with a single region
 						Name:         "AWS East",
 						Profile:      "coreos-cl",
-						Bucket:       "coreos-dev-ami-import-us-east-2",
-						BucketRegion: "us-east-2",
+						Bucket:       "coreos-dev-ami-import-us-east-1",
+						BucketRegion: "us-east-1",
 						LaunchPermissions: []string{
 							"595879546273", // prod account, to test LaunchPermissions
 						},
 						Regions: []string{
-							"us-east-2",
+							"us-east-1",
 						},
 					},
 				},


### PR DESCRIPTION
As of #864, we reject attempts to create a PV AMI in us-east-2, so that region can no longer be the primary region for a partition.  Use us-east-1 instead, which is sufficient for testing purposes.