### PR TITLE
README: Add azure configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ sudo emerge --ask awscli
 ```
 
 ### azure
-TBD (FIXME)
+`azure` uses `.azure/azureProfile.json`. See [the official documentation](https://docs.microsoft.com/en-us/python/azure/python-sdk-azure-authenticate?view=azure-python) for setting up your profile.
 
 ### do
 `do` uses `~/.config/digitalocean.json`. This can be configured manually:


### PR DESCRIPTION
Link to Azure docs (in this case, Python SDK) with information on generating/manually creating a profile configuration.