### PR TITLE
gcp: Add UEFI_COMPATIBLE and SECURE_BOOT

### DIFF
--- a/cmd/ore/gcloud/create-image.go
+++ b/cmd/ore/gcloud/create-image.go
@@ -41,6 +41,7 @@ var (
 	createImageRoot    string
 	createImageName    string
 	createImageForce   bool
+	createImageFcos    bool
 )
 
 func init() {
@@ -59,6 +60,7 @@ func init() {
 		"Storage image name")
 	cmdCreateImage.Flags().BoolVar(&createImageForce, "force",
 		false, "overwrite existing GCE images without prompt")
+	cmdCreateImage.Flags().BoolVar(&uploadFedora, "fcos", false, "Flag this is Fedora CoreOS (or a derivative); currently enables SECURE_BOOT and UEFI_COMPATIBLE")
 	GCloud.AddCommand(cmdCreateImage)
 }
 
@@ -116,7 +118,7 @@ func runCreateImage(cmd *cobra.Command, args []string) {
 	_, pending, err := api.CreateImage(&gcloud.ImageSpec{
 		Name:        imageNameGCE,
 		SourceImage: storageSrc,
-	}, createImageForce)
+	}, createImageForce, createImageFcos)
 	if err == nil {
 		err = pending.Wait()
 	}

--- a/cmd/ore/gcloud/upload.go
+++ b/cmd/ore/gcloud/upload.go
@@ -41,6 +41,7 @@ var (
 	uploadImageName string
 	uploadBoard     string
 	uploadFile      string
+	uploadFedora    bool
 	uploadForce     bool
 )
 
@@ -52,6 +53,7 @@ func init() {
 	cmdUpload.Flags().StringVar(&uploadFile, "file",
 		build+"/images/amd64-usr/latest/coreos_production_gce.tar.gz",
 		"path_to_coreos_image (build with: ./image_to_vm.sh --format=gce ...)")
+	cmdUpload.Flags().BoolVar(&uploadFedora, "fcos", false, "Flag this is Fedora CoreOS (or a derivative); currently enables SECURE_BOOT and UEFI_COMPATIBLE")
 	cmdUpload.Flags().BoolVar(&uploadForce, "force", false, "overwrite existing GS and GCE images without prompt")
 	GCloud.AddCommand(cmdUpload)
 }
@@ -141,7 +143,7 @@ func runUpload(cmd *cobra.Command, args []string) {
 	_, pending, err := api.CreateImage(&gcloud.ImageSpec{
 		Name:        imageNameGCE,
 		SourceImage: storageSrc,
-	}, uploadForce)
+	}, uploadForce, uploadFedora)
 	if err == nil {
 		err = pending.Wait()
 	}
@@ -160,7 +162,7 @@ func runUpload(cmd *cobra.Command, args []string) {
 			_, pending, err = api.CreateImage(&gcloud.ImageSpec{
 				Name:        imageNameGCE,
 				SourceImage: storageSrc,
-			}, true)
+			}, true, uploadFedora)
 			if err == nil {
 				err = pending.Wait()
 			}

--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -230,7 +230,7 @@ func gceUploadImage(spec *channelSpec, api *gcloud.API, obj *gs.Object, name, de
 		Name:        name,
 		Description: desc,
 		Licenses:    spec.GCE.Licenses,
-	}, false)
+	}, false, selectedDistro == "fcos")
 	if err != nil {
 		plog.Fatalf("GCE image creation failed: %v", err)
 	}


### PR DESCRIPTION
For FCOS we support both.  Mainly I'm adding these because
they seem to be prerequisites for accessing the "vTPM" which
is part of the "Shielded Cloud" umbrella.  We want access to the vTPM
to enable support for LUKS bound to vTPM for example.  Also,
for OpenShift, I think at some point we want to enable using TPM
as a "strong identity" for nodes.