### PR TITLE
Check for qemu-unpriv platform when converting board to arch

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -540,7 +540,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 // architecture returns the machine architecture of the given platform.
 func architecture(pltfrm string) string {
 	nativeArch := "amd64"
-	if pltfrm == "qemu" && QEMUOptions.Board != "" {
+	if (pltfrm == "qemu" || pltfrm == "qemu-unpriv") && QEMUOptions.Board != "" {
 		nativeArch = boardToArch(QEMUOptions.Board)
 	}
 	if pltfrm == "packet" && PacketOptions.Board != "" {


### PR DESCRIPTION
A minor fix for non x86 platforms to consider qemu-unpriv when getting the architecture in order
to retrieve the correct kolet binary

Closes: #1074