### PR TITLE
*: drop legacy names for Packet plans

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -133,7 +133,7 @@ func init() {
 	sv(&kola.PacketOptions.ApiKey, "packet-api-key", "", "Packet API key (overrides config file)")
 	sv(&kola.PacketOptions.Project, "packet-project", "", "Packet project UUID (overrides config file)")
 	sv(&kola.PacketOptions.Facility, "packet-facility", "sjc1", "Packet facility code")
-	sv(&kola.PacketOptions.Plan, "packet-plan", "", "Packet plan slug (default board-dependent, e.g. \"baremetal_0\")")
+	sv(&kola.PacketOptions.Plan, "packet-plan", "", "Packet plan slug (default board-dependent, e.g. \"t1.small.x86\")")
 	sv(&kola.PacketOptions.InstallerImageBaseURL, "packet-installer-image-base-url", "", "Packet installer image base URL, non-https (default board-dependent, e.g. \"http://stable.release.core-os.net/amd64-usr/current\")")
 	sv(&kola.PacketOptions.ImageURL, "packet-image-url", "", "Packet image URL (default board-dependent, e.g. \"https://alpha.release.core-os.net/amd64-usr/current/coreos_production_packet_image.bin.bz2\")")
 	sv(&kola.PacketOptions.StorageURL, "packet-storage-url", "gs://users.developer.core-os.net/"+os.Getenv("USER")+"/mantle", "Google Storage base URL for temporary uploads")

--- a/cmd/ore/packet/create-device.go
+++ b/cmd/ore/packet/create-device.go
@@ -40,7 +40,7 @@ var (
 func init() {
 	Packet.AddCommand(cmdCreateDevice)
 	cmdCreateDevice.Flags().StringVar(&options.Facility, "facility", "sjc1", "facility code")
-	cmdCreateDevice.Flags().StringVar(&options.Plan, "plan", "", "plan slug (default board-dependent, e.g. \"baremetal_0\")")
+	cmdCreateDevice.Flags().StringVar(&options.Plan, "plan", "", "plan slug (default board-dependent, e.g. \"t1.small.x86\")")
 	cmdCreateDevice.Flags().StringVar(&options.Board, "board", "amd64-usr", "Container Linux board")
 	cmdCreateDevice.Flags().StringVar(&options.InstallerImageBaseURL, "installer-image-base-url", "", "installer image base URL, non-https (default board-dependent, e.g. \"http://stable.release.core-os.net/amd64-usr/current\")")
 	cmdCreateDevice.Flags().StringVar(&options.ImageURL, "image-url", "", "image base URL (default board-dependent, e.g. \"https://alpha.release.core-os.net/amd64-usr/current/coreos_production_packet_image.bin.bz2\")")

--- a/platform/api/packet/api.go
+++ b/platform/api/packet/api.go
@@ -63,9 +63,8 @@ var (
 		"arm64-usr": "https://alpha.release.core-os.net/arm64-usr/current/coreos_production_packet_image.bin.bz2",
 	}
 	defaultPlan = map[string]string{
-		"amd64-usr": "baremetal_0",
-		"arm64-usr": "baremetal_2a",
-		"s390x-usr": "baremetal_3a",
+		"amd64-usr": "t1.small.x86",
+		"arm64-usr": "c1.large.arm",
 	}
 	linuxConsole = map[string]string{
 		"amd64-usr":   "ttyS1,115200",
@@ -89,7 +88,7 @@ type Options struct {
 
 	// Packet location code
 	Facility string
-	// Slug of the device type (e.g. "baremetal_0")
+	// Slug of the device type (e.g. "t1.small.x86")
 	Plan string
 	// The Container Linux board name
 	Board string


### PR DESCRIPTION
Drop bogus `baremetal_3a` plan for s390x.