### PR TITLE
kola/qemu: Add a swtpm by default

### DIFF
--- a/platform/machine/unprivqemu/cluster.go
+++ b/platform/machine/unprivqemu/cluster.go
@@ -91,6 +91,28 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		consolePath: filepath.Join(dir, "console.txt"),
 	}
 
+	qm.swtpmTmpd, err = ioutil.TempDir("", "kola-swtpm")
+	if err != nil {
+		return nil, err
+	}
+
+	swtpmSock := filepath.Join(qm.swtpmTmpd, "swtpm-sock")
+
+	qm.swtpm = exec.Command("swtpm", "socket", "--tpm2",
+		"--ctrl", fmt.Sprintf("type=unixio,path=%s", swtpmSock),
+		"--terminate", "--tpmstate", fmt.Sprintf("dir=%s", qm.swtpmTmpd))
+	cmd := qm.swtpm.(*exec.ExecCmd)
+	cmd.Stderr = os.Stderr
+
+	if pdeathsig {
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Pdeathsig: syscall.SIGTERM,
+		}
+	}
+	if err = qm.swtpm.Start(); err != nil {
+		return nil, err
+	}
+
 	qmCmd, extraFiles, err := platform.CreateQEMUCommand(qc.flight.opts.Board, qm.id, qc.flight.opts.BIOSImage, qm.consolePath, confPath, qc.flight.diskImagePath, conf.IsIgnition(), options)
 	if err != nil {
 		return nil, err
@@ -102,7 +124,10 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 
 	qc.mu.Lock()
 
+	// Default to user mode networking
 	qmCmd = append(qmCmd, "-netdev", "user,id=eth0,hostfwd=tcp:127.0.0.1:0-:22", "-device", platform.Virtio(qc.flight.opts.Board, "net", "netdev=eth0"))
+	// Bind the TPM device
+	qmCmd = append(qmCmd, "-chardev", fmt.Sprintf("socket,id=chrtpm,path=%s", swtpmSock), "-tpmdev", "emulator,id=tpm0,chardev=chrtpm", "-device", "tpm-tis,tpmdev=tpm0")
 
 	plog.Debugf("NewMachine: %q", qmCmd)
 
@@ -110,7 +135,7 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 
 	qc.mu.Unlock()
 
-	cmd := qm.qemu.(*exec.ExecCmd)
+	cmd = qm.qemu.(*exec.ExecCmd)
 	cmd.Stderr = os.Stderr
 
 	if pdeathsig {

--- a/platform/machine/unprivqemu/machine.go
+++ b/platform/machine/unprivqemu/machine.go
@@ -16,6 +16,7 @@ package unprivqemu
 
 import (
 	"io/ioutil"
+	"os"
 
 	"golang.org/x/crypto/ssh"
 
@@ -27,6 +28,8 @@ type machine struct {
 	qc          *Cluster
 	id          string
 	qemu        exec.Cmd
+	swtpmTmpd   string
+	swtpm       exec.Cmd
 	journal     *platform.Journal
 	consolePath string
 	console     string
@@ -66,6 +69,12 @@ func (m *machine) Reboot() error {
 }
 
 func (m *machine) Destroy() {
+	if err := m.swtpm.Kill(); err != nil {
+		plog.Errorf("Error killing swtpm of %v: %v", m.ID(), err)
+	}
+	if err := os.RemoveAll(m.swtpmTmpd); err != nil {
+		plog.Errorf("Error removing swtpm dir: %v", err)
+	}
 	if err := m.qemu.Kill(); err != nil {
 		plog.Errorf("Error killing instance %v: %v", m.ID(), err)
 	}


### PR DESCRIPTION
The duplication in qemu code between cosa and kola needs
to end - this is the start of moving some bits into kola.
Eventually we'll have `cosa run` be a wrapper for something
like `kola qemuexec`.

This bit is the equivalent of
https://github.com/coreos/coreos-assembler/pull/878/commits/55c9b651e5ee94fb4de947a943df213ff3c601eb

We want to strongly emphasize use of TPM devices in CoreOS, so let's provision
one by default.

They can be used for disk encryption, secure secret storage, etc.