### PR TITLE
plume: upload release index with max-age=300

### DIFF
--- a/cmd/ore/aws/upload.go
+++ b/cmd/ore/aws/upload.go
@@ -221,7 +221,7 @@ func runUpload(cmd *cobra.Command, args []string) error {
 		}
 		defer f.Close()
 
-		err = API.UploadObject(f, s3BucketName, s3ObjectPath, uploadForce, "", "")
+		err = API.UploadObject(f, s3BucketName, s3ObjectPath, uploadForce)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error uploading: %v\n", err)
 			os.Exit(1)

--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -516,7 +516,7 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imageName, 
 
 	if snapshot == nil {
 		plog.Printf("Creating S3 object %v...", s3ObjectURL)
-		err = api.UploadObject(f, part.Bucket, s3ObjectPath, false, "", "")
+		err = api.UploadObject(f, part.Bucket, s3ObjectPath, false)
 		if err != nil {
 			return nil, nil, fmt.Errorf("Error uploading: %v", err)
 		}

--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -612,7 +612,7 @@ func modifyReleaseMetadataIndex(spec *fcosChannelSpec, commitId string) {
 		plog.Fatalf("marshalling release metadata json: %v", err)
 	}
 
-	err = api.UploadObject(bytes.NewReader(out), spec.Bucket, path, true, specPolicy, aws.ContentTypeJSON)
+	err = api.UploadObjectExt(bytes.NewReader(out), spec.Bucket, path, true, specPolicy, aws.ContentTypeJSON)
 	if err != nil {
 		plog.Fatalf("uploading release metadata json: %v", err)
 	}

--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -612,7 +612,7 @@ func modifyReleaseMetadataIndex(spec *fcosChannelSpec, commitId string) {
 		plog.Fatalf("marshalling release metadata json: %v", err)
 	}
 
-	err = api.UploadObjectExt(bytes.NewReader(out), spec.Bucket, path, true, specPolicy, aws.ContentTypeJSON)
+	err = api.UploadObjectExt(bytes.NewReader(out), spec.Bucket, path, true, specPolicy, aws.ContentTypeJSON, -1)
 	if err != nil {
 		plog.Fatalf("uploading release metadata json: %v", err)
 	}

--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -528,7 +528,7 @@ func modifyReleaseMetadataIndex(spec *fcosChannelSpec, commitId string) {
 
 	releaseFile, err := api.DownloadFile(spec.Bucket, releasePath)
 	if err != nil {
-		plog.Fatalf("downloading release metadata: %v", err)
+		plog.Fatalf("downloading release metadata at %s: %v", releasePath, err)
 	}
 	defer releaseFile.Close()
 

--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -612,7 +612,9 @@ func modifyReleaseMetadataIndex(spec *fcosChannelSpec, commitId string) {
 		plog.Fatalf("marshalling release metadata json: %v", err)
 	}
 
-	err = api.UploadObjectExt(bytes.NewReader(out), spec.Bucket, path, true, specPolicy, aws.ContentTypeJSON, -1)
+	// we don't want this to be cached for very long so that e.g. Cincinnati picks it up quickly
+	var releases_max_age = 60 * 5
+	err = api.UploadObjectExt(bytes.NewReader(out), spec.Bucket, path, true, specPolicy, aws.ContentTypeJSON, releases_max_age)
 	if err != nil {
 		plog.Fatalf("uploading release metadata json: %v", err)
 	}

--- a/platform/api/aws/s3.go
+++ b/platform/api/aws/s3.go
@@ -49,7 +49,12 @@ func s3IsNotFound(err error) bool {
 }
 
 // UploadObject uploads an object to S3
-func (a *API) UploadObject(r io.Reader, bucket, path string, force bool, policy string, contentType string) error {
+func (a *API) UploadObject(r io.Reader, bucket, path string, force bool) error {
+	return a.UploadObjectExt(r, bucket, path, force, "", "")
+}
+
+// UploadObjectExt uploads an object to S3 with more control over options.
+func (a *API) UploadObjectExt(r io.Reader, bucket, path string, force bool, policy string, contentType string) error {
 	s3uploader := s3manager.NewUploaderWithClient(a.s3)
 
 	if !force {

--- a/platform/api/aws/s3.go
+++ b/platform/api/aws/s3.go
@@ -50,11 +50,11 @@ func s3IsNotFound(err error) bool {
 
 // UploadObject uploads an object to S3
 func (a *API) UploadObject(r io.Reader, bucket, path string, force bool) error {
-	return a.UploadObjectExt(r, bucket, path, force, "", "")
+	return a.UploadObjectExt(r, bucket, path, force, "", "", -1)
 }
 
 // UploadObjectExt uploads an object to S3 with more control over options.
-func (a *API) UploadObjectExt(r io.Reader, bucket, path string, force bool, policy string, contentType string) error {
+func (a *API) UploadObjectExt(r io.Reader, bucket, path string, force bool, policy string, contentType string, max_age int) error {
 	s3uploader := s3manager.NewUploaderWithClient(a.s3)
 
 	if !force {
@@ -77,6 +77,9 @@ func (a *API) UploadObjectExt(r io.Reader, bucket, path string, force bool, poli
 		Bucket: aws.String(bucket),
 		Key:    aws.String(path),
 		ACL:    aws.String(policy),
+	}
+	if max_age >= 0 {
+		input.CacheControl = aws.String(fmt.Sprintf("max-age=%d", max_age))
 	}
 	if contentType != "" {
 		input.ContentType = aws.String(contentType)


### PR DESCRIPTION
Ideally, we'd be able to signal CloudFront at release time that the
release index has changed. But at least let's upload it with a more
aggressive caching policy so that Cincinnati isn't lagging e.g. a whole
day behind.

See related discussions in:
coreos/fedora-coreos-tracker#232