### PR TITLE
kola/tests: exclude all coreos-cloudinit tests on Packet

### DIFF
--- a/kola/tests/docker/torcx_docker_flag.go
+++ b/kola/tests/docker/torcx_docker_flag.go
@@ -49,8 +49,10 @@ write_files:
   - path: "/etc/coreos/docker-1.12"
     content: yes
 `),
-		Distros:          []string{"cl"},
-		ExcludePlatforms: []string{"qemu-unpriv"},
+		Distros: []string{"cl"},
+		// tcsd.service can't be effectively disabled from
+		// cloud-config on Packet
+		ExcludePlatforms: []string{"qemu-unpriv", "packet"},
 	})
 }
 

--- a/kola/tests/kubernetes/kubelet_wrapper.go
+++ b/kola/tests/kubernetes/kubelet_wrapper.go
@@ -54,6 +54,9 @@ systemd:
 `),
 		Flags:   []register.Flag{register.RequiresInternetAccess}, // network access for hyperkube
 		Distros: []string{"cl"},
+		// tcsd.service can't be effectively disabled from
+		// cloud-config on Packet, and setupCluster() uses one
+		ExcludePlatforms: []string{"packet"},
 	})
 }
 

--- a/kola/tests/misc/cloudinit.go
+++ b/kola/tests/misc/cloudinit.go
@@ -32,8 +32,10 @@ hostname: "core1"
 write_files:
   - path: "/foo"
     content: bar`),
-		Distros:          []string{"cl"},
-		ExcludePlatforms: []string{"qemu-unpriv"},
+		Distros: []string{"cl"},
+		// tcsd.service can't be effectively disabled from
+		// cloud-config on Packet
+		ExcludePlatforms: []string{"qemu-unpriv", "packet"},
 	})
 	register.Register(&register.Test{
 		Run:         CloudInitScript,
@@ -48,8 +50,10 @@ EOF
 chown -R core.core ~core/.ssh
 chmod 700 ~core/.ssh
 chmod 600 ~core/.ssh/authorized_keys`),
-		Distros:          []string{"cl"},
-		ExcludePlatforms: []string{"qemu-unpriv"},
+		Distros: []string{"cl"},
+		// tcsd.service can't be effectively disabled from
+		// script on Packet
+		ExcludePlatforms: []string{"qemu-unpriv", "packet"},
 	})
 }
 

--- a/kola/tests/misc/grub.go
+++ b/kola/tests/misc/grub.go
@@ -147,13 +147,15 @@ coreos:
 
 func init() {
 	register.Register(&register.Test{
-		Run:              UpdateGrubNop,
-		ClusterSize:      1,
-		Name:             "cl.update.grubnop",
-		UserData:         grubUpdaterConf,
-		MinVersion:       semver.Version{Major: 1745},
-		Distros:          []string{"cl"},
-		ExcludePlatforms: []string{"qemu-unpriv"},
+		Run:         UpdateGrubNop,
+		ClusterSize: 1,
+		Name:        "cl.update.grubnop",
+		UserData:    grubUpdaterConf,
+		MinVersion:  semver.Version{Major: 1745},
+		Distros:     []string{"cl"},
+		// tcsd.service can't be effectively disabled from
+		// cloud-config on Packet
+		ExcludePlatforms: []string{"qemu-unpriv", "packet"},
 	})
 }
 


### PR DESCRIPTION
Avoid more tcsd.service flakes.