### PR TITLE
kola: initial ppc64le support

### DIFF
--- a/build
+++ b/build
@@ -26,7 +26,7 @@ host_build() {
 
 cross_build() {
 	local a
-	for a in amd64 arm64 s390x; do
+	for a in amd64 arm64 s390x ppc64le; do
 		echo "Building $a/$1"
 		mkdir -p "bin/$a"
 		CGO_ENABLED=0 GOARCH=$a \

--- a/platform/api/packet/api.go
+++ b/platform/api/packet/api.go
@@ -68,9 +68,10 @@ var (
 		"s390x-usr": "baremetal_3a",
 	}
 	linuxConsole = map[string]string{
-		"amd64-usr": "ttyS1,115200",
-		"arm64-usr": "ttyAMA0,115200",
-		"s390x-usr": "ttysclp0,115200",
+		"amd64-usr":   "ttyS1,115200",
+		"arm64-usr":   "ttyAMA0,115200",
+		"s390x-usr":   "ttysclp0,115200",
+		"ppc64le-usr": "hvc0,115200",
 	}
 )
 

--- a/system/arch.go
+++ b/system/arch.go
@@ -30,9 +30,7 @@ func PortageArch() string {
 	case "arm64":
 	case "ppc64":
 	case "s390x":
-	// Gentoo doesn't have a little-endian PPC port.
 	case "ppc64le":
-		fallthrough
 	default:
 		panic("No portage arch defined for " + arch)
 	}


### PR DESCRIPTION
This allows kola to be build and run on ppc64le, although the tests will not yet pass.

