### PR TITLE
Update CI to Go 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 sudo: false
 matrix:
   include:
-    - go: "1.11"
+    - go: "1.12.x"
   allow_failures:
     - go: tip
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,11 +21,11 @@ node('amd64 && docker') {
     }
 
     stage('Build') {
-        sh "docker run --rm -e CGO_ENABLED=1 -e GOARCH=${params.GOARCH} -u \"\$(id -u):\$(id -g)\" -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro -v \"\$PWD\":/usr/src/myapp -w /usr/src/myapp golang:1.11.2 ./build"
+        sh "docker run --rm -e CGO_ENABLED=1 -e GOARCH=${params.GOARCH} -e GOCACHE=/usr/src/myapp/cache -u \"\$(id -u):\$(id -g)\" -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro -v \"\$PWD\":/usr/src/myapp -w /usr/src/myapp golang:1.12 ./build"
     }
 
     stage('Test') {
-        sh 'docker run --rm -u "$(id -u):$(id -g)" -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro -v "$PWD":/usr/src/myapp -w /usr/src/myapp golang:1.11.2 ./test'
+        sh 'docker run --rm -e GOCACHE=/usr/src/myapp/cache -u "$(id -u):$(id -g)" -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro -v "$PWD":/usr/src/myapp -w /usr/src/myapp golang:1.12 ./test'
     }
 
     stage('Post-build') {

--- a/update/generator/full_test.go
+++ b/update/generator/full_test.go
@@ -56,7 +56,7 @@ func checkReplace(t *testing.T, ops []*metadata.InstallOperation, source, source
 	}
 
 	if len(op.DstExtents) != 1 {
-		t.Fatalf("unexpected extents: %d", op.GetDstExtents())
+		t.Fatalf("unexpected extents: %v", op.GetDstExtents())
 	}
 
 	ext := op.DstExtents[0]
@@ -88,7 +88,7 @@ func checkReplaceBZ(t *testing.T, ops []*metadata.InstallOperation, source, sour
 	}
 
 	if len(op.DstExtents) != 1 {
-		t.Fatalf("unexpected extents: %d", op.GetDstExtents())
+		t.Fatalf("unexpected extents: %v", op.GetDstExtents())
 	}
 
 	ext := op.DstExtents[0]


### PR DESCRIPTION
This picks the general settings that use the latest 1.12 patch version release since we usually forget to follow those.

Also fix the Jenkins build cache and a test's string format so it is able to build.