### PR TITLE
Change kola rpmostree install/unistall test package to epel 8 and bird

### DIFF
--- a/kola/tests/rpmostree/deployments.go
+++ b/kola/tests/rpmostree/deployments.go
@@ -53,7 +53,7 @@ func init() {
           "name": "root"
         },
         "contents": {
-          "source": "data:,%5Bepel%5D%0Aname%3DExtra%20Packages%20for%20Enterprise%20Linux%207%20-%20%24basearch%0Ametalink%3Dhttps%3A%2F%2Fmirrors.fedoraproject.org%2Fmetalink%3Frepo%3Depel-7%26arch%3D%24basearch%0Afailovermethod%3Dpriority%0Aenabled%3D1%0Agpgcheck%3D1%0Agpgkey%3Dfile%3A%2F%2F%2Fetc%2Fpki%2Frpm-gpg%2FRPM-GPG-KEY-EPEL-7%0A"
+          "source": "data:,%5Bepel%5D%0Aname%3DExtra%20Packages%20for%20Enterprise%20Linux%208%20-%20%24basearch%0Ametalink%3Dhttps%3A%2F%2Fmirrors.fedoraproject.org%2Fmetalink%3Frepo%3Depel-8%26arch%3D%24basearch%0Afailovermethod%3Dpriority%0Aenabled%3D1%0Agpgcheck%3D1%0Agpgkey%3Dfile%3A%2F%2F%2Fetc%2Fpki%2Frpm-gpg%2FRPM-GPG-KEY-EPEL-8%0A"
         },
         "mode": 420
       },
@@ -62,12 +62,12 @@ func init() {
         "group": {
           "name": "root"
         },
-        "path": "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7",
+        "path": "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8",
         "user": {
           "name": "root"
         },
         "contents": {
-          "source": "data:,-----BEGIN%20PGP%20PUBLIC%20KEY%20BLOCK-----%0AVersion%3A%20GnuPG%20v1.4.11%20(GNU%2FLinux)%0A%0AmQINBFKuaIQBEAC1UphXwMqCAarPUH%2FZsOFslabeTVO2pDk5YnO96f%2BrgZB7xArB%0AOSeQk7B90iqSJ85%2Fc72OAn4OXYvT63gfCeXpJs5M7emXkPsNQWWSju99lW%2BAqSNm%0AjYWhmRlLRGl0OO7gIwj776dIXvcMNFlzSPj00N2xAqjMbjlnV2n2abAE5gq6VpqP%0AvFXVyfrVa%2FualogDVmf6h2t4Rdpifq8qTHsHFU3xpCz%2BT6%2FdGWKGQ42ZQfTaLnDM%0AjToAsmY0AyevkIbX6iZVtzGvanYpPcWW4X0RDPcpqfFNZk643xI4lsZ%2BY2Er9Yu5%0AS%2F8x0ly%2BtmmIokaE0wwbdUu740YTZjCesroYWiRg5zuQ2xfKxJoV5E%2BEh%2BtYwGDJ%0An6HfWhRgnudRRwvuJ45ztYVtKulKw8QQpd2STWrcQQDJaRWmnMooX%2FPATTjCBExB%0A9dkz38Druvk7IkHMtsIqlkAOQMdsX1d3Tov6BE2XDjIG0zFxLduJGbVwc%2F6rIc95%0AT055j36Ez0HrjxdpTGOOHxRqMK5m9flFbaxxtDnS7w77WqzW7HjFrD0VeTx2vnjj%0AGqchHEQpfDpFOzb8LTFhgYidyRNUflQY35WLOzLNV%2BpV3eQ3Jg11UFwelSNLqfQf%0AuFRGc%2BzcwkNjHh5yPvm9odR1BIfqJ6sKGPGbtPNXo7ERMRypWyRz0zi0twARAQAB%0AtChGZWRvcmEgRVBFTCAoNykgPGVwZWxAZmVkb3JhcHJvamVjdC5vcmc%2BiQI4BBMB%0AAgAiBQJSrmiEAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAKCRBqL66iNSxk%0A5cfGD%2F4spqpsTjtDM7qpytKLHKruZtvuWiqt5RfvT9ww9GUUFMZ4ZZGX4nUXg49q%0AixDLayWR8ddG%2Fs5kyOi3C0uX%2F6inzaYyRg%2BBh70brqKUK14F1BrrPi29eaKfG%2BGu%0AMFtXdBG2a7OtPmw3yuKmq9Epv6B0mP6E5KSdvSRSqJWtGcA6wRS%2FwDzXJENHp5re%0A9Ism3CYydpy0GLRA5wo4fPB5uLdUhLEUDvh2KK%2F%2FfMjja3o0L%2BSNz8N0aDZyn5Ax%0ACU9RB3EHcTecFgoy5umRj99BZrebR1NO%2B4gBrivIfdvD4fJNfNBHXwhSH9ACGCNv%0AHnXVjHQF9iHWApKkRIeh8Fr2n5dtfJEF7SEX8GbX7FbsWo29kXMrVgNqHNyDnfAB%0AVoPubgQdtJZJkVZAkaHrMu8AytwT62Q4eNqmJI1aWbZQNI5jWYqc6RKuCK6%2FF99q%0AthFT9gJO17%2ByRuL6Uv2%2FvgzVR1RGdwVLKwlUjGPAjYflpCQwWMAASxiv9uPyYPHc%0AErSrbRG0wjIfAR3vus1OSOx3xZHZpXFfmQTsDP7zVROLzV98R3JwFAxJ4%2FxqeON4%0AvCPFU6OsT3lWQ8w7il5ohY95wmujfr6lk89kEzJdOTzcn7DBbUru33CQMGKZ3Evt%0ARjsC7FDbL017qxS%2BZVA%2FHGkyfiu4cpgV8VUnbql5eAZ%2B1Ll6Dw%3D%3D%0A%3DhdPa%0A-----END%20PGP%20PUBLIC%20KEY%20BLOCK-----%0A"
+          "source": "data:text/plain;charset=utf-8,-----BEGIN%20PGP%20PUBLIC%20KEY%20BLOCK-----%0D%0A%0D%0AmQINBFz3zvsBEADJOIIWllGudxnpvJnkxQz2CtoWI7godVnoclrdl83kVjqSQp%2B2%0D%0AdgxuG5mUiADUfYHaRQzxKw8efuQnwxzU9kZ70ngCxtmbQWGmUmfSThiapOz00018%0D%0A%2Beo5MFabd2vdiGo1y%2B51m2sRDpN8qdCaqXko65cyMuLXrojJHIuvRA%2Fx7iqOrRfy%0D%0Aa8x3OxC4PEgl5pgDnP8pVK0lLYncDEQCN76D9ubhZQWhISF%2FzJI%2Be806V71hzfyL%0D%0A%2FMt3mQm%2Fli%2BlRKU25Usk9dWaf4NH%2FwZHMIPAkVJ4uD4H%2FuS49wqWnyiTYGT7hUbi%0D%0AecF7crhLCmlRzvJR8mkRP6%2F4T%2FF3tNDPWZeDNEDVFUkTFHNU6%2Fh2%2BO398MNY%2FfOh%0D%0AyKaNK3nnE0g6QJ1dOH31lXHARlpFOtWt3VmZU0JnWLeYdvap4Eff9qTWZJhI7Cq0%0D%0AWm8DgLUpXgNlkmquvE7P2W5EAr2E5AqKQoDbfw%2FGiWdRvHWKeNGMRLnGI3QuoX3U%0D%0ApAlXD7v13VdZxNydvpeypbf%2FAfRyrHRKhkUj3cU1pYkM3DNZE77C5JUe6%2F0nxbt4%0D%0AETUZBTgLgYJGP8c7PbkVnO6I%2FKgL1jw%2B7MW6Az8Ox%2BRXZLyGMVmbW%2FTMc8haJfKL%0D%0AMoUo3TVk8nPiUhoOC0%2FkI7j9ilFrBxBU5dUtF4ITAWc8xnG6jJs%2FIsvRpQARAQAB%0D%0AtChGZWRvcmEgRVBFTCAoOCkgPGVwZWxAZmVkb3JhcHJvamVjdC5vcmc%2BiQI4BBMB%0D%0AAgAiBQJc9877AhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAKCRAh6kWrL4bW%0D%0AoWagD%2F4xnLWws34GByVDQkjprk0fX7Iyhpm%2FU7BsIHKspHLL%2BY46vAAGY%2F9vMvdE%0D%0A0fcr9Ek2Zp7zE1RWmSCzzzUgTG6BFoTG1H4Fho%2F7Z8BXK%2FjybowXSZfqXnTOfhSF%0D%0AalwDdwlSJvfYNV9MbyvbxN8qZRU1z7PEWZrIzFDDToFRk0R71zHpnPTNIJ5%2FYXTw%0D%0ANqU9OxII8hMQj4ufF11040AJQZ7br3rzerlyBOB%2BJd1zSPVrAPpeMyJppWFHSDAI%0D%0AWK6x%2Bam13VIInXtqB%2FCz4GBHLFK5d2%2FIYspVw47Solj8jiFEtnAq6%2B1Aq5WH3iB4%0D%0AbE2e6z00DSF93frwOyWN7WmPIoc2QsNRJhgfJC%2BisGQAwwq8xAbHEBeuyMG8GZjz%0D%0Axohg0H4bOSEujVLTjH1xbAG4DnhWO%2F1VXLX%2BLXELycO8ZQTcjj%2F4AQKuo4wvMPrv%0D%0A9A169oETG%2BVwQlNd74VBPGCvhnzwGXNbTK%2FKH1%2BWRH0YSb%2B41flB3NKhMSU6dGI0%0D%0ASGtIxDSHhVVNmx2%2F6XiT9U%2FznrZsG5Kw8nIbbFz%2B9MGUUWgJMsd1Zl9R8gz7V9fp%0D%0An7L7y5LhJ8HOCMsY%2FZ7%2F7HUs%2Bt%2FA1MI4g7Q5g5UuSZdgi0zxukiWuCkLeAiAP4y7%0D%0AzKK4OjJ644NDcWCHa36znwVmkz3ixL8Q0auR15Oqq2BjR%2Ffyog%3D%3D%0D%0A%3D84m8%0D%0A-----END%20PGP%20PUBLIC%20KEY%20BLOCK-----%0A"
         },
         "mode": 420
       }
@@ -89,7 +89,7 @@ func init() {
           "name": "root"
         },
         "contents": {
-          "source": "data:,%5Bepel%5D%0Aname%3DExtra%20Packages%20for%20Enterprise%20Linux%207%20-%20%24basearch%0Ametalink%3Dhttps%3A%2F%2Fmirrors.fedoraproject.org%2Fmetalink%3Frepo%3Depel-7%26arch%3D%24basearch%0Afailovermethod%3Dpriority%0Aenabled%3D1%0Agpgcheck%3D1%0Agpgkey%3Dfile%3A%2F%2F%2Fetc%2Fpki%2Frpm-gpg%2FRPM-GPG-KEY-EPEL-7%0A"
+          "source": "data:,%5Bepel%5D%0Aname%3DExtra%20Packages%20for%20Enterprise%20Linux%208%20-%20%24basearch%0Ametalink%3Dhttps%3A%2F%2Fmirrors.fedoraproject.org%2Fmetalink%3Frepo%3Depel-8%26arch%3D%24basearch%0Afailovermethod%3Dpriority%0Aenabled%3D1%0Agpgcheck%3D1%0Agpgkey%3Dfile%3A%2F%2F%2Fetc%2Fpki%2Frpm-gpg%2FRPM-GPG-KEY-EPEL-8%0A"
         },
         "mode": 420
       },
@@ -97,12 +97,12 @@ func init() {
         "group": {
           "name": "root"
         },
-        "path": "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7",
+        "path": "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8",
         "user": {
           "name": "root"
         },
         "contents": {
-          "source": "data:,-----BEGIN%20PGP%20PUBLIC%20KEY%20BLOCK-----%0AVersion%3A%20GnuPG%20v1.4.11%20(GNU%2FLinux)%0A%0AmQINBFKuaIQBEAC1UphXwMqCAarPUH%2FZsOFslabeTVO2pDk5YnO96f%2BrgZB7xArB%0AOSeQk7B90iqSJ85%2Fc72OAn4OXYvT63gfCeXpJs5M7emXkPsNQWWSju99lW%2BAqSNm%0AjYWhmRlLRGl0OO7gIwj776dIXvcMNFlzSPj00N2xAqjMbjlnV2n2abAE5gq6VpqP%0AvFXVyfrVa%2FualogDVmf6h2t4Rdpifq8qTHsHFU3xpCz%2BT6%2FdGWKGQ42ZQfTaLnDM%0AjToAsmY0AyevkIbX6iZVtzGvanYpPcWW4X0RDPcpqfFNZk643xI4lsZ%2BY2Er9Yu5%0AS%2F8x0ly%2BtmmIokaE0wwbdUu740YTZjCesroYWiRg5zuQ2xfKxJoV5E%2BEh%2BtYwGDJ%0An6HfWhRgnudRRwvuJ45ztYVtKulKw8QQpd2STWrcQQDJaRWmnMooX%2FPATTjCBExB%0A9dkz38Druvk7IkHMtsIqlkAOQMdsX1d3Tov6BE2XDjIG0zFxLduJGbVwc%2F6rIc95%0AT055j36Ez0HrjxdpTGOOHxRqMK5m9flFbaxxtDnS7w77WqzW7HjFrD0VeTx2vnjj%0AGqchHEQpfDpFOzb8LTFhgYidyRNUflQY35WLOzLNV%2BpV3eQ3Jg11UFwelSNLqfQf%0AuFRGc%2BzcwkNjHh5yPvm9odR1BIfqJ6sKGPGbtPNXo7ERMRypWyRz0zi0twARAQAB%0AtChGZWRvcmEgRVBFTCAoNykgPGVwZWxAZmVkb3JhcHJvamVjdC5vcmc%2BiQI4BBMB%0AAgAiBQJSrmiEAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAKCRBqL66iNSxk%0A5cfGD%2F4spqpsTjtDM7qpytKLHKruZtvuWiqt5RfvT9ww9GUUFMZ4ZZGX4nUXg49q%0AixDLayWR8ddG%2Fs5kyOi3C0uX%2F6inzaYyRg%2BBh70brqKUK14F1BrrPi29eaKfG%2BGu%0AMFtXdBG2a7OtPmw3yuKmq9Epv6B0mP6E5KSdvSRSqJWtGcA6wRS%2FwDzXJENHp5re%0A9Ism3CYydpy0GLRA5wo4fPB5uLdUhLEUDvh2KK%2F%2FfMjja3o0L%2BSNz8N0aDZyn5Ax%0ACU9RB3EHcTecFgoy5umRj99BZrebR1NO%2B4gBrivIfdvD4fJNfNBHXwhSH9ACGCNv%0AHnXVjHQF9iHWApKkRIeh8Fr2n5dtfJEF7SEX8GbX7FbsWo29kXMrVgNqHNyDnfAB%0AVoPubgQdtJZJkVZAkaHrMu8AytwT62Q4eNqmJI1aWbZQNI5jWYqc6RKuCK6%2FF99q%0AthFT9gJO17%2ByRuL6Uv2%2FvgzVR1RGdwVLKwlUjGPAjYflpCQwWMAASxiv9uPyYPHc%0AErSrbRG0wjIfAR3vus1OSOx3xZHZpXFfmQTsDP7zVROLzV98R3JwFAxJ4%2FxqeON4%0AvCPFU6OsT3lWQ8w7il5ohY95wmujfr6lk89kEzJdOTzcn7DBbUru33CQMGKZ3Evt%0ARjsC7FDbL017qxS%2BZVA%2FHGkyfiu4cpgV8VUnbql5eAZ%2B1Ll6Dw%3D%3D%0A%3DhdPa%0A-----END%20PGP%20PUBLIC%20KEY%20BLOCK-----%0A"
+          "source": "data:text/plain;charset=utf-8,-----BEGIN%20PGP%20PUBLIC%20KEY%20BLOCK-----%0D%0A%0D%0AmQINBFz3zvsBEADJOIIWllGudxnpvJnkxQz2CtoWI7godVnoclrdl83kVjqSQp%2B2%0D%0AdgxuG5mUiADUfYHaRQzxKw8efuQnwxzU9kZ70ngCxtmbQWGmUmfSThiapOz00018%0D%0A%2Beo5MFabd2vdiGo1y%2B51m2sRDpN8qdCaqXko65cyMuLXrojJHIuvRA%2Fx7iqOrRfy%0D%0Aa8x3OxC4PEgl5pgDnP8pVK0lLYncDEQCN76D9ubhZQWhISF%2FzJI%2Be806V71hzfyL%0D%0A%2FMt3mQm%2Fli%2BlRKU25Usk9dWaf4NH%2FwZHMIPAkVJ4uD4H%2FuS49wqWnyiTYGT7hUbi%0D%0AecF7crhLCmlRzvJR8mkRP6%2F4T%2FF3tNDPWZeDNEDVFUkTFHNU6%2Fh2%2BO398MNY%2FfOh%0D%0AyKaNK3nnE0g6QJ1dOH31lXHARlpFOtWt3VmZU0JnWLeYdvap4Eff9qTWZJhI7Cq0%0D%0AWm8DgLUpXgNlkmquvE7P2W5EAr2E5AqKQoDbfw%2FGiWdRvHWKeNGMRLnGI3QuoX3U%0D%0ApAlXD7v13VdZxNydvpeypbf%2FAfRyrHRKhkUj3cU1pYkM3DNZE77C5JUe6%2F0nxbt4%0D%0AETUZBTgLgYJGP8c7PbkVnO6I%2FKgL1jw%2B7MW6Az8Ox%2BRXZLyGMVmbW%2FTMc8haJfKL%0D%0AMoUo3TVk8nPiUhoOC0%2FkI7j9ilFrBxBU5dUtF4ITAWc8xnG6jJs%2FIsvRpQARAQAB%0D%0AtChGZWRvcmEgRVBFTCAoOCkgPGVwZWxAZmVkb3JhcHJvamVjdC5vcmc%2BiQI4BBMB%0D%0AAgAiBQJc9877AhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAKCRAh6kWrL4bW%0D%0AoWagD%2F4xnLWws34GByVDQkjprk0fX7Iyhpm%2FU7BsIHKspHLL%2BY46vAAGY%2F9vMvdE%0D%0A0fcr9Ek2Zp7zE1RWmSCzzzUgTG6BFoTG1H4Fho%2F7Z8BXK%2FjybowXSZfqXnTOfhSF%0D%0AalwDdwlSJvfYNV9MbyvbxN8qZRU1z7PEWZrIzFDDToFRk0R71zHpnPTNIJ5%2FYXTw%0D%0ANqU9OxII8hMQj4ufF11040AJQZ7br3rzerlyBOB%2BJd1zSPVrAPpeMyJppWFHSDAI%0D%0AWK6x%2Bam13VIInXtqB%2FCz4GBHLFK5d2%2FIYspVw47Solj8jiFEtnAq6%2B1Aq5WH3iB4%0D%0AbE2e6z00DSF93frwOyWN7WmPIoc2QsNRJhgfJC%2BisGQAwwq8xAbHEBeuyMG8GZjz%0D%0Axohg0H4bOSEujVLTjH1xbAG4DnhWO%2F1VXLX%2BLXELycO8ZQTcjj%2F4AQKuo4wvMPrv%0D%0A9A169oETG%2BVwQlNd74VBPGCvhnzwGXNbTK%2FKH1%2BWRH0YSb%2B41flB3NKhMSU6dGI0%0D%0ASGtIxDSHhVVNmx2%2F6XiT9U%2FznrZsG5Kw8nIbbFz%2B9MGUUWgJMsd1Zl9R8gz7V9fp%0D%0An7L7y5LhJ8HOCMsY%2FZ7%2F7HUs%2Bt%2FA1MI4g7Q5g5UuSZdgi0zxukiWuCkLeAiAP4y7%0D%0AzKK4OjJ644NDcWCHa36znwVmkz3ixL8Q0auR15Oqq2BjR%2Ffyog%3D%3D%0D%0A%3D84m8%0D%0A-----END%20PGP%20PUBLIC%20KEY%20BLOCK-----%0A"
         },
         "mode": 420
       }
@@ -231,20 +231,21 @@ func rpmOstreeUpgradeRollback(c cluster.TestCluster) {
 // rpmOstreeInstallUninstall verifies that we can install a package
 // and then uninstall it
 //
-// 'bcrypt' is available in EPEL and installs on Fedora 29 and RHEL 8
+// 'bird' is available in EPEL(8) and installs on Fedora 29 and RHEL 8
+// on all arches
 //
 // NOTE: we could be churning on the package choice going forward as
 // we need something that is a) small, b) has no dependencies, and c)
-// can be installed on Fedora + RHEL from the EPEL repo that we are
-// currently using.  We've already had to swap from `fpaste` to `bcrypt`
+// can be installed on Fedora + RHEL + all arches from the EPEL repo that we are
+// currently using.  We've already had to swap from `fpaste`-`bcrypt`-`bird`
 func rpmOstreeInstallUninstall(c cluster.TestCluster) {
-	var installPkgName = "bcrypt"
+	var installPkgName = "bird"
 	var installPkgBin string
 
 	if c.Distribution() == "fcos" {
-		installPkgBin = "/usr/bin/bcrypt"
+		installPkgBin = "/usr/sbin/bird"
 	} else {
-		installPkgBin = "/bin/bcrypt"
+		installPkgBin = "/sbin/bird"
 	}
 
 	m := c.Machines()[0]


### PR DESCRIPTION
epel7 is not available for s390x. Thus changing to epel 8 and I picked bird because it was available on all arches and was a small self contained package.

Any other suggestions are welcome.