### PR TITLE
platform/qemu: fix bug in QEMU cluster creation

### DIFF
--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -168,7 +168,7 @@ func (d Disk) setupFile() (*os.File, error) {
 	}
 
 	if d.Size != "" {
-		return setupDisk(d.Size, d.ConfPath)
+		return setupDisk(d.ConfPath, d.Size)
 	} else {
 		return setupDiskFromFile(d.BackingFile, d.ConfPath)
 	}


### PR DESCRIPTION
Fixed a bug where the `Size` & `ConfPath` (used on `s390x` to inject
Ignition configs)  were reversed when calling `setupDisk` resulting in
errors being spat out by `qemu-img`.

Example error messages:
```
qemu-img: Invalid image size specified! You may use k, M, G, T, P or E suffixes for
qemu-img: kilobytes, megabytes, gigabytes, terabytes, petabytes and exabytes.
```