### PR TITLE
build-sys: Add `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,22 @@
+PREFIX ?= /usr
+DESTDIR ?=
+
+GOARCH:=$(shell uname -m)
+# Copied from coreos-assembler Makefile
+ifeq ($(GOARCH),x86_64)
+	GOARCH=amd64
+else ifeq ($(GOARCH),aarch64)
+	GOARCH=arm64
+endif
+
 .PHONY: build test vendor
 build:
 	./build
+
+.PHONY: install
+install: build
+	install -D -t $(DESTDIR)$(PREFIX)/bin bin/{ore,kola,plume}
+	install -D -m 0755 -t $(DESTDIR)$(PREFIX)/lib/kola/$(GOARCH) bin/$(GOARCH)/kolet
 
 test:
 	./test


### PR DESCRIPTION
Same rationale as https://github.com/coreos/ignition-dracut/pull/106/commits/9b66bf5cb688217f2e3c6d0f3e92a4fa5c1ea46e

This is a standard rule that one can use when developing on
the software.  Further, with this we can change the cosa `Makefile`
that's currently installing to just invoke this one.