### PR TITLE
kola: Remove podman network-multi test

### DIFF
--- a/kola/tests/podman/podman.go
+++ b/kola/tests/podman/podman.go
@@ -56,12 +56,13 @@ func init() {
 		Name:        `podman.network-single`,
 		Distros:     []string{"fcos"},
 	})
-	register.Register(&register.Test{
-		Run:         podmanNetworkTest,
-		ClusterSize: 2,
-		Name:        `podman.network-multi`,
-		Distros:     []string{"fcos"},
-	})
+	// https://github.com/coreos/mantle/pull/1080
+	// register.Register(&register.Test{
+	// 	Run:         podmanNetworkTest,
+	// 	ClusterSize: 2,
+	// 	Name:        `podman.network-multi`,
+	// 	Distros:     []string{"fcos"},
+	// })
 }
 
 // simplifiedContainerPsInfo represents a container entry in podman ps -a


### PR DESCRIPTION
I thought this passed at one time, but it seems to just hang
here.  I tried to debug it a little, but the expected flow here
is opaque to me, and it just doesn't seem worth it.

Bigger picture anyways, rather than inventing our own tests for most
upstream projects, we should run *their* tests that have
already been run in *their* CI too.  This is what I plan to
do for ostree/rpm-ostree at least with FCOS.  Basically download
tests from a container built from upstream sources, pull content
onto host and exec there.