### PR TITLE
kola: Add a test that /etc/sysconfig/network-scripts is empty

### DIFF
--- a/kola/tests/coretest/core.go
+++ b/kola/tests/coretest/core.go
@@ -3,6 +3,7 @@ package coretest
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -70,6 +71,7 @@ func init() {
 		NativeFuncs: map[string]func() error{
 			"PortSSH":          TestPortSsh,
 			"DbusPerms":        TestDbusPerms,
+			"NetworkScripts":   TestNetworkScripts,
 			"ServicesActive":   TestServicesActiveCoreOS,
 			"ServicesDisabled": TestServicesDisabledRHCOS,
 			"ReadOnly":         TestReadOnlyFs,
@@ -85,6 +87,7 @@ func init() {
 		NativeFuncs: map[string]func() error{
 			"PortSSH":        TestPortSsh,
 			"DbusPerms":      TestDbusPerms,
+			"NetworkScripts": TestNetworkScripts,
 			"ServicesActive": TestServicesActiveCoreOS,
 			"ReadOnly":       TestReadOnlyFs,
 			"Useradd":        TestUseradd,
@@ -353,6 +356,21 @@ func TestReadOnlyFs() error {
 		}
 	}
 	return fmt.Errorf("could not find /usr or / mount points.")
+}
+
+func TestNetworkScripts() error {
+	networkScriptsDir := "/etc/sysconfig/network-scripts"
+	entries, err := ioutil.ReadDir(networkScriptsDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+	if len(entries) > 0 {
+		return fmt.Errorf("Found content in %s", networkScriptsDir)
+	}
+	return nil
 }
 
 // Test that the root disk's GUID was set to a random one on first boot.


### PR DESCRIPTION
We shouldn't be writing anything to it, and this regressed
in RHCOS.
See https://bugzilla.redhat.com/show_bug.cgi?id=1762509