### PR TITLE
Check endianness when getting the qemu port

### DIFF
--- a/platform/machine/unprivqemu/cluster.go
+++ b/platform/machine/unprivqemu/cluster.go
@@ -163,7 +163,13 @@ func getAddress(pid string) (string, error) {
 		remoteAddress := fields[2]
 		inode := fields[9]
 
-		isLocalPat := regexp.MustCompile("0100007F:[[:xdigit:]]{4}")
+		var isLocalPat *regexp.Regexp
+		if util.HostEndianness == util.LITTLE {
+			isLocalPat = regexp.MustCompile("0100007F:[[:xdigit:]]{4}")
+		} else {
+			isLocalPat = regexp.MustCompile("7F000001:[[:xdigit:]]{4}")
+		}
+
 		if !isLocalPat.MatchString(localAddress) || remoteAddress != "00000000:0000" {
 			continue
 		}

--- a/util/common.go
+++ b/util/common.go
@@ -14,6 +14,35 @@
 
 package util
 
+import (
+	"unsafe"
+)
+
+const (
+	LITTLE Endian = iota // little endian
+	BIG                  // big endian
+)
+
+// Endianness of the platform - big or little
+type Endian int
+
+var HostEndianness Endian
+
+func init() {
+	// Determine endianness - https://stackoverflow.com/questions/51332658/any-better-way-to-check-endianness-in-go
+	buf := [2]byte{}
+	*(*uint16)(unsafe.Pointer(&buf[0])) = uint16(0x0100)
+
+	switch buf {
+	case [2]byte{0x00, 0x01}:
+		HostEndianness = LITTLE
+	case [2]byte{0x01, 0x00}:
+		HostEndianness = BIG
+	default:
+		HostEndianness = LITTLE
+	}
+}
+
 func StrToPtr(s string) *string {
 	return &s
 }


### PR DESCRIPTION
When getting the qemu port, the list of connections in /proc/net/tcp is checked and the localhost address
is compares against. Ensure that the correct value is used for big and little endian arches

Potential fix for: #1068