### PR TITLE
platform: disable pinger & zincati by default on FCOS

### DIFF
--- a/platform/cluster.go
+++ b/platform/cluster.go
@@ -169,6 +169,14 @@ func (bc *BaseCluster) RenderUserData(userdata *conf.UserData, ignitionVars map[
 		conf.CopyKeys(keys)
 	}
 
+	// disable Zincati & Pinger by default
+	if bc.Distribution() == "fcos" {
+		conf.AddFile("/etc/fedora-coreos-pinger/config.d/90-disable-reporting.toml", "root", `[reporting]
+enabled = false`, 0644)
+		conf.AddFile("/etc/zincati/config.d/90-disable-auto-updates.toml", "root", `[updates]
+enabled = false`, 0644)
+	}
+
 	if bc.bf.baseopts.OSContainer != "" {
 		if bc.Distribution() != "rhcos" {
 			return nil, fmt.Errorf("oscontainer is only supported on the rhcos distribution")


### PR DESCRIPTION
Defaults to disabling both fedora-coreos-pinger & Zincati on the FCOS
distribution. Both are using a `90-` config so that it can still be
overridden by individual tests.

Closes #1017 