### PR TITLE
plume: FCOS URLs & structure update

### DIFF
--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -519,7 +519,7 @@ func modifyReleaseMetadataIndex(spec *fcosChannelSpec, commitId string) {
 	}
 
 	releasePath := filepath.Join("prod", "streams", specChannel, "builds", specVersion, "release.json")
-	url, err := url.Parse(fmt.Sprintf("https://%s.s3.amazonaws.com/%s", spec.Bucket, releasePath))
+	url, err := url.Parse(fmt.Sprintf("https://builds.coreos.fedoraproject.org/%s", releasePath))
 	if err != nil {
 		plog.Fatalf("creating metadata url: %v", err)
 	}

--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -581,6 +581,7 @@ func modifyReleaseMetadataIndex(spec *fcosChannelSpec, commitId string) {
 
 	m.Metadata.LastModified = time.Now().UTC().Format("2006-01-02T15:04:05Z")
 	m.Note = "For use only by Fedora CoreOS internal tooling.  All other applications should obtain release info from stream metadata endpoints."
+	m.Stream = specChannel
 
 	out, err := json.Marshal(m)
 	if err != nil {

--- a/cmd/plume/types.go
+++ b/cmd/plume/types.go
@@ -89,6 +89,7 @@ type ReleaseMetadata struct {
 	Note     string          `json:"note"` // used to note to users not to consume the release metadata index
 	Releases []BuildMetadata `json:"releases"`
 	Metadata Metadata        `json:"metadata"`
+	Stream   string          `json:"stream"`
 }
 
 type BuildMetadata struct {


### PR DESCRIPTION
Switches the FCOS release-index URLs to use builds.coreos.fedoraproject.org & adds a new `stream` field to the base structure.