### PR TITLE
platform/cluster: mask tcsd.service on Packet for CL

### DIFF
--- a/platform/cluster.go
+++ b/platform/cluster.go
@@ -26,7 +26,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 
-	"github.com/coreos/mantle/platform/conf"
+	platformConf "github.com/coreos/mantle/platform/conf"
 	"github.com/coreos/mantle/util"
 )
 
@@ -132,13 +132,13 @@ func (bc *BaseCluster) Keys() ([]*agent.Key, error) {
 	return bc.bf.Keys()
 }
 
-func (bc *BaseCluster) RenderUserData(userdata *conf.UserData, ignitionVars map[string]string) (*conf.Conf, error) {
+func (bc *BaseCluster) RenderUserData(userdata *platformConf.UserData, ignitionVars map[string]string) (*platformConf.Conf, error) {
 	if userdata == nil {
 		switch bc.IgnitionVersion() {
 		case "v2":
-			userdata = conf.Ignition(`{"ignition": {"version": "2.0.0"}}`)
+			userdata = platformConf.Ignition(`{"ignition": {"version": "2.0.0"}}`)
 		case "v3":
-			userdata = conf.Ignition(`{"ignition": {"version": "3.0.0"}}`)
+			userdata = platformConf.Ignition(`{"ignition": {"version": "3.0.0"}}`)
 		default:
 			return nil, fmt.Errorf("unknown ignition version")
 		}
@@ -183,7 +183,7 @@ enabled = false`, 0644)
 		}
 		conf.AddSystemdUnitDropin("pivot.service", "00-before-sshd.conf", `[Unit]
 Before=sshd.service`)
-		conf.AddSystemdUnit("pivot.service", "", true)
+		conf.AddSystemdUnit("pivot.service", "", platformConf.Enable)
 		conf.AddSystemdUnit("pivot-write-reboot-needed.service", `[Unit]
 Description=Touch /run/pivot/reboot-needed
 ConditionFirstBoot=true
@@ -195,7 +195,7 @@ ExecStart=/usr/bin/touch /run/pivot/reboot-needed
 
 [Install]
 WantedBy=multi-user.target
-`, true)
+`, platformConf.Enable)
 		conf.AddFile("/etc/pivot/image-pullspec", "root", bc.bf.baseopts.OSContainer, 0644)
 	}
 

--- a/platform/cluster.go
+++ b/platform/cluster.go
@@ -199,6 +199,11 @@ WantedBy=multi-user.target
 		conf.AddFile("/etc/pivot/image-pullspec", "root", bc.bf.baseopts.OSContainer, 0644)
 	}
 
+	// mask tcsd on Packet for CL
+	if bc.Distribution() == "cl" && bc.Platform() == "packet" {
+		conf.AddSystemdUnit("tcsd.service", "", platformConf.Mask)
+	}
+
 	if conf.IsIgnition() {
 		if !conf.ValidConfig() {
 			return nil, fmt.Errorf("invalid ignition config")

--- a/platform/conf/conf.go
+++ b/platform/conf/conf.go
@@ -62,7 +62,6 @@ const (
 	NoState systemdUnitState = iota
 	Enable
 	Mask
-	EnableAndMask
 )
 
 var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "platform/conf")
@@ -538,9 +537,6 @@ func (c *Conf) addSystemdUnitCloudConfig(name, contents string, enable, mask boo
 func (c *Conf) AddSystemdUnit(name, contents string, state systemdUnitState) {
 	enable, mask := false, false
 	switch state {
-	case EnableAndMask:
-		enable = true
-		mask = true
 	case Enable:
 		enable = true
 	case Mask:

--- a/platform/machine/esx/cluster.go
+++ b/platform/machine/esx/cluster.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/coreos/mantle/platform"
-	"github.com/coreos/mantle/platform/conf"
+	platformConf "github.com/coreos/mantle/platform/conf"
 )
 
 type cluster struct {
@@ -35,7 +35,7 @@ func (ec *cluster) vmname() string {
 	return fmt.Sprintf("%s-%x", ec.Name(), b)
 }
 
-func (ec *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error) {
+func (ec *cluster) NewMachine(userdata *platformConf.UserData) (platform.Machine, error) {
 	conf, err := ec.RenderUserData(userdata, map[string]string{
 		"$public_ipv4":  "${COREOS_ESX_IPV4_PUBLIC_0}",
 		"$private_ipv4": "${COREOS_ESX_IPV4_PRIVATE_0}",
@@ -51,7 +51,7 @@ Description=VMware metadata agent
 Type=oneshot
 Environment=OUTPUT=/run/metadata/coreos
 ExecStart=/usr/bin/mkdir --parent /run/metadata
-ExecStart=/usr/bin/bash -c 'echo "COREOS_ESX_IPV4_PRIVATE_0=$(ip addr show ens192 | grep -Po "inet \K[\d.]+")\nCOREOS_ESX_IPV4_PUBLIC_0=$(ip addr show ens192 | grep -Po "inet \K[\d.]+")" > ${OUTPUT}'`, false)
+ExecStart=/usr/bin/bash -c 'echo "COREOS_ESX_IPV4_PRIVATE_0=$(ip addr show ens192 | grep -Po "inet \K[\d.]+")\nCOREOS_ESX_IPV4_PUBLIC_0=$(ip addr show ens192 | grep -Po "inet \K[\d.]+")" > ${OUTPUT}'`, platformConf.NoState)
 
 	instance, err := ec.flight.api.CreateDevice(ec.vmname(), conf)
 	if err != nil {


### PR DESCRIPTION
tcsd.service can fail to start on Packet nodes which have TPM due to a
longstanding issue that won't be fixed in the CL lifespan. As such mask
it when running CL on Packet.

Also adds a new `Mask` option to the `AddSystemdUnit` function in
`platform/conf`.

Closes #1056 