### PR TITLE
podman: Also run tests on fcos

### DIFF
--- a/kola/tests/podman/podman.go
+++ b/kola/tests/podman/podman.go
@@ -38,21 +38,21 @@ func init() {
 		Run:         podmanBaseTest,
 		ClusterSize: 1,
 		Name:        `podman.base`,
-		Distros:     []string{"rhcos"},
+		Distros:     []string{"fcos", "rhcos"},
 	})
 	register.Register(&register.Test{
 		Run:         podmanWorkflow,
 		ClusterSize: 1,
 		Name:        `podman.workflow`,
 		Flags:       []register.Flag{register.RequiresInternetAccess}, // For pulling nginx
-		Distros:     []string{"rhcos"},
+		Distros:     []string{"fcos", "rhcos"},
 		FailFast:    true,
 	})
 	register.Register(&register.Test{
 		Run:         podmanNetworkTest,
 		ClusterSize: 2,
 		Name:        `podman.network`,
-		Distros:     []string{"rhcos"},
+		Distros:     []string{"fcos", "rhcos"},
 	})
 }
 


### PR DESCRIPTION
No reason why not to.

(Actually since mantle is branched we could probably just switch to
 assuming tests run on both but eh, later)