### PR TITLE
kola/test/util/containers.go: don't reuse layers when building images

### DIFF
--- a/kola/tests/util/containers.go
+++ b/kola/tests/util/containers.go
@@ -27,6 +27,6 @@ func GenPodmanScratchContainer(c cluster.TestCluster, m platform.Machine, name s
 	cmd := `tmpdir=$(mktemp -d); cd $tmpdir; echo -e "FROM scratch\nCOPY . /" > Dockerfile;
 	        b=$(which %s); libs=$(sudo ldd $b | grep -o /lib'[^ ]*' | sort -u);
 			sudo rsync -av --relative --copy-links $b $libs ./;
-			sudo podman build -t localhost/%s .`
+			sudo podman build --layers=false -t localhost/%s .`
 	c.MustSSH(m, fmt.Sprintf(cmd, strings.Join(binnames, " "), name))
 }


### PR DESCRIPTION
By default `podman` will reuse layers when building images.  This can
cause problems when building different images using the same
`Dockerfile` as is done in `GenPodmanScratchContainer()`.