### PR TITLE
podman: Only run podman network tests on fcos, use --net=none some

### DIFF
--- a/kola/tests/util/containers.go
+++ b/kola/tests/util/containers.go
@@ -27,6 +27,6 @@ func GenPodmanScratchContainer(c cluster.TestCluster, m platform.Machine, name s
 	cmd := `tmpdir=$(mktemp -d); cd $tmpdir; echo -e "FROM scratch\nCOPY . /" > Dockerfile;
 	        b=$(which %s); libs=$(sudo ldd $b | grep -o /lib'[^ ]*' | sort -u);
 			sudo rsync -av --relative --copy-links $b $libs ./;
-			sudo podman build --layers=false -t localhost/%s .`
+			sudo podman build --network host --layers=false -t localhost/%s .`
 	c.MustSSH(m, fmt.Sprintf(cmd, strings.Join(binnames, " "), name))
 }


### PR DESCRIPTION
First, use `--net=none|host` where applicable unless we actually
*intend* to test networking.  Podman will by default allocate
a bridge even if all you wanted is e.g. some stdout from a container.

Second, only run the network tests on FCOS by default because
right now RHCOS has both `podman` and `cri-o` installed and
this causes networking issues:
https://bugzilla.redhat.com/show_bug.cgi?id=1757572

We do want the "base" podman sanity tests though since
that's how the OpenShift installer works on the bootstrap node.