### PR TITLE
kola/tests: disable versioned s3 test on qemu & do

### DIFF
--- a/kola/tests/ignition/resource.go
+++ b/kola/tests/ignition/resource.go
@@ -155,7 +155,9 @@ func init() {
 		Name:        "coreos.ignition.v2_1.resource.s3.versioned",
 		Run:         resourceS3Versioned,
 		ClusterSize: 1,
-		MinVersion:  semver.Version{Major: 1995},
+		// https://github.com/coreos/bugs/issues/2205 for DO
+		ExcludePlatforms: []string{"qemu", "do"},
+		MinVersion:       semver.Version{Major: 1995},
 		UserData: conf.Ignition(`{
 		  "ignition": {
 		      "version": "2.1.0"


### PR DESCRIPTION
The test requires networking in the initramfs and as such shouldn't be
ran on these platforms.