### PR TITLE
plume: lots of tiny fixups for Fedora distro 

### DIFF
--- a/cmd/plume/README.md
+++ b/cmd/plume/README.md
@@ -146,15 +146,30 @@ There are two sub-commands to do a Fedora Cloud Release: `pre-release` and `rele
 Here is an example of doing a Fedora Cloud pre-release with plume:
 
 ```
-./bin/plume pre-release \
-  --system fedora \
-  --channel cloud \
-  --version 30 \
-  --timestamp 20190819 \
-  --respin 0 \
-  --board x86_64 \
+./bin/plume pre-release                   \
+  --distro fedora                         \
+  --channel cloud                         \
+  --version 30                            \
+  --timestamp 20190819                    \
+  --respin 0                              \
+  --board x86_64                          \
   --compose-id Fedora-Cloud-30-20190819.0 \
-  --image-type Cloud-Base \
+  --image-type Cloud-Base                 \
+  --debug
+```
+
+Here is an example of doing a Fedora Cloud release with plume:
+
+```
+./bin/plume release                       \
+  --distro fedora                         \
+  --channel cloud                         \
+  --version 30                            \
+  --timestamp 20190819                    \
+  --respin 0                              \
+  --board x86_64                          \
+  --compose-id Fedora-Cloud-30-20190819.0 \
+  --image-type Cloud-Base                 \
   --debug
 ```
 

--- a/cmd/plume/fedora.go
+++ b/cmd/plume/fedora.go
@@ -30,7 +30,7 @@ var (
 		"x86_64",
 		"aarch64",
 	}
-	awsFedoraPartitions = []awsPartitionSpec{
+	awsFedoraProdAccountPartitions = []awsPartitionSpec{
 		awsPartitionSpec{
 			Name:         "AWS",
 			Profile:      "default",
@@ -58,7 +58,7 @@ var (
 			},
 		},
 	}
-	awsFedoraUserPartitions = []awsPartitionSpec{
+	awsFedoraDevAccountPartitions = []awsPartitionSpec{
 		awsPartitionSpec{
 			Name:         "AWS",
 			Profile:      "default",
@@ -82,7 +82,7 @@ var (
 				BaseName:        "Fedora",
 				BaseDescription: "Fedora {{.ImageType}} AMI",
 				Image:           "Fedora-{{.ImageType}}-{{.Version}}-{{.Timestamp}}.n.{{.Respin}}.{{.Arch}}.raw.xz",
-				Partitions:      awsFedoraPartitions,
+				Partitions:      awsFedoraProdAccountPartitions,
 			},
 		},
 		"branched": channelSpec{
@@ -92,7 +92,7 @@ var (
 				BaseName:        "Fedora",
 				BaseDescription: "Fedora {{.ImageType}} AMI",
 				Image:           "Fedora-{{.ImageType}}-{{.Version}}-{{.Timestamp}}.n.{{.Respin}}.{{.Arch}}.raw.xz",
-				Partitions:      awsFedoraPartitions,
+				Partitions:      awsFedoraProdAccountPartitions,
 			},
 		},
 		"updates": channelSpec{
@@ -102,7 +102,7 @@ var (
 				BaseName:        "Fedora",
 				BaseDescription: "Fedora {{.ImageType}} AMI",
 				Image:           "Fedora-{{.ImageType}}-{{.Version}}-{{.Timestamp}}.{{.Respin}}.{{.Arch}}.raw.xz",
-				Partitions:      awsFedoraPartitions,
+				Partitions:      awsFedoraProdAccountPartitions,
 			},
 		},
 		"cloud": channelSpec{
@@ -112,7 +112,7 @@ var (
 				BaseName:        "Fedora",
 				BaseDescription: "Fedora AMI",
 				Image:           "Fedora-{{.ImageType}}-{{.Version}}-{{.Timestamp}}.{{.Respin}}.{{.Arch}}.raw.xz",
-				Partitions:      awsFedoraPartitions,
+				Partitions:      awsFedoraProdAccountPartitions,
 			},
 		},
 	}
@@ -145,6 +145,9 @@ func ChannelFedoraSpec() (channelSpec, error) {
 		return channelSpec{}, fmt.Errorf("Unknown channel: %q", specChannel)
 	}
 
+	if specEnv == "dev" {
+		spec.AWS.Partitions = awsFedoraDevAccountPartitions
+	}
 	boardOk := false
 	for _, board := range spec.Boards {
 		if specBoard == board {

--- a/cmd/plume/fedora.go
+++ b/cmd/plume/fedora.go
@@ -34,7 +34,7 @@ var (
 		awsPartitionSpec{
 			Name:         "AWS",
 			Profile:      "default",
-			Bucket:       "fedora-s3-bucket-fedimg",
+			Bucket:       "fedora-cloud-plume-ami-vmimport",
 			BucketRegion: "us-east-1",
 			LaunchPermissions: []string{
 				"125523088429", // fedora production account
@@ -62,7 +62,7 @@ var (
 		awsPartitionSpec{
 			Name:         "AWS",
 			Profile:      "default",
-			Bucket:       "fedora-s3-bucket-fedimg-test",
+			Bucket:       "prod-account-match-fedora-cloud-plume-ami-vmimport",
 			BucketRegion: "us-east-1",
 			LaunchPermissions: []string{
 				"013116697141", // fedora community dev test account

--- a/cmd/plume/fedora.go
+++ b/cmd/plume/fedora.go
@@ -81,7 +81,6 @@ var (
 			AWS: awsSpec{
 				BaseName:        "Fedora",
 				BaseDescription: "Fedora {{.ImageType}} AMI",
-				Prefix:          "fedora_{{.Env}}_ami_",
 				Image:           "Fedora-{{.ImageType}}-{{.Version}}-{{.Timestamp}}.n.{{.Respin}}.{{.Arch}}.raw.xz",
 				Partitions:      awsFedoraPartitions,
 			},
@@ -92,7 +91,6 @@ var (
 			AWS: awsSpec{
 				BaseName:        "Fedora",
 				BaseDescription: "Fedora {{.ImageType}} AMI",
-				Prefix:          "fedora_{{.Env}}_ami_",
 				Image:           "Fedora-{{.ImageType}}-{{.Version}}-{{.Timestamp}}.n.{{.Respin}}.{{.Arch}}.raw.xz",
 				Partitions:      awsFedoraPartitions,
 			},
@@ -103,7 +101,6 @@ var (
 			AWS: awsSpec{
 				BaseName:        "Fedora",
 				BaseDescription: "Fedora {{.ImageType}} AMI",
-				Prefix:          "fedora_{{.Env}}_ami_",
 				Image:           "Fedora-{{.ImageType}}-{{.Version}}-{{.Timestamp}}.{{.Respin}}.{{.Arch}}.raw.xz",
 				Partitions:      awsFedoraPartitions,
 			},
@@ -114,7 +111,6 @@ var (
 			AWS: awsSpec{
 				BaseName:        "Fedora",
 				BaseDescription: "Fedora AMI",
-				Prefix:          "fedora_{{.Env}}_ami_",
 				Image:           "Fedora-{{.ImageType}}-{{.Version}}-{{.Timestamp}}.{{.Respin}}.{{.Arch}}.raw.xz",
 				Partitions:      awsFedoraPartitions,
 			},

--- a/cmd/plume/fedora.go
+++ b/cmd/plume/fedora.go
@@ -119,11 +119,11 @@ var (
 )
 
 func AddFedoraSpecFlags(flags *pflag.FlagSet) {
-	flags.StringVarP(&specEnv, "environment", "E", "prod", "instance environment")
-	flags.StringVarP(&specImageType, "image-type", "I", "Cloud-Base", "type of image")
-	flags.StringVarP(&specTimestamp, "timestamp", "T", "", "compose timestamp")
-	flags.StringVarP(&specRespin, "respin", "R", "0", "compose respin")
-	flags.StringVarP(&specComposeID, "compose-id", "O", "", "compose id")
+	flags.StringVar(&specEnv, "environment", "prod", "AMI upload environment")
+	flags.StringVar(&specImageType, "image-type", "Cloud-Base", "type of image")
+	flags.StringVar(&specTimestamp, "timestamp", "", "compose timestamp")
+	flags.StringVar(&specRespin, "respin", "0", "compose respin")
+	flags.StringVar(&specComposeID, "compose-id", "", "compose id")
 }
 
 func ChannelFedoraSpec() (channelSpec, error) {

--- a/cmd/plume/fedora.go
+++ b/cmd/plume/fedora.go
@@ -80,7 +80,7 @@ var (
 			Boards:  awsFedoraBoards,
 			AWS: awsSpec{
 				BaseName:        "Fedora",
-				BaseDescription: "Fedora {{.ImageType}} AMI",
+				BaseDescription: "Fedora Cloud Base AMI",
 				Image:           "Fedora-{{.ImageType}}-{{.Version}}-{{.Timestamp}}.n.{{.Respin}}.{{.Arch}}.raw.xz",
 				Partitions:      awsFedoraProdAccountPartitions,
 			},
@@ -90,7 +90,7 @@ var (
 			Boards:  awsFedoraBoards,
 			AWS: awsSpec{
 				BaseName:        "Fedora",
-				BaseDescription: "Fedora {{.ImageType}} AMI",
+				BaseDescription: "Fedora Cloud Base AMI",
 				Image:           "Fedora-{{.ImageType}}-{{.Version}}-{{.Timestamp}}.n.{{.Respin}}.{{.Arch}}.raw.xz",
 				Partitions:      awsFedoraProdAccountPartitions,
 			},
@@ -100,7 +100,7 @@ var (
 			Boards:  awsFedoraBoards,
 			AWS: awsSpec{
 				BaseName:        "Fedora",
-				BaseDescription: "Fedora {{.ImageType}} AMI",
+				BaseDescription: "Fedora Cloud Base AMI",
 				Image:           "Fedora-{{.ImageType}}-{{.Version}}-{{.Timestamp}}.{{.Respin}}.{{.Arch}}.raw.xz",
 				Partitions:      awsFedoraProdAccountPartitions,
 			},
@@ -110,7 +110,7 @@ var (
 			Boards:  awsFedoraBoards,
 			AWS: awsSpec{
 				BaseName:        "Fedora",
-				BaseDescription: "Fedora AMI",
+				BaseDescription: "Fedora Cloud Base AMI",
 				Image:           "Fedora-{{.ImageType}}-{{.Version}}-{{.Timestamp}}.{{.Respin}}.{{.Arch}}.raw.xz",
 				Partitions:      awsFedoraProdAccountPartitions,
 			},

--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -71,6 +71,10 @@ func runRelease(cmd *cobra.Command, args []string) {
 		if err := runFcosRelease(cmd, args); err != nil {
 			plog.Fatal(err)
 		}
+	case "fedora":
+		if err := runFedoraRelease(cmd, args); err != nil {
+			plog.Fatal(err)
+		}
 	default:
 		plog.Fatalf("Unknown distro %q:", selectedDistro)
 	}

--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -460,8 +460,10 @@ func doAWS(ctx context.Context, client *http.Client, src *storage.Bucket, spec *
 					}
 				}
 			}
-			if aws.RegionSupportsPV(region) {
-				publish(imageName)
+			if selectedDistro == "cl" {
+				if aws.RegionSupportsPV(region) {
+					publish(imageName)
+				}
 			}
 			publish(imageName + "-hvm")
 		}


### PR DESCRIPTION
- plume: add release example to the README
- plume: fedora: update s3 bucket names
- plume: release: only try to publish PV AMIs for CL
- plume: release: add code to do fedora release
- plume: fedora: remove templating from spec.AWS.BaseDescription
- plume: fedora: remove short options
- plume: fedora: target prod/dev account based on `--environment`
- plume: remove Prefix from Fedora channelspecs                    
