### PR TITLE
kola: Don't check for crio.service started on RHCOS

### DIFF
--- a/kola/tests/coretest/core.go
+++ b/kola/tests/coretest/core.go
@@ -70,7 +70,7 @@ func init() {
 		NativeFuncs: map[string]func() error{
 			"PortSSH":          TestPortSsh,
 			"DbusPerms":        TestDbusPerms,
-			"ServicesActive":   TestServicesActiveRHCOS,
+			"ServicesActive":   TestServicesActiveCoreOS,
 			"ServicesDisabled": TestServicesDisabledRHCOS,
 			"ReadOnly":         TestReadOnlyFs,
 			"Useradd":          TestUseradd,
@@ -85,7 +85,7 @@ func init() {
 		NativeFuncs: map[string]func() error{
 			"PortSSH":        TestPortSsh,
 			"DbusPerms":      TestDbusPerms,
-			"ServicesActive": TestServicesActiveFCOS,
+			"ServicesActive": TestServicesActiveCoreOS,
 			"ReadOnly":       TestReadOnlyFs,
 			"Useradd":        TestUseradd,
 			"MachineID":      TestMachineID,
@@ -271,14 +271,7 @@ func TestServicesActive() error {
 	})
 }
 
-func TestServicesActiveRHCOS() error {
-	return servicesActive([]string{
-		"multi-user.target",
-		"crio.service",
-	})
-}
-
-func TestServicesActiveFCOS() error {
+func TestServicesActiveCoreOS() error {
 	return servicesActive([]string{
 		"multi-user.target",
 	})


### PR DESCRIPTION
I plan to disable it by default, see this commit message:

    preset: Don't enable crio.service by default

    First, we actually need to reconfigure crio before using
    it in primary OpenShift use cases to use the pause image from
    the release payload; see
    https://github.com/openshift/installer/pull/1761
    And also the followup
    https://github.com/openshift/installer/pull/1768

    Second, having it enabled by default breaks our kola tests
    https://github.com/coreos/mantle/issues/1004
    because the way it handles networking is broken:
    https://github.com/cri-o/cri-o/issues/2478

    We don't need to enable it by default; rather, have it
    be pulled in by `kubelet.service`.