### PR TITLE
kola/tests/rpmostree/status: relax regex matching for version

### DIFF
--- a/kola/tests/rpmostree/status.go
+++ b/kola/tests/rpmostree/status.go
@@ -36,7 +36,7 @@ func init() {
 
 var (
 	// Regex to extract version number from "rpm-ostree status"
-	rpmOstreeVersionRegex string = `^Version: (\d+\.\d+\.?\d*).*`
+	rpmOstreeVersionRegex string = `^Version: ([\d.]+).*`
 )
 
 // rpmOstreeCleanup calls 'rpm-ostree cleanup -rpmb' on a host and verifies


### PR DESCRIPTION
When RHCOS changed the version numbering to something that looks like
`400.7.20190227.0`, it broke the `rpm-ostree status` test.  Example
version output from RHCOS:

`Version: 400.7.20190227.0 (2019-02-27T16:19:34Z)`

This relaxes the regex to match one or more digits, then anything
afterwards, until the first paren is hit.  Since I assume RHCOS and
FCOS are going to use numbers for their versions, this should work for
both situations.