### PR TITLE
*: add oscontainer pivot support

### DIFF
--- a/cmd/kola/kola.go
+++ b/cmd/kola/kola.go
@@ -168,22 +168,24 @@ func writeProps() error {
 		Mangled bool   `json:"mangled"`
 	}
 	return enc.Encode(&struct {
-		Cmdline   []string  `json:"cmdline"`
-		Platform  string    `json:"platform"`
-		Distro    string    `json:"distro"`
-		Board     string    `json:"board"`
-		AWS       AWS       `json:"aws"`
-		DO        DO        `json:"do"`
-		ESX       ESX       `json:"esx"`
-		GCE       GCE       `json:"gce"`
-		OpenStack OpenStack `json:"openstack"`
-		Packet    Packet    `json:"packet"`
-		QEMU      QEMU      `json:"qemu"`
+		Cmdline     []string  `json:"cmdline"`
+		Platform    string    `json:"platform"`
+		Distro      string    `json:"distro"`
+		Board       string    `json:"board"`
+		OSContainer string    `json:"oscontainer"`
+		AWS         AWS       `json:"aws"`
+		DO          DO        `json:"do"`
+		ESX         ESX       `json:"esx"`
+		GCE         GCE       `json:"gce"`
+		OpenStack   OpenStack `json:"openstack"`
+		Packet      Packet    `json:"packet"`
+		QEMU        QEMU      `json:"qemu"`
 	}{
-		Cmdline:  os.Args,
-		Platform: kolaPlatform,
-		Distro:   kola.Options.Distribution,
-		Board:    kola.QEMUOptions.Board,
+		Cmdline:     os.Args,
+		Platform:    kolaPlatform,
+		Distro:      kola.Options.Distribution,
+		Board:       kola.QEMUOptions.Board,
+		OSContainer: kola.Options.OSContainer,
 		AWS: AWS{
 			Region:       kola.AWSOptions.Region,
 			AMI:          kola.AWSOptions.AMI,

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -59,6 +59,9 @@ func init() {
 	ss("debug-systemd-unit", []string{}, "full-unit-name.service to enable SYSTEMD_LOG_LEVEL=debug on. Specify multiple times for multiple units.")
 	sv(&kola.UpdatePayloadFile, "update-payload", "", "Path to an update payload that should be made available to tests")
 
+	// rhcos-specific options
+	sv(&kola.Options.OSContainer, "oscontainer", "", "oscontainer image pullspec for pivot (RHCOS only)")
+
 	// aws-specific options
 	defaultRegion := os.Getenv("AWS_REGION")
 	if defaultRegion == "" {
@@ -165,6 +168,10 @@ func syncOptions() error {
 			Name:     "10-debug.conf",
 			Contents: "[Service]\nEnvironment=SYSTEMD_LOG_LEVEL=debug",
 		})
+	}
+
+	if kola.Options.OSContainer != "" && kola.Options.Distribution != "rhcos" {
+		return fmt.Errorf("oscontainer is only supported on rhcos")
 	}
 
 	return nil

--- a/kola/tests/ignition/passwd.go
+++ b/kola/tests/ignition/passwd.go
@@ -26,7 +26,7 @@ import (
 
 func init() {
 	register.Register(&register.Test{
-		Name:        "coreos.ignition.v1.groups",
+		Name:        "cl.ignition.v1.groups",
 		Run:         groups,
 		ClusterSize: 1,
 		UserData: conf.Ignition(`{
@@ -51,7 +51,7 @@ func init() {
 		               ]
 		             }
 		           }`),
-		Distros: []string{"cl", "rhcos", "fcos"},
+		Distros: []string{"cl"},
 	})
 	register.Register(&register.Test{
 		Name:        "coreos.ignition.v2.groups",
@@ -148,34 +148,6 @@ func init() {
 		             }
 		           }`),
 		Distros: []string{"cl"},
-	})
-	register.Register(&register.Test{
-		Name:        "rhcos.ignition.v1.users",
-		Run:         usersRhcos,
-		ClusterSize: 1,
-		UserData: conf.Ignition(`{
-		             "ignitionVersion": 1,
-		             "passwd": {
-		               "users": [
-		                 {
-		                   "name": "core",
-		                   "passwordHash": "foobar"
-		                 },
-		                 {
-		                   "name": "user1",
-		                   "create": {}
-		                 },
-		                 {
-		                   "name": "user2",
-		                   "create": {
-		                     "uid": 1010,
-		                     "groups": [ "sudo" ]
-		                   }
-		                 }
-		               ]
-		             }
-		           }`),
-		Distros: []string{"rhcos", "fcos"},
 	})
 	register.Register(&register.Test{
 		Name:        "rhcos.ignition.v2.users",

--- a/kola/tests/ignition/ssh.go
+++ b/kola/tests/ignition/ssh.go
@@ -23,13 +23,13 @@ func init() {
 	// verify that SSH key injection works correctly through Ignition,
 	// without injecting via platform metadata
 	register.Register(&register.Test{
-		Name:             "coreos.ignition.v1.ssh.key",
+		Name:             "cl.ignition.v1.ssh.key",
 		Run:              empty,
 		ClusterSize:      1,
 		ExcludePlatforms: []string{"qemu"}, // redundant on qemu
 		Flags:            []register.Flag{register.NoSSHKeyInMetadata},
 		UserData:         conf.Ignition(`{"ignitionVersion": 1}`),
-		Distros:          []string{"cl", "rhcos"},
+		Distros:          []string{"cl"},
 	})
 	register.Register(&register.Test{
 		Name:             "coreos.ignition.v2.ssh.key",

--- a/kola/tests/ostree/basic.go
+++ b/kola/tests/ostree/basic.go
@@ -79,7 +79,7 @@ func getOstreeAdminStatus(c cluster.TestCluster, m platform.Machine) (ostreeAdmi
 	}
 
 	oasSplit := strings.Split(string(oasOutput), "\n")
-	if len(oasSplit) != 3 {
+	if len(oasSplit) < 3 {
 		return oaStatus, fmt.Errorf(`Unexpected output from "ostree admin status": %v`, string(oasOutput))
 	}
 

--- a/kola/tests/rpmostree/deployments.go
+++ b/kola/tests/rpmostree/deployments.go
@@ -117,9 +117,9 @@ func rpmOstreeUpgradeRollback(c cluster.TestCluster) {
 			c.Fatal(err)
 		}
 
-		// should have two deployments
-		if len(postUpgradeStatus.Deployments) != 2 {
-			c.Fatalf("Expected two deployments; found %d deployments", len(postUpgradeStatus.Deployments))
+		// should have an additional deployment
+		if len(postUpgradeStatus.Deployments) != len(originalStatus.Deployments)+1 {
+			c.Fatalf("Expected %d deployments; found %d deployments", len(originalStatus.Deployments)+1, len(postUpgradeStatus.Deployments))
 		}
 
 		// reboot into new deployment
@@ -134,9 +134,9 @@ func rpmOstreeUpgradeRollback(c cluster.TestCluster) {
 			c.Fatal(err)
 		}
 
-		// should still have 2 deployments
+		// should have 2 deployments, the previously booted deployment and the test deployment due to rpm-ostree pruning
 		if len(postRebootStatus.Deployments) != 2 {
-			c.Fatalf("Expected two deployments; found %d deployment", len(postRebootStatus.Deployments))
+			c.Fatalf("Expected %d deployments; found %d deployment", 2, len(postRebootStatus.Deployments))
 		}
 
 		// origin should be new branch
@@ -176,7 +176,7 @@ func rpmOstreeUpgradeRollback(c cluster.TestCluster) {
 
 		// still 2 deployments...
 		if len(rollbackStatus.Deployments) != 2 {
-			c.Fatalf("Expected two deployments; found %d deployments", len(rollbackStatus.Deployments))
+			c.Fatalf("Expected %d deployments; found %d deployments", 2, len(rollbackStatus.Deployments))
 		}
 
 		// validate we are back to the original deployment by comparing the
@@ -291,7 +291,7 @@ func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 
 		// check the metadata to make sure everything went well
 		if len(postUninstallStatus.Deployments) != 2 {
-			c.Fatal("Expected two deployments, got %d", len(postUninstallStatus.Deployments))
+			c.Fatal("Expected %d deployments, got %d", 2, len(postUninstallStatus.Deployments))
 		}
 
 		if postUninstallStatus.Deployments[0].Checksum != originalCsum {

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -144,6 +144,12 @@ type Options struct {
 	BaseName       string
 	Distribution   string
 	SystemdDropins []SystemdDropin
+
+	// OSContainer is an image pull spec that can be given to the pivot service
+	// in RHCOS machines to perform machine content upgrades.
+	// When specified additional files & units will be automatically generated
+	// inside of RenderUserData
+	OSContainer string
 }
 
 // RuntimeConfig contains cluster-specific configuration.


### PR DESCRIPTION
Adds a new flag `--oscontainer` to `kola` which allows the specification
of an oscontainer image pull spec when running against the `rhcos`
distribution. When specified it will create the relevant files & the
systemd units required to perform a `pivot` operation before `sshd`
starts.

Closes #987 