### PR TITLE
plume: rename --system argument to --distro

### DIFF
--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -96,7 +96,7 @@ func init() {
 	sort.Sort(sort.StringSlice(platformList))
 
 	cmdPreRelease.Flags().StringSliceVar(&selectedPlatforms, "platform", platformList, "platform to pre-release")
-	cmdPreRelease.Flags().StringVar(&selectedDistro, "system", "cl", "system to pre-release")
+	cmdPreRelease.Flags().StringVar(&selectedDistro, "distro", "cl", "system to pre-release")
 	cmdPreRelease.Flags().StringVar(&azureProfile, "azure-profile", "", "Azure Profile json file")
 	cmdPreRelease.Flags().StringVar(&awsCredentialsFile, "aws-credentials", "", "AWS credentials file")
 	cmdPreRelease.Flags().StringVar(&verifyKeyFile,


### PR DESCRIPTION
I'm not sure why release and pre-release have two separate option
names for the same thing, which means that the invocation between
release and pre-release differs in a non-intuitive way. This commit
makes them match.