### PR TITLE
kola: Add --blacklist-test switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ runs any tests whose registered names matches a glob pattern.
 
 `kola run <glob pattern>`
 
+`--blacklist-test` can be used if one or more tests in the pattern should be skipped.
+This switch may be provided once:
+
+`kola --blacklist-test linux.nfs.v3 run`
+
+multiple times:
+
+`kola --blacklist-test linux.nfs.v3 --blacklist-test linux.nfs.v4 run`
+
+and can also be used with glob patterns:
+
+`kola --blacklist-test linux.nfs* --blacklist-test crio.* run`
+
 #### kola list
 The list command lists all of the available tests.
 

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -52,6 +52,7 @@ func init() {
 	sv := root.PersistentFlags().StringVar
 	bv := root.PersistentFlags().BoolVar
 	ss := root.PersistentFlags().StringSlice
+	ssv := root.PersistentFlags().StringSliceVar
 
 	// general options
 	sv(&outputDir, "output-dir", "", "Temporary output directory for test data and logs")
@@ -64,7 +65,7 @@ func init() {
 	ss("debug-systemd-unit", []string{}, "full-unit-name.service to enable SYSTEMD_LOG_LEVEL=debug on. Specify multiple times for multiple units.")
 	sv(&kola.UpdatePayloadFile, "update-payload", "", "Path to an update payload that should be made available to tests")
 	sv(&kola.Options.IgnitionVersion, "ignition-version", "", "Ignition version override: v2, v3")
-
+	ssv(&kola.BlacklistedTests, "blacklist-test", []string{}, "List of tests to blacklist")
 	// rhcos-specific options
 	sv(&kola.Options.OSContainer, "oscontainer", "", "oscontainer image pullspec for pivot (RHCOS only)")
 


### PR DESCRIPTION
When one or more --blacklist-test provided at run time any test that matches by name or pattern to the provided black list is not added to the list of tests to execute.

Example:
```
$ # Run all linux tests except the nfs ones
$ ./bin/kola --blacklist-test linux.nfs* run linux.*
$ # Run everything but linux.nfs.v3
$ ./bin/kola --blacklist-test linux.nfs.v3 run
```

/cc @miabbott