### PR TITLE
cmd/plume/release: change fcos release index file name

### DIFF
--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -499,7 +499,7 @@ func modifyReleaseMetadataIndex(spec *fcosChannelSpec, commitId string) {
 		plog.Fatalf("creating aws client: %v", err)
 	}
 
-	path := filepath.Join("prod", "streams", specChannel, "releases.json")
+	path := filepath.Join("prod", "streams", specChannel, "release-index.json")
 
 	f, err := api.DownloadFile(spec.Bucket, path)
 	if err != nil {


### PR DESCRIPTION
The file name for the FCOS release index has changed from
`releases.json` to `release-index.json`.