### PR TITLE
plume/s3: use proper content-type for releases.json

### DIFF
--- a/cmd/ore/aws/upload.go
+++ b/cmd/ore/aws/upload.go
@@ -221,7 +221,7 @@ func runUpload(cmd *cobra.Command, args []string) error {
 		}
 		defer f.Close()
 
-		err = API.UploadObject(f, s3BucketName, s3ObjectPath, uploadForce, "")
+		err = API.UploadObject(f, s3BucketName, s3ObjectPath, uploadForce, "", "")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error uploading: %v\n", err)
 			os.Exit(1)

--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -516,7 +516,7 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imageName, 
 
 	if snapshot == nil {
 		plog.Printf("Creating S3 object %v...", s3ObjectURL)
-		err = api.UploadObject(f, part.Bucket, s3ObjectPath, false, "")
+		err = api.UploadObject(f, part.Bucket, s3ObjectPath, false, "", "")
 		if err != nil {
 			return nil, nil, fmt.Errorf("Error uploading: %v", err)
 		}

--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -580,7 +580,7 @@ func modifyReleaseMetadataIndex(spec *fcosChannelSpec, commitId string) {
 		plog.Fatalf("marshalling release metadata json: %v", err)
 	}
 
-	err = api.UploadObject(bytes.NewReader(out), spec.Bucket, path, true, specPolicy)
+	err = api.UploadObject(bytes.NewReader(out), spec.Bucket, path, true, specPolicy, aws.ContentTypeJSON)
 	if err != nil {
 		plog.Fatalf("uploading release metadata json: %v", err)
 	}


### PR DESCRIPTION
This fixes plume and the underlying library to use "application/json"
as the proper content-type for `releases.json`.

Closes: https://github.com/coreos/mantle/issues/1025