### PR TITLE
platform/api/aws: enable SharedConfigState

### DIFF
--- a/platform/api/aws/api.go
+++ b/platform/api/aws/api.go
@@ -79,8 +79,9 @@ func New(opts *Options) (*API, error) {
 	}
 
 	sess, err := session.NewSessionWithOptions(session.Options{
-		Profile: opts.Profile,
-		Config:  awsCfg,
+		SharedConfigState: session.SharedConfigEnable,
+		Profile:           opts.Profile,
+		Config:            awsCfg,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
A subset of the AWS environment variables are gated behind
SharedConfigState being enabled. This will allow users to specify the
following additional environment variables:

 - `AWS_DEFAULT_REGION`
 - `AWS_DEFAULT_PROFILE`
 - `AWS_SHARED_CREDENTIALS_FILE`
 - `AWS_CONFIG_FILE`

Closes #1023 