### PR TITLE
kola: Allow sssd.service to be on in RHCOS

### DIFF
--- a/kola/tests/coretest/core.go
+++ b/kola/tests/coretest/core.go
@@ -40,7 +40,6 @@ var offServices = []string{
 	"rpc-statd.service",
 	"rpcbind.service",
 	"rpcbind.socket",
-	"sssd.service",
 	"tcsd.service",
 }
 


### PR DESCRIPTION
We don't explicitly expect sssd.service to be on as older versions of RHCOS have the service off by default.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1749910