### PR TITLE
platform/api/gcloud: Increase image creation timeout

### DIFF
--- a/platform/api/gcloud/pending.go
+++ b/platform/api/gcloud/pending.go
@@ -38,7 +38,7 @@ type Pending struct {
 func (a *API) NewPending(desc string, do doable) *Pending {
 	pending := &Pending{
 		Interval: 10 * time.Second,
-		Timeout:  5 * time.Minute,
+		Timeout:  10 * time.Minute,
 		desc:     desc,
 		do:       do,
 	}


### PR DESCRIPTION
Tests have been failing to start lately due to image creation timing out.  It was waiting for five minutes, while it took about six minutes, so double the timeout to ten minutes.