### PR TITLE
kola/tests: fixes for RHCOS tests

### DIFF
--- a/kola/tests/crio/crio.go
+++ b/kola/tests/crio/crio.go
@@ -205,10 +205,10 @@ func crioBaseTests(c cluster.TestCluster) {
 
 // generateCrioConfig generates a crio pod/container configuration
 // based on the input name and arguments returning the path to the generated configs.
-func generateCrioConfig(name string, command []string) (string, string, error) {
-	fileContentsPod := fmt.Sprintf(crioPodTemplate, name, name)
+func generateCrioConfig(podName, imageName string, command []string) (string, string, error) {
+	fileContentsPod := fmt.Sprintf(crioPodTemplate, podName, imageName)
 
-	tmpFilePod, err := ioutil.TempFile("", name+"Pod")
+	tmpFilePod, err := ioutil.TempFile("", podName+"Pod")
 	if err != nil {
 		return "", "", err
 	}
@@ -217,9 +217,9 @@ func generateCrioConfig(name string, command []string) (string, string, error) {
 		return "", "", err
 	}
 	cmd := strings.Join(command, " ")
-	fileContentsContainer := fmt.Sprintf(crioContainerTemplate, name, name, cmd)
+	fileContentsContainer := fmt.Sprintf(crioContainerTemplate, imageName, imageName, cmd)
 
-	tmpFileContainer, err := ioutil.TempFile("", name+"Container")
+	tmpFileContainer, err := ioutil.TempFile("", imageName+"Container")
 	if err != nil {
 		return "", "", err
 	}
@@ -236,8 +236,8 @@ func generateCrioConfig(name string, command []string) (string, string, error) {
 // string returned is the container config to be used with crictl create/exec. They will be dropped
 // on to all machines in the cluster as ~/$STRING_RETURNED_FROM_FUNCTION. Note that the string returned
 // here is just the name, not the full path on the cluster machine(s).
-func genContainer(c cluster.TestCluster, m platform.Machine, name string, binnames []string, shellCommands []string) (string, string, error) {
-	configPathPod, configPathContainer, err := generateCrioConfig(name, shellCommands)
+func genContainer(c cluster.TestCluster, m platform.Machine, podName, imageName string, binnames []string, shellCommands []string) (string, string, error) {
+	configPathPod, configPathContainer, err := generateCrioConfig(podName, imageName, shellCommands)
 	if err != nil {
 		return "", "", err
 	}
@@ -248,8 +248,11 @@ func genContainer(c cluster.TestCluster, m platform.Machine, name string, binnam
 		return "", "", err
 	}
 
-	// Create the crio image used for testing
-	util.GenPodmanScratchContainer(c, m, name, binnames)
+	// Create the crio image used for testing, only if it doesn't exist already
+	output := c.MustSSH(m, "sudo podman images -n --format '{{.Repository}}'")
+	if !strings.Contains(string(output), "localhost/"+imageName) {
+		util.GenPodmanScratchContainer(c, m, imageName, binnames)
+	}
 
 	return path.Base(configPathPod), path.Base(configPathContainer), nil
 }
@@ -264,11 +267,11 @@ func crioNetwork(c cluster.TestCluster) {
 	// Since genContainer also generates crio pod/container configs,
 	// there will be a duplicate config file on each machine.
 	// Thus we only save one set for later use.
-	crioConfigPod, crioConfigContainer, err := genContainer(c, src, "ncat", []string{"ncat", "echo"}, []string{"ncat"})
+	crioConfigPod, crioConfigContainer, err := genContainer(c, src, "ncat", "ncat", []string{"ncat", "echo"}, []string{"ncat"})
 	if err != nil {
 		c.Fatal(err)
 	}
-	_, _, err = genContainer(c, dest, "ncat", []string{"ncat", "echo"}, []string{"ncat"})
+	_, _, err = genContainer(c, dest, "ncat", "ncat", []string{"ncat", "echo"}, []string{"ncat"})
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -352,18 +355,18 @@ func crioNetwork(c cluster.TestCluster) {
 func crioNetworksReliably(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
-	crioConfigPod, crioConfigContainer, err := genContainer(
-		c, m, "ping", []string{"ping"},
-		[]string{"ping"})
-	if err != nil {
-		c.Fatal(err)
-	}
-
 	// Here we generate 10 pods, each will run a container responsible for
 	// pinging to host
-	cmdCreatePod := fmt.Sprintf("sudo crictl runp %s", crioConfigPod)
 	output := ""
 	for x := 1; x <= 10; x++ {
+		// append int to name to avoid pod name collision
+		crioConfigPod, crioConfigContainer, err := genContainer(
+			c, m, fmt.Sprintf("ping%d", x), "ping", []string{"ping"},
+			[]string{"ping"})
+		if err != nil {
+			c.Fatal(err)
+		}
+		cmdCreatePod := fmt.Sprintf("sudo crictl runp %s", crioConfigPod)
 		podID := c.MustSSH(m, cmdCreatePod)
 		containerID := c.MustSSH(m, fmt.Sprintf("sudo crictl create %s %s %s",
 			podID, crioConfigContainer, crioConfigPod))

--- a/kola/tests/rpmostree/status.go
+++ b/kola/tests/rpmostree/status.go
@@ -36,7 +36,7 @@ func init() {
 
 var (
 	// Regex to extract version number from "rpm-ostree status"
-	rpmOstreeVersionRegex string = `^Version: ([\d.]+).*`
+	rpmOstreeVersionRegex string = `^Version: ([0-9a-zA-Z.]+).*`
 )
 
 // rpmOstreeCleanup calls 'rpm-ostree cleanup -rpmb' on a host and verifies
@@ -95,7 +95,7 @@ func rpmOstreeStatus(c cluster.TestCluster) {
 	for _, line := range statusArray {
 		versionMatch := reVersion.FindStringSubmatch(strings.Trim(line, " "))
 		if versionMatch != nil {
-			// versionMatch should be like `[Version: 4.0.5516 (2018-09-12 17:22:06) 4.0.5516]`
+			// versionMatch should be like `[Version: 420.8.20190711.0 (2019-07-11T09:00:04Z) 420.8.20190711.0]`
 			// i.e. the full match and the group we want
 			// `versionMatch[len(versionMatch)-1]` gets the last element in the array
 			rpmOstreeVersion = versionMatch[len(versionMatch)-1]


### PR DESCRIPTION
- update how version strings are compared in `rpm-ostree` test
- update `crio` tests to start service automatically
- change `crio` tests to use unique pod names
- change `crio` tests to only generate container images if previously not create