### PR TITLE
kola/tests/ignition/passwd: update passwd entry for core user on RHCOS

### DIFF
--- a/kola/tests/ignition/passwd.go
+++ b/kola/tests/ignition/passwd.go
@@ -282,7 +282,7 @@ func usersRhcos(c cluster.TestCluster) {
 	tests := []userTest{
 		{
 			user:           "core",
-			passwdRecord:   "core:x:1000:1000::/home/core:/bin/bash",
+			passwdRecord:   "core:x:1000:1000:CoreOS Admin:/home/core:/bin/bash",
 			shadowPassword: "foobar",
 		},
 		{


### PR DESCRIPTION
Now that RHCOS is inheriting some of its config from `fedora-coreos-config`,
it uses the same `base.ign` file that includes a `gecos` entry set to
`CoreOS Admin` for the `core` user.