### PR TITLE
kola/tests/rpmostree: handle install path for fcos

### DIFF
--- a/kola/tests/rpmostree/deployments.go
+++ b/kola/tests/rpmostree/deployments.go
@@ -239,7 +239,13 @@ func rpmOstreeUpgradeRollback(c cluster.TestCluster) {
 // currently using.  We've already had to swap from `fpaste` to `bcrypt`
 func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 	var installPkgName = "bcrypt"
-	var installPkgBin = "/bin/bcrypt"
+	var installPkgBin string
+
+	if c.Distribution() == "fcos" {
+		installPkgBin = "/usr/bin/bcrypt"
+	} else {
+		installPkgBin = "/bin/bcrypt"
+	}
 
 	m := c.Machines()[0]
 

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -111,6 +111,9 @@ type Cluster interface {
 	// cluster machines.
 	JournalOutput() map[string]string
 
+	// Distribution returns the Distribution
+	Distribution() string
+
 	// IgnitionVersion returns the version of Ignition supported by the
 	// cluster
 	IgnitionVersion() string


### PR DESCRIPTION
The rpm-ostree install/uninstall tests  were failing because bcrypt
is installed in /bin on RHEL CoreOS and /usr/bin in Fedora CoreOS.