### PR TITLE
auth/aliyun: fix parsing config file

### DIFF
--- a/auth/aliyun.go
+++ b/auth/aliyun.go
@@ -31,6 +31,10 @@ type AliyunProfile struct {
 	Region          string `json:"region_id"`
 }
 
+type AliyunConfig struct {
+	Profiles []AliyunProfile `json:"profiles"`
+}
+
 // ReadAliyunConfig decodes an aliyun config file
 //
 // If path is empty, $HOME/.aliyun/config.json is read.
@@ -49,16 +53,16 @@ func ReadAliyunConfig(path string) (map[string]AliyunProfile, error) {
 	}
 	defer f.Close()
 
-	var profiles []AliyunProfile
-	if err := json.NewDecoder(f).Decode(&profiles); err != nil {
+	var config AliyunConfig
+	if err := json.NewDecoder(f).Decode(&config); err != nil {
 		return nil, err
 	}
-	if len(profiles) == 0 {
+	if len(config.Profiles) == 0 {
 		return nil, fmt.Errorf("aliyun config %q contains no profiles", path)
 	}
 
 	retProfiles := make(map[string]AliyunProfile)
-	for _, p := range profiles {
+	for _, p := range config.Profiles {
 		retProfiles[p.Name] = p
 	}
 


### PR DESCRIPTION
The code is expecting `~/.aliyun/config.json` to be a list of profiles,
but the one I have (that was created by the `aliyun` CLI) is an object
where the `profiles` key is a list of profile objects:

```
{
  "current": "default",
  "profiles": [
    {
      "name": "default",
      "access_key_id": "...",
      "access_key_secret": "...",
      "region_id": "...",
      ...
    }
  ],
  "meta_path": ""
}
```

Fix the code to adapt to this.