### PR TITLE
platform/api/aws/images: return snapshotID from CopyImage 

### DIFF
--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -610,9 +610,13 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imageName, 
 		amis := map[string]string{}
 		if len(destRegions) > 0 {
 			plog.Printf("Replicating AMI %v...", imageID)
-			amis, err = api.CopyImage(imageID, destRegions)
+			copiedAmis, err := api.CopyImage(imageID, destRegions)
 			if err != nil {
 				return nil, fmt.Errorf("couldn't copy image: %v", err)
+			}
+
+			for region, data := range copiedAmis {
+				amis[region] = data.AMI
 			}
 		}
 		amis[part.BucketRegion] = imageID

--- a/platform/api/aws/images.go
+++ b/platform/api/aws/images.go
@@ -100,6 +100,11 @@ type Snapshot struct {
 	SnapshotID string
 }
 
+type ImageData struct {
+	AMI        string `json:"ami"`
+	SnapshotID string `json:"snapshot"`
+}
+
 // Look up a Snapshot by name. Return nil if not found.
 func (a *API) FindSnapshot(imageName string) (*Snapshot, error) {
 	// Look for an existing snapshot with this image name.
@@ -450,11 +455,11 @@ func (a *API) GrantLaunchPermission(imageID string, userIDs []string) error {
 	return nil
 }
 
-func (a *API) CopyImage(sourceImageID string, regions []string) (map[string]string, error) {
+func (a *API) CopyImage(sourceImageID string, regions []string) (map[string]ImageData, error) {
 	type result struct {
-		region  string
-		imageID string
-		err     error
+		region string
+		data   ImageData
+		err    error
 	}
 
 	image, err := a.describeImage(sourceImageID)
@@ -504,7 +509,7 @@ func (a *API) CopyImage(sourceImageID string, regions []string) (map[string]stri
 		go func() {
 			defer wg.Done()
 			res := result{region: aa.opts.Region}
-			res.imageID, res.err = aa.copyImageIn(a.opts.Region, sourceImageID,
+			res.data, res.err = aa.copyImageIn(a.opts.Region, sourceImageID,
 				*image.Name, *image.Description,
 				image.Tags, snapshot.Tags,
 				launchPermissions)
@@ -514,10 +519,10 @@ func (a *API) CopyImage(sourceImageID string, regions []string) (map[string]stri
 	wg.Wait()
 	close(ch)
 
-	amis := make(map[string]string)
+	amis := make(map[string]ImageData)
 	for res := range ch {
-		if res.imageID != "" {
-			amis[res.region] = res.imageID
+		if res.data.AMI != "" {
+			amis[res.region] = res.data
 		}
 		if err == nil {
 			err = res.err
@@ -526,10 +531,10 @@ func (a *API) CopyImage(sourceImageID string, regions []string) (map[string]stri
 	return amis, err
 }
 
-func (a *API) copyImageIn(sourceRegion, sourceImageID, name, description string, imageTags, snapshotTags []*ec2.Tag, launchPermissions []*ec2.LaunchPermission) (string, error) {
+func (a *API) copyImageIn(sourceRegion, sourceImageID, name, description string, imageTags, snapshotTags []*ec2.Tag, launchPermissions []*ec2.LaunchPermission) (ImageData, error) {
 	imageID, err := a.FindImage(name)
 	if err != nil {
-		return "", err
+		return ImageData{}, err
 	}
 
 	if imageID == "" {
@@ -540,7 +545,7 @@ func (a *API) copyImageIn(sourceRegion, sourceImageID, name, description string,
 			Description:   aws.String(description),
 		})
 		if err != nil {
-			return "", fmt.Errorf("couldn't initiate image copy to %v: %v", a.opts.Region, err)
+			return ImageData{}, fmt.Errorf("couldn't initiate image copy to %v: %v", a.opts.Region, err)
 		}
 		imageID = *copyRes.ImageId
 	}
@@ -553,7 +558,7 @@ func (a *API) copyImageIn(sourceRegion, sourceImageID, name, description string,
 		w.Delay = request.ConstantWaiterDelay(30 * time.Second)
 	})
 	if err != nil {
-		return "", fmt.Errorf("couldn't copy image to %v: %v", a.opts.Region, err)
+		return ImageData{}, fmt.Errorf("couldn't copy image to %v: %v", a.opts.Region, err)
 	}
 
 	if len(imageTags) > 0 {
@@ -562,21 +567,26 @@ func (a *API) copyImageIn(sourceRegion, sourceImageID, name, description string,
 			Tags:      imageTags,
 		})
 		if err != nil {
-			return "", fmt.Errorf("couldn't create image tags: %v", err)
+			return ImageData{}, fmt.Errorf("couldn't create image tags: %v", err)
 		}
 	}
 
+	var snapshotID string
+	image, err := a.describeImage(imageID)
+	if err != nil {
+		return ImageData{}, err
+	}
+	if image.BlockDeviceMappings[0].Ebs.SnapshotId != nil {
+		snapshotID = *image.BlockDeviceMappings[0].Ebs.SnapshotId
+	}
+
 	if len(snapshotTags) > 0 {
-		image, err := a.describeImage(imageID)
-		if err != nil {
-			return "", err
-		}
 		_, err = a.ec2.CreateTags(&ec2.CreateTagsInput{
-			Resources: []*string{image.BlockDeviceMappings[0].Ebs.SnapshotId},
+			Resources: []*string{&snapshotID},
 			Tags:      snapshotTags,
 		})
 		if err != nil {
-			return "", fmt.Errorf("couldn't create snapshot tags: %v", err)
+			return ImageData{}, fmt.Errorf("couldn't create snapshot tags: %v", err)
 		}
 	}
 
@@ -589,7 +599,7 @@ func (a *API) copyImageIn(sourceRegion, sourceImageID, name, description string,
 			},
 		})
 		if err != nil {
-			return "", fmt.Errorf("couldn't grant launch permissions: %v", err)
+			return ImageData{}, fmt.Errorf("couldn't grant launch permissions: %v", err)
 		}
 	}
 
@@ -603,10 +613,13 @@ func (a *API) copyImageIn(sourceRegion, sourceImageID, name, description string,
 	// plume release.
 	_, err = a.FindImage(name)
 	if err != nil {
-		return "", fmt.Errorf("checking for duplicate images: %v", err)
+		return ImageData{}, fmt.Errorf("checking for duplicate images: %v", err)
 	}
 
-	return imageID, nil
+	return ImageData{
+		AMI:        imageID,
+		SnapshotID: snapshotID,
+	}, nil
 }
 
 // Find an image we own with the specified name. Return ID or "".


### PR DESCRIPTION
Snapshots are created when copying images to new regions, these extra
resources cost money and should be communicated by the API. Add
additional code in `plume` to throw out said snapshot IDs as they are
not published to end-users.

The end result of this PR from the perspective of command interactions
is that `ore aws copy-image` will have the snapshot ID included in the
JSON output.