### PR TITLE
kola/tests: disable additional clustered tests on qemu-unpriv

### DIFF
--- a/kola/tests/crio/crio.go
+++ b/kola/tests/crio/crio.go
@@ -194,6 +194,8 @@ func init() {
 		Distros:     []string{"rhcos"},
 		UserData:    enableCrioIgn,
 		UserDataV3:  enableCrioIgnV3,
+		// qemu-unpriv machines cannot communicate between each other
+		ExcludePlatforms: []string{"qemu-unpriv"},
 	})
 }
 

--- a/kola/tests/etcd/rhcos.go
+++ b/kola/tests/etcd/rhcos.go
@@ -65,6 +65,8 @@ func init() {
 }`),
 		Flags:   []register.Flag{register.RequiresInternetAccess}, // fetching etcd requires networking
 		Distros: []string{"rhcos"},
+		// qemu-unpriv machines cannot communicate between each other
+		ExcludePlatforms: []string{"qemu-unpriv"},
 	})
 	register.Register(&register.Test{
 		Run:         rhcosClusterTLS,
@@ -123,6 +125,8 @@ func init() {
 }`),
 		Flags:   []register.Flag{register.RequiresInternetAccess}, // fetching etcd requires networking
 		Distros: []string{"rhcos"},
+		// qemu-unpriv machines cannot communicate between each other
+		ExcludePlatforms: []string{"qemu-unpriv"},
 	})
 }
 


### PR DESCRIPTION
A few of the tests were relying on the fact that they had flagged
themselves as requiring internet access to prevent being ran on
`qemu-unpriv` (which does not support clusters as machines cannot talk
to each other) that are now failing on the platform.