### PR TITLE
network: Honor MANTLE_SSH_DIR

### DIFF
--- a/network/ssh.go
+++ b/network/ssh.go
@@ -68,9 +68,15 @@ func NewSSHAgent(dialer Dialer) (*SSHAgent, error) {
 		return nil, err
 	}
 
-	sockDir, err := ioutil.TempDir("", "mantle-ssh-")
-	if err != nil {
-		return nil, err
+	var sockDir string
+	var ok bool
+	// This will be set by at least `coreos-assembler kola` since
+	// we have an implicit workdir.
+	if sockDir, ok = os.LookupEnv("MANTLE_SSH_DIR"); !ok {
+		sockDir, err = ioutil.TempDir("", "mantle-ssh-")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Use a similar naming scheme to ssh-agent


### PR DESCRIPTION
I plan to use this for cosa to make it a bit easier to log in
manually to instances created by `cosa kola`.  It will be set
to a predictable path rather than a dir in `/tmp` that one may
have to hunt down.