### PR TITLE
kola/tests/docker: Double the memory test limit to 20 megabytes

### DIFF
--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -248,7 +248,7 @@ func dockerResources(c cluster.TestCluster) {
 	// ref https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources
 	for _, dockerCmd := range []string{
 		// must set memory when setting memory-swap
-		dCmd("--memory=10m --memory-swap=10m"),
+		dCmd("--memory=20m --memory-swap=20m"),
 		dCmd("--memory-reservation=10m"),
 		dCmd("--kernel-memory=10m"),
 		dCmd("--cpu-shares=100"),
@@ -264,7 +264,7 @@ func dockerResources(c cluster.TestCluster) {
 		//dCmd("--device-write-bps=/dev/vda:1kb"),
 		//dCmd("--device-read-iops=/dev/vda:10"),
 		//dCmd("--device-write-iops=/dev/vda:10"),
-		dCmd("--memory=10m --oom-kill-disable=true"),
+		dCmd("--memory=20m --oom-kill-disable=true"),
 		dCmd("--memory-swappiness=50"),
 		dCmd("--shm-size=1m"),
 	} {


### PR DESCRIPTION
Testing some changes results in this test failing for one of the Docker versions when using limits less than 15 megabytes.  No problems were encountered with higher values.