### PR TITLE
kola/tests/rpmostree: use NVR instead of NVRA

### DIFF
--- a/kola/tests/rpmostree/deployments.go
+++ b/kola/tests/rpmostree/deployments.go
@@ -285,8 +285,7 @@ func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 		}
 
 		rpmOut := c.MustSSH(m, "rpm -q "+installPkgName)
-		// forcing use of x86_64; may need to adapt this in the future
-		rpmRegex := "^" + installPkgName + ".*x86_64"
+		rpmRegex := "^" + installPkgName
 		rpmMatch := regexp.MustCompile(rpmRegex).MatchString(string(rpmOut))
 		if !rpmMatch {
 			c.Fatalf(`Output from "rpm -q" was unexpected: %q`, string(rpmOut))


### PR DESCRIPTION
Drop the Architecture from the NVRA in the check as it can only pass on the hard coded A. Is there any reason to have the A checked there? i386(stray multilib package)?