### PR TITLE
kola/tests: touch /var/lib/nfs/etab in NFS tests for RHCOS

### DIFF
--- a/kola/tests/ignition/systemd.go
+++ b/kola/tests/ignition/systemd.go
@@ -27,7 +27,8 @@ func init() {
 		Name:        "coreos.ignition.systemd.enable-service",
 		Run:         enableSystemdService,
 		ClusterSize: 1,
-		// enable nfs-server & touch /etc/exports as it doesn't exist by default on Container Linux
+		// enable nfs-server, touch /etc/exports as it doesn't exist by default on Container Linux,
+		// and touch /var/lib/nfs/etab (https://bugzilla.redhat.com/show_bug.cgi?id=1394395) for RHCOS
 		UserData: conf.Ignition(`{
     "ignition": {"version": "2.2.0"},
     "systemd": {
@@ -40,6 +41,10 @@ func init() {
         "files": [{
             "filesystem":"root",
             "path":"/etc/exports"
+        },
+        {
+            "filesystem":"root",
+            "path":"/var/lib/nfs/etab"
         }]
     }
 }`),

--- a/kola/tests/misc/nfs.go
+++ b/kola/tests/misc/nfs.go
@@ -38,6 +38,9 @@ var (
       contents:
         inline: "/tmp  *(ro,insecure,all_squash,no_subtree_check,fsid=0)"
       mode: 0644
+    - filesystem: "root"
+      path: "/var/lib/nfs/etab"
+      mode: 0644
 systemd:
   units:
     - name: "nfs-server.service"


### PR DESCRIPTION
There is a known issue where /var/lib/nfs/etab does not exist
(https://bugzilla.redhat.com/show_bug.cgi?id=1394395). Touching this
file allows nfs-mountd to succeed on RHCOS and doens't break anything on
CL.