### PR TITLE
cmd/plume/fcos: modify build metadata structure

### DIFF
--- a/cmd/plume/fcos.go
+++ b/cmd/plume/fcos.go
@@ -31,7 +31,6 @@ var (
 
 func AddFcosSpecFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&specPolicy, "policy", "public-read", "Canned ACL policy")
-	flags.StringVar(&specCommitId, "commit-id", "", "OSTree Commit ID")
 }
 
 func FcosValidateArguments() {
@@ -40,9 +39,6 @@ func FcosValidateArguments() {
 	}
 	if specChannel == "" {
 		plog.Fatal("--channel is required")
-	}
-	if specCommitId == "" {
-		plog.Fatal("--commit-id is required")
 	}
 }
 

--- a/cmd/plume/types.go
+++ b/cmd/plume/types.go
@@ -92,11 +92,24 @@ type ReleaseMetadata struct {
 }
 
 type BuildMetadata struct {
-	CommitHash string `json:"commit"`
-	Version    string `json:"version"`
-	Endpoint   string `json:"endpoint"`
+	CommitHash []Commit `json:"commits"`
+	Version    string   `json:"version"`
+	Endpoint   string   `json:"metadata"`
 }
 
 type Metadata struct {
 	LastModified string `json:"last-modified"`
+}
+
+type IndividualReleaseMetadata struct {
+	Architectures map[string]Architecture `json:"architectures"`
+}
+
+type Architecture struct {
+	Commit string `json:"commit"`
+}
+
+type Commit struct {
+	Architecture string `json:"architecture"`
+	Checksum     string `json:"checksum"`
 }


### PR DESCRIPTION
Per discussions in the [fedora-coreos-tracker](https://github.com/coreos/fedora-coreos-tracker/issues/98#issuecomment-505104633), modify the build metadata structure to better support multi-arch.