### PR TITLE
RHCOS: ignition/password.go: Use proper home paths

### DIFF
--- a/kola/tests/ignition/passwd.go
+++ b/kola/tests/ignition/passwd.go
@@ -271,12 +271,12 @@ func usersRhcos(c cluster.TestCluster) {
 		},
 		{
 			user:           "user1",
-			passwdRecord:   "user1:x:1001:1001::/home/user1:/bin/bash",
+			passwdRecord:   "user1:x:1001:1001::/var/home/user1:/bin/bash",
 			shadowPassword: "*",
 		},
 		{
 			user:           "user2",
-			passwdRecord:   "user2:x:1010:1010::/home/user2:/bin/bash",
+			passwdRecord:   "user2:x:1010:1010::/var/home/user2:/bin/bash",
 			shadowPassword: "*",
 		},
 	}


### PR DESCRIPTION
The issue found was:
    - `got "user1:x:1001:1001::/var/home/user1:/bin/bash"`
    - `expected "user1:x:1001:1001::/home/user1:/bin/bash"`

This update updates the expectation for user1 and user2 to
have their homes under `/var/home`.

Note: core still is referenced under `/home`.