### PR TITLE
kola: Note qemu-unpriv now has networking

### DIFF
--- a/kola/register/register.go
+++ b/kola/register/register.go
@@ -37,7 +37,6 @@ var (
 	// platforms that have no Internet access
 	PlatformsNoInternet = []string{
 		"qemu",
-		"qemu-unpriv",
 	}
 )
 


### PR DESCRIPTION
We just lifted the `restrict=yes` from the qemu-unpriv path
which fixed the podman tests, but didn't remove it from the
`PlatformsNoInternet` list.  This meant that we were still
skipping tests like `crio.base` that now *should* run with
qemu-unpriv.

(In the PR we discussed reworking all of this so that
 "no networking" is an opt-in thing for qemu-unpriv,
 which I'll do once we've drained the queue of other mantle PRs)