### PR TITLE
platform/unprivqemu: Drop restrict=yes

### DIFF
--- a/platform/machine/unprivqemu/cluster.go
+++ b/platform/machine/unprivqemu/cluster.go
@@ -101,7 +101,7 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 
 	qc.mu.Lock()
 
-	qmCmd = append(qmCmd, "-netdev", "user,id=eth0,restrict=yes,hostfwd=tcp:127.0.0.1:0-:22", "-device", platform.Virtio(qc.flight.opts.Board, "net", "netdev=eth0"))
+	qmCmd = append(qmCmd, "-netdev", "user,id=eth0,hostfwd=tcp:127.0.0.1:0-:22", "-device", platform.Virtio(qc.flight.opts.Board, "net", "netdev=eth0"))
 
 	plog.Debugf("NewMachine: %q", qmCmd)
 


### PR DESCRIPTION
Denying external network access indirectly breaks the `podman.go`
tests because podman uses bridging by default, expecting `/etc/resolv.conf`
to exist on the host and dying messily if it isn't.

I don't know of a reason for us to do this by default - probably
what we should do is something like only use `restrict=yes` for
tests that aren't flagged as requiring network.

But for now, let's make unprivqemu work like the other platforms
by default.  (As much as it can; this uses usermode TCP which has
weird limitations like no ICMP, and bugs of course, but it does
mostly work for what we need)