### PR TITLE
plume: FCOS: modify launch-permissions for AMIs

### DIFF
--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -569,6 +569,28 @@ func modifyReleaseMetadataIndex(spec *fcosChannelSpec, commitId string) {
 		}
 	}
 
+	for _, archs := range im.Architectures {
+		for name, media := range archs.Media {
+			if name == "aws" {
+				for region, ami := range media.Images {
+					aws_api, err := aws.New(&aws.Options{
+						CredentialsFile: awsCredentialsFile,
+						Profile:         specProfile,
+						Region:          region,
+					})
+					if err != nil {
+						plog.Fatalf("creating AWS API for modifying launch permissions: %v", err)
+					}
+
+					err = aws_api.PublishImage(ami.Image)
+					if err != nil {
+						plog.Fatalf("couldn't publish image in %v: %v", region, err)
+					}
+				}
+			}
+		}
+	}
+
 	m.Releases = append(m.Releases, newRel)
 
 	m.Metadata.LastModified = time.Now().UTC().Format("2006-01-02T15:04:05Z")

--- a/cmd/plume/types.go
+++ b/cmd/plume/types.go
@@ -107,7 +107,16 @@ type IndividualReleaseMetadata struct {
 }
 
 type Architecture struct {
-	Commit string `json:"commit"`
+	Commit string           `json:"commit"`
+	Media  map[string]Media `json:"media"`
+}
+
+type Media struct {
+	Images map[string]AMI `json:"images"`
+}
+
+type AMI struct {
+	Image string `json:"image"`
 }
 
 type Commit struct {


### PR DESCRIPTION
Modifies the launch permissions to be public for all AMIs in the
release.json