### PR TITLE
Add guestfs utility usage for s390x, to replace unsupported fw_cfg

### DIFF
--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -15,6 +15,7 @@
 package platform
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -39,6 +40,7 @@ type Disk struct {
 	Size        string   // disk image size in bytes, optional suffixes "K", "M", "G", "T" allowed. Incompatible with BackingFile
 	BackingFile string   // raw disk image to use. Incompatible with Size.
 	DeviceOpts  []string // extra options to pass to qemu. "serial=XXXX" makes disks show up as /dev/disk/by-id/virtio-<serial>
+	ConfPath    string   // path to ignition to be able to use it with guestfs for temporary qcow2 images
 }
 
 var (
@@ -167,14 +169,14 @@ func (d Disk) setupFile() (*os.File, error) {
 	}
 
 	if d.Size != "" {
-		return setupDisk(d.Size)
+		return setupDisk(d.Size, d.ConfPath)
 	} else {
-		return setupDiskFromFile(d.BackingFile)
+		return setupDiskFromFile(d.BackingFile, d.ConfPath)
 	}
 }
 
 // Create a nameless temporary qcow2 image file backed by a raw image.
-func setupDiskFromFile(imageFile string) (*os.File, error) {
+func setupDiskFromFile(imageFile string, confPath string) (*os.File, error) {
 	// a relative path would be interpreted relative to /tmp
 	backingFile, err := filepath.Abs(imageFile)
 	if err != nil {
@@ -191,10 +193,10 @@ func setupDiskFromFile(imageFile string) (*os.File, error) {
 	}
 
 	qcowOpts := fmt.Sprintf("backing_file=%s,lazy_refcounts=on", backingFile)
-	return setupDisk("-o", qcowOpts)
+	return setupDisk(confPath, "-o", qcowOpts)
 }
 
-func setupDisk(additionalOptions ...string) (*os.File, error) {
+func setupDisk(confPath string, additionalOptions ...string) (*os.File, error) {
 	dstFileName, err := mkpath("")
 	if err != nil {
 		return nil, err
@@ -210,7 +212,12 @@ func setupDisk(additionalOptions ...string) (*os.File, error) {
 	if err := qemuImg.Run(); err != nil {
 		return nil, err
 	}
-
+	if len(confPath) > 0 {
+		err = setupIgnition(confPath, dstFileName)
+		if err != nil {
+			return nil, fmt.Errorf("ignition injection with guestfs failed: %v", err)
+		}
+	}
 	return os.OpenFile(dstFileName, os.O_RDWR, 0)
 }
 
@@ -290,8 +297,11 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 	}
 
 	if isIgnition {
-		qmCmd = append(qmCmd,
-			"-fw_cfg", "name=opt/com.coreos/config,file="+confPath)
+		// -fw_cfg is not supported for s390x, instead guestfs utility is used
+		if board != "s390x-usr" {
+			qmCmd = append(qmCmd,
+				"-fw_cfg", "name=opt/com.coreos/config,file="+confPath)
+		}
 	} else {
 		qmCmd = append(qmCmd,
 			"-fsdev", "local,id=cfg,security_model=none,readonly,path="+confPath,
@@ -318,12 +328,17 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 		plog.Debugf("disabling auto-read-only for QEMU drives")
 	}
 
-	allDisks := append([]Disk{
-		{
-			BackingFile: diskImagePath,
-			DeviceOpts:  primaryDiskOptions,
-		},
-	}, options.AdditionalDisks...)
+	primaryDisk := Disk{
+		BackingFile: diskImagePath,
+		DeviceOpts:  primaryDiskOptions,
+		ConfPath:    "",
+	}
+
+	if board == "s390x-usr" {
+		primaryDisk.ConfPath = confPath
+	}
+
+	allDisks := append([]Disk{primaryDisk}, options.AdditionalDisks...)
 
 	var extraFiles []*os.File
 	fdnum := 3 // first additional file starts at position 3
@@ -363,4 +378,94 @@ func Virtio(board, device, args string) string {
 		panic(board)
 	}
 	return fmt.Sprintf("virtio-%s-%s,%s", device, suffix, args)
+}
+
+func setupIgnition(confPath string, diskImagePath string) error {
+	fileRemoteLocation := "/boot/ignition/config.ign"
+
+	plog.Debugf("START guestfs")
+
+	cmd := exec.Command("guestfish", "--listen", "-a", diskImagePath)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("getting stdout pipe: %v", err)
+	}
+	defer stdout.Close()
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("running guestfish: %v", err)
+	}
+	buf, err := ioutil.ReadAll(stdout)
+	if err != nil {
+		cmd.Wait()
+		return fmt.Errorf("reading guestfish output: %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("waiting for guestfish response: %v", err)
+	}
+	//GUESTFISH_PID=$PID; export GUESTFISH_PID
+	gfVarPid := strings.Split(string(buf), ";")
+	gfVarPidArr := strings.Split(gfVarPid[0], "=")
+	os.Setenv(gfVarPidArr[0], gfVarPidArr[1])
+
+	if err := exec.Command("guestfish", "--remote", "--", "run").Run(); err != nil {
+		return fmt.Errorf("guestfish launch failed: %v", err)
+	}
+
+	bootfs, err := findLabel("boot")
+	if err != nil {
+		return fmt.Errorf("guestfish command failed: %v", err)
+	}
+
+	rootfs, err := findLabel("root")
+	if err != nil {
+		return fmt.Errorf("guestfish command failed: %v", err)
+	}
+
+	defer func() {
+		plog.Debugf("guestfish exit")
+		if err := exec.Command("guestfish", "--remote", "--", "exit").Run(); err != nil {
+			plog.Errorf("guestfish exit failed: %v", err)
+		}
+	}()
+
+	if err := exec.Command("guestfish", "--remote", "--", "mount", rootfs, "/").Run(); err != nil {
+		return fmt.Errorf("guestfish root mount failed: %v", err)
+	}
+
+	if err := exec.Command("guestfish", "--remote", "--", "mount", bootfs, "/boot").Run(); err != nil {
+		return fmt.Errorf("guestfish boot mount failed: %v", err)
+	}
+
+	if err := exec.Command("guestfish", "--remote", "--", "mkdir-p", "/boot/ignition").Run(); err != nil {
+		return fmt.Errorf("guestfish directory creation failed: %v", err)
+	}
+
+	if err := exec.Command("guestfish", "--remote", "--", "upload", confPath, fileRemoteLocation).Run(); err != nil {
+		return fmt.Errorf("guestfish upload failed: %v", err)
+	}
+
+	if err := exec.Command("guestfish", "--remote", "--", "umount-all").Run(); err != nil {
+		return fmt.Errorf("guestfish umount failed: %v", err)
+	}
+
+	plog.Debugf("SUCCESS guestfs")
+	return nil
+}
+
+func findLabel(label string) (string, error) {
+	cmd := exec.Command("guestfish", "--remote", "findfs-label", label)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", fmt.Errorf("get stdout for findfs-label failed: %v", err)
+	}
+	defer stdout.Close()
+
+	err = cmd.Start()
+	if err != nil {
+		return "", fmt.Errorf("start findfs-label command failed: %v", err)
+	}
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(stdout)
+	return strings.TrimSpace(buf.String()), nil
 }


### PR DESCRIPTION
In case of x86 architecture fw_cfg is used to pass ignition config file to the KVM guest.
s390x does not support fw_cfg, so guestfs is option to use.
guestfs allows to modify qcow2 image before running it as guest.
Current implementation modifies not the base qcow2 image, but the temporary one, created based on the testing qcow2 image.
Code has implementation of several calls to guestfish utility, it is expected that libguestfs-tools is installed on host.
The according issue is https://github.com/coreos/mantle/issues/1045

The list of commands to execute and their output for s390x case. Filesystems are not hardcoded in the code, but found based on their labels
  - guestfish --listen -a $IMG
         -- > GUESTFISH_PID=$PID; export GUESTFISH_PID
  - guestfish --remote -- run
  - guestfish --remote -- findfs-label boot
         -- >  /dev/sda1
  - guestfish --remote -- findfs-label root
         -- >  /dev/sda2
  - guestfish --remote -- mount /dev/sda2 /
  - guestfish --remote -- mount /dev/sda1 /boot
  - guestfish --remote -- mkdir -p /boot/ignition
  - guestfish --remote -- upload $HOST_IGNITION_FILE $GUEST_IGNITION_FILE
  - guestfish --remote -- umount-all
  - guestfish --remote -- exit