### PR TITLE
kola: skip tests incompatible with FCOS

### DIFF
--- a/kola/tests/ignition/systemd.go
+++ b/kola/tests/ignition/systemd.go
@@ -70,6 +70,11 @@ func init() {
 		// no routes to the link to spin in the configuring state. nfs-server.service pulls in the network-online
 		// target which causes the basic machine checks to fail
 		ExcludePlatforms: []string{"qemu-unpriv"},
+		// FCOS just ships the client (see
+		// https://github.com/coreos/fedora-coreos-tracker/issues/121).
+		// Should probably just pick a different unit to test with, though
+		// testing the NFS workflow is useful for RHCOS/CL.
+		ExcludeDistros: []string{"fcos"},
 	})
 }
 

--- a/kola/tests/misc/tls.go
+++ b/kola/tests/misc/tls.go
@@ -35,7 +35,7 @@ func init() {
 		ClusterSize:    1,
 		Name:           "coreos.tls.fetch-urls",
 		Flags:          []register.Flag{register.RequiresInternetAccess}, // Networking outside cluster required
-		ExcludeDistros: []string{"rhcos"},                                // wget not included in RHCOS
+		ExcludeDistros: []string{"rhcos", "fcos"},                        // wget not included in *COS
 	})
 }
 


### PR DESCRIPTION
With this, we get a clean FCOS run on AWS! 🎉