### PR TITLE
ore/aliyun: add --delete-object and default to true

### DIFF
--- a/cmd/ore/aliyun/create-image.go
+++ b/cmd/ore/aliyun/create-image.go
@@ -44,6 +44,7 @@ After a successful run, the final line of output will be the ID of the image.
 	architecture string
 	force        bool
 	sizeInspect  bool
+	deleteObject bool
 )
 
 func init() {
@@ -58,6 +59,7 @@ func init() {
 	cmdCreate.Flags().StringVar(&architecture, "architecture", "x86_64", "image architecture")
 	cmdCreate.Flags().StringVar(&name, "name", "", "image name")
 	cmdCreate.Flags().BoolVar(&force, "force", false, "overwrite any existing object storage")
+	cmdCreate.Flags().BoolVar(&deleteObject, "delete-object", true, "delete uploaded OSS object after image is created")
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
@@ -89,6 +91,14 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "Couldn't create image: %v\n", err)
 		os.Exit(1)
 	}
+
+	if deleteObject {
+		if err := API.DeleteFile(bucket, name); err != nil {
+			fmt.Fprintf(os.Stderr, "Deleting image from object storage: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
 	fmt.Println(id)
 	return nil
 }

--- a/platform/api/aliyun/api.go
+++ b/platform/api/aliyun/api.go
@@ -249,6 +249,16 @@ func (a *API) UploadFile(filepath, bucket, path string, force bool) error {
 	return bucketClient.UploadFile(path, filepath, 1000*1024, oss.Routines(10))
 }
 
+// DeleteFile deletes a file from an OSS bucket
+func (a *API) DeleteFile(bucket, path string) error {
+	bucketClient, err := a.oss.Bucket(bucket)
+	if err != nil {
+		return fmt.Errorf("getting bucket %q: %v", bucket, err)
+	}
+
+	return bucketClient.DeleteObject(path)
+}
+
 // PutObject performs a singlepart upload into an OSS bucket
 func (a *API) PutObject(r io.Reader, bucket, path string, force bool) error {
 	bucketClient, err := a.oss.Bucket(bucket)

--- a/platform/api/aliyun/api.go
+++ b/platform/api/aliyun/api.go
@@ -139,6 +139,7 @@ func (a *API) ImportImage(format, bucket, object, image_size, device, name, desc
 		}
 
 		for _, image := range images.Images.Image {
+			plog.Infof("deleting pre-existing image %v", image.ImageId)
 			err = a.DeleteImage(image.ImageId, force)
 			if err != nil {
 				return "", fmt.Errorf("deleting image %v: %v", image.ImageId, err)
@@ -161,6 +162,7 @@ func (a *API) ImportImage(format, bucket, object, image_size, device, name, desc
 	request.Description = description
 	request.Architecture = architecture
 
+	plog.Infof("importing image")
 	response, err := a.ecs.ImportImage(request)
 	if err != nil {
 		return "", fmt.Errorf("importing image: %v", err)
@@ -246,6 +248,7 @@ func (a *API) UploadFile(filepath, bucket, path string, force bool) error {
 	}
 
 	// Use 1000K part size with 10 coroutines to speed up the upload
+	plog.Infof("uploading oss://%v/%v", bucket, path)
 	return bucketClient.UploadFile(path, filepath, 1000*1024, oss.Routines(10))
 }
 
@@ -256,6 +259,7 @@ func (a *API) DeleteFile(bucket, path string) error {
 		return fmt.Errorf("getting bucket %q: %v", bucket, err)
 	}
 
+	plog.Infof("deleting oss://%v/%v", bucket, path)
 	return bucketClient.DeleteObject(path)
 }
 


### PR DESCRIPTION
Match what `ore aws upload` does and delete the OSS file by default
after the image was successfully uploaded. Then the GC strategy for
pipelines is just about cleaning up old images, and we don't have to
worry about the bucket too.

Closes: #1106