### PR TITLE
WIP: cmd/ore/aliyun: support ALIYUN_CONFIG_FILE env var

### DIFF
--- a/cmd/ore/aliyun/aliyun.go
+++ b/cmd/ore/aliyun/aliyun.go
@@ -16,6 +16,7 @@ package aliyun
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/spf13/cobra"
@@ -38,7 +39,12 @@ var (
 )
 
 func init() {
-	Aliyun.PersistentFlags().StringVar(&options.ConfigPath, "config-file", "", "config file (default \"~/"+auth.AliyunConfigPath+"\")")
+	defaultConfigPath := os.Getenv("ALIYUN_CONFIG_FILE")
+	if defaultConfigPath == "" {
+		defaultConfigPath = "~/" + auth.AliyunConfigPath
+	}
+
+	Aliyun.PersistentFlags().StringVar(&options.ConfigPath, "config-file", defaultConfigPath, "config file (default \""+defaultConfigPath+"\")")
 	Aliyun.PersistentFlags().StringVar(&options.Profile, "profile", "", "profile (default \"default\")")
 	Aliyun.PersistentFlags().StringVar(&options.Region, "region", "", "region")
 	cli.WrapPreRun(Aliyun, preflightCheck)


### PR DESCRIPTION
Similar to the `AWS_SHARED_CREDENTIALS_FILE`. This will allow us to
more easily point `ore` to the mounted secret inside the RHCOS pipeline.