### PR TITLE
Add s390x support for kola in mantle

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ properties([
 
     parameters([
         choice(name: 'GOARCH',
-               choices: "amd64\narm64",
+               choices: "amd64\narm64\ns390x",
                description: 'target architecture for building binaries')
     ]),
 

--- a/build
+++ b/build
@@ -26,7 +26,7 @@ host_build() {
 
 cross_build() {
 	local a
-	for a in amd64 arm64; do
+	for a in amd64 arm64 s390x; do
 		echo "Building $a/$1"
 		mkdir -p "bin/$a"
 		CGO_ENABLED=0 GOARCH=$a \

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -167,7 +167,7 @@ func syncOptions() error {
 	}
 
 	image, ok := kolaDefaultImages[kola.QEMUOptions.Board]
-	if !ok {
+	if kola.QEMUOptions.Distribution == "cl" && !ok {
 		return fmt.Errorf("unsupport board %q", kola.QEMUOptions.Board)
 	}
 

--- a/platform/api/packet/api.go
+++ b/platform/api/packet/api.go
@@ -65,10 +65,12 @@ var (
 	defaultPlan = map[string]string{
 		"amd64-usr": "baremetal_0",
 		"arm64-usr": "baremetal_2a",
+		"s390x-usr": "baremetal_3a",
 	}
 	linuxConsole = map[string]string{
 		"amd64-usr": "ttyS1,115200",
 		"arm64-usr": "ttyAMA0,115200",
+		"s390x-usr": "ttysclp0,115200",
 	}
 )
 

--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -265,18 +265,29 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 			"-cpu", "host",
 			"-m", "2048",
 		}
+	case "s390x--s390x-usr":
+		qmBinary = "qemu-system-s390x"
+		qmCmd = []string{
+			"qemu-system-s390x",
+			"-machine", "s390-ccw-virtio,accel=kvm",
+			"-cpu", "host",
+			"-m", "2048",
+		}
 	default:
 		panic("host-guest combo not supported: " + combo)
 	}
 
 	qmCmd = append(qmCmd,
-		"-bios", biosImage,
 		"-smp", "1",
 		"-uuid", uuid,
 		"-display", "none",
 		"-chardev", "file,id=log,path="+consolePath,
 		"-serial", "chardev:log",
 	)
+
+	if board != "s390x-usr" {
+		qmCmd = append(qmCmd, "-bios", biosImage)
+	}
 
 	if isIgnition {
 		qmCmd = append(qmCmd,
@@ -346,6 +357,8 @@ func Virtio(board, device, args string) string {
 		suffix = "pci"
 	case "arm64-usr":
 		suffix = "device"
+	case "s390x-usr":
+		suffix = "ccw"
 	default:
 		panic(board)
 	}

--- a/system/arch.go
+++ b/system/arch.go
@@ -29,7 +29,7 @@ func PortageArch() string {
 	case "arm":
 	case "arm64":
 	case "ppc64":
-
+	case "s390x":
 	// Gentoo doesn't have a little-endian PPC port.
 	case "ppc64le":
 		fallthrough


### PR DESCRIPTION
This is the starting PR to add possibility to build mantle utilities and run kola on s390x architecture.
The code adds s390x architecture to the list of other supported archs to avoid "not-supported" errors and add functionality to generate qemu command, working for s390x 
