### PR TITLE
*: minor tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /bin/
 /gopath/
 _kola_temp/
+.cache/

--- a/build
+++ b/build
@@ -26,7 +26,7 @@ cross_build() {
 		echo "Building $a/$1"
 		mkdir -p "bin/$a"
 		CGO_ENABLED=0 GOARCH=$a \
-			go build -ldflags "${ldflags}" \
+			go build -mod=vendor -ldflags "${ldflags}" \
 			-o "bin/$a/$1" "${REPO_PATH}/cmd/$1"
 	done
 }

--- a/test
+++ b/test
@@ -24,11 +24,11 @@ pkgs=$(go list $PKG | grep -v /vendor/)
 src=$(find . -name '*.go' -not -path "./vendor/*")
 
 echo "Building tests..."
-go test -i "$@" $pkgs
+go test -mod=vendor -i "$@" $pkgs
 go install $pkgs
 
 echo "Running tests..."
-go test -cover "$@" $pkgs
+go test -mod=vendor -cover "$@" $pkgs
 
 echo "Checking gofmt..."
 res=$(gofmt -d -e $src)

--- a/test
+++ b/test
@@ -15,6 +15,7 @@ cd $(dirname $0)
 source ./env
 # Use an alternate bin to avoid clobbering output from ./build
 export GOBIN="$(pwd)/_testbin"
+trap "rm -rf _testbin/" EXIT
 
 # PKG may be passed in from ./cover
 [[ -z "$PKG" ]] && PKG="./..."


### PR DESCRIPTION
Add missing `-mod=vendor` flags to both the `build` & `test` scripts, add `.cache/` to the `.gitignore`, & add a `trap` to remove the `_testbin` folder in `test`.