### PR TITLE
Misc minor items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.sw?
 /bin/
 /gopath/
+_kola_temp/

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -202,7 +202,7 @@ func filterTests(tests map[string]*register.Test, pattern, platform string, vers
 		}
 
 		if existsIn(platform, register.PlatformsNoInternet) && t.HasFlag(register.RequiresInternetAccess) {
-			plog.Debugf("skipping test %s: Internet required but not supported by platform %s", t.Name, platform)
+			plog.Infof("skipping test %s: Internet required but not supported by platform %s", t.Name, platform)
 			continue
 		}
 


### PR DESCRIPTION
- Add `_kola_temp` to `.gitignore`
- Bump up warning on no network access from `DEBUG` to `INFO`

The second noted item was something I hit while attempting to recreate some `cri-o` failures. Specifically the tests were not running and under `-v` I could see there was some failure but no information. The `_kola_temp` also was primarily void of data as to why there were "no tests found". It wasn't until I dropped into `-d` that I realized what was happening. However, noting that tests are being skipped feels more like an `INFO` item for users than a development/testing `DEBUG` option.