### PR TITLE
*: add ssh-on-test-failure flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ heavy use of the native code interface.
 The `platform.Manhole()` function creates an interactive SSH session which can
 be used to inspect a machine during a test.
 
+The `--ssh-on-test-failure` flag can be specified to have the kola runner
+automatically SSH into a machine when any `MustSSH` calls fail.
+
 ### kolet
 kolet is run on kola instances to run native functions in tests. Generally kolet
 is not invoked manually.

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -66,6 +66,7 @@ func init() {
 	sv(&kola.UpdatePayloadFile, "update-payload", "", "Path to an update payload that should be made available to tests")
 	sv(&kola.Options.IgnitionVersion, "ignition-version", "", "Ignition version override: v2, v3")
 	ssv(&kola.BlacklistedTests, "blacklist-test", []string{}, "List of tests to blacklist")
+	bv(&kola.Options.SSHOnTestFailure, "ssh-on-test-failure", false, "SSH into a machine when tests fail")
 	// rhcos-specific options
 	sv(&kola.Options.OSContainer, "oscontainer", "", "oscontainer image pullspec for pivot (RHCOS only)")
 

--- a/kola/cluster/cluster.go
+++ b/kola/cluster/cluster.go
@@ -23,6 +23,11 @@ import (
 
 	"github.com/coreos/mantle/harness"
 	"github.com/coreos/mantle/platform"
+	"github.com/coreos/pkg/capnslog"
+)
+
+var (
+	plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "kola/cluster")
 )
 
 // TestCluster embedds a Cluster to provide platform independant helper
@@ -127,6 +132,10 @@ func (t *TestCluster) SSH(m platform.Machine, cmd string) ([]byte, error) {
 func (t *TestCluster) MustSSH(m platform.Machine, cmd string) []byte {
 	out, err := t.SSH(m, cmd)
 	if err != nil {
+		if t.SSHOnTestFailure() {
+			plog.Errorf("dropping to shell: %q failed: output %s, status %v", cmd, out, err)
+			platform.Manhole(m)
+		}
 		t.Fatalf("%q failed: output %s, status %v", cmd, out, err)
 	}
 	return out

--- a/platform/cluster.go
+++ b/platform/cluster.go
@@ -252,6 +252,10 @@ func (bc *BaseCluster) IgnitionVersion() string {
 	return bc.bf.baseopts.IgnitionVersion
 }
 
+func (bc *BaseCluster) SSHOnTestFailure() bool {
+	return bc.bf.baseopts.SSHOnTestFailure
+}
+
 func (bc *BaseCluster) Platform() Name {
 	return bc.bf.Platform()
 }

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -117,6 +117,10 @@ type Cluster interface {
 	// IgnitionVersion returns the version of Ignition supported by the
 	// cluster
 	IgnitionVersion() string
+
+	// SSHOnTestFailure returns whether the cluster should Manhole into
+	// a machine when a MustSSH call fails
+	SSHOnTestFailure() bool
 }
 
 // Flight represents a group of Clusters within a single platform.
@@ -158,6 +162,8 @@ type Options struct {
 	// When specified additional files & units will be automatically generated
 	// inside of RenderUserData
 	OSContainer string
+
+	SSHOnTestFailure bool
 }
 
 // RuntimeConfig contains cluster-specific configuration.


### PR DESCRIPTION
Adds a new flag that automatically manholes into a machine when a
MustSSH call fails.