### PR TITLE
Some `kola spawn` enhancements

### DIFF
--- a/cmd/kola/spawn.go
+++ b/cmd/kola/spawn.go
@@ -51,6 +51,7 @@ var (
 	spawnDetach         bool
 	spawnOmahaPackage   string
 	spawnShell          bool
+	spawnIdle           bool
 	spawnRemove         bool
 	spawnVerbose        bool
 	spawnMachineOptions string
@@ -65,6 +66,7 @@ func init() {
 	cmdSpawn.Flags().BoolVarP(&spawnDetach, "detach", "t", false, "-kv --shell=false --remove=false")
 	cmdSpawn.Flags().StringVar(&spawnOmahaPackage, "omaha-package", "", "add an update payload to the Omaha server, referenced by image version (e.g. 'latest')")
 	cmdSpawn.Flags().BoolVarP(&spawnShell, "shell", "s", true, "spawn a shell in an instance before exiting")
+	cmdSpawn.Flags().BoolVarP(&spawnIdle, "idle", "", false, "idle after starting machines (implies --shell=false)")
 	cmdSpawn.Flags().BoolVarP(&spawnRemove, "remove", "r", true, "remove instances after shell exits")
 	cmdSpawn.Flags().BoolVarP(&spawnVerbose, "verbose", "v", false, "output information about spawned instances")
 	cmdSpawn.Flags().StringVar(&spawnMachineOptions, "qemu-options", "", "experimental: path to QEMU machine options JSON")
@@ -89,6 +91,10 @@ func doSpawn(cmd *cobra.Command, args []string) error {
 		spawnVerbose = true
 		spawnShell = false
 		spawnRemove = false
+	}
+
+	if spawnIdle {
+		spawnShell = false
 	}
 
 	if spawnNodeCount <= 0 {
@@ -244,6 +250,8 @@ func doSpawn(cmd *cobra.Command, args []string) error {
 		if err := platform.Manhole(someMach); err != nil {
 			return fmt.Errorf("Manhole failed: %v", err)
 		}
+	} else if spawnIdle {
+		select {}
 	}
 	return nil
 }

--- a/kola/tests/misc/raid.go
+++ b/kola/tests/misc/raid.go
@@ -118,9 +118,9 @@ func RootOnRaid(c cluster.TestCluster) {
 	// the golang compiler no longer checks that the individual types in the case have the
 	// NewMachineWithOptions function, but rather whether platform.Cluster does which fails
 	case *qemu.Cluster:
-		m, err = pc.NewMachineWithOptions(raidRootUserData, options)
+		m, err = pc.NewMachineWithOptions(raidRootUserData, options, true)
 	case *unprivqemu.Cluster:
-		m, err = pc.NewMachineWithOptions(raidRootUserData, options)
+		m, err = pc.NewMachineWithOptions(raidRootUserData, options, true)
 	default:
 		c.Fatal("unknown cluster type")
 	}

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -16,6 +16,7 @@ package platform
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -372,4 +373,22 @@ func CheckMachine(ctx context.Context, m Machine) error {
 	}
 
 	return ctx.Err()
+}
+
+type machineInfo struct {
+	Id        string `json:"id"`
+	PublicIp  string `json:"public_ip"`
+	OutputDir string `json:"output_dir"`
+}
+
+func WriteJSONInfo(m Machine, w io.Writer) error {
+	info := machineInfo{
+		Id:        m.ID(),
+		PublicIp:  m.IP(),
+		OutputDir: filepath.Join(m.RuntimeConf().OutputDir, m.ID()),
+	}
+	e := json.NewEncoder(w)
+	// disable pretty printing, so we emit newline-delimited streaming JSON objects
+	e.SetIndent("", "")
+	return e.Encode(info)
 }


### PR DESCRIPTION
As mentioned elsewhere, I'd like to use `kola spawn` in the rpm-ostree CI instead of re-inventing the wheel wrt bringing up temporary VMs, extracting the journal and console, etc... These sets of patches make it more useful for this purpose.

See individual commit messages for details.