### PR TITLE
Add a --qemu-swtpm option to kola to support running kola tests without TPM

### DIFF
--- a/cmd/kola/kola.go
+++ b/cmd/kola/kola.go
@@ -174,6 +174,7 @@ func writeProps() error {
 	}
 	type QEMU struct {
 		Image string `json:"image"`
+		Swtpm bool   `json:"swtpm"`
 	}
 	return enc.Encode(&struct {
 		Cmdline         []string  `json:"cmdline"`
@@ -237,6 +238,7 @@ func writeProps() error {
 		},
 		QEMU: QEMU{
 			Image: kola.QEMUOptions.DiskImage,
+			Swtpm: kola.QEMUOptions.Swtpm,
 		},
 	})
 }

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -142,6 +142,7 @@ func init() {
 	sv(&kola.QEMUOptions.Board, "board", defaultTargetBoard, "target board")
 	sv(&kola.QEMUOptions.DiskImage, "qemu-image", "", "path to CoreOS disk image")
 	sv(&kola.QEMUOptions.BIOSImage, "qemu-bios", "", "BIOS to use for QEMU vm")
+	bv(&kola.QEMUOptions.Swtpm, "qemu-swtpm", true, "Create temporary software TPM")
 }
 
 // Sync up the command line options if there is dependency

--- a/platform/machine/qemu/flight.go
+++ b/platform/machine/qemu/flight.go
@@ -36,6 +36,9 @@ type Options struct {
 	// It can be a plain name, or a full path.
 	BIOSImage string
 
+	//Option to create a temporary software TPM - true by default
+	Swtpm bool
+
 	*platform.Options
 }
 

--- a/platform/machine/unprivqemu/cluster.go
+++ b/platform/machine/unprivqemu/cluster.go
@@ -91,26 +91,29 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		consolePath: filepath.Join(dir, "console.txt"),
 	}
 
-	qm.swtpmTmpd, err = ioutil.TempDir("", "kola-swtpm")
-	if err != nil {
-		return nil, err
-	}
-
-	swtpmSock := filepath.Join(qm.swtpmTmpd, "swtpm-sock")
-
-	qm.swtpm = exec.Command("swtpm", "socket", "--tpm2",
-		"--ctrl", fmt.Sprintf("type=unixio,path=%s", swtpmSock),
-		"--terminate", "--tpmstate", fmt.Sprintf("dir=%s", qm.swtpmTmpd))
-	cmd := qm.swtpm.(*exec.ExecCmd)
-	cmd.Stderr = os.Stderr
-
-	if pdeathsig {
-		cmd.SysProcAttr = &syscall.SysProcAttr{
-			Pdeathsig: syscall.SIGTERM,
+	swtpmSock := ""
+	if qc.flight.opts.Swtpm {
+		qm.swtpmTmpd, err = ioutil.TempDir("", "kola-swtpm")
+		if err != nil {
+			return nil, err
 		}
-	}
-	if err = qm.swtpm.Start(); err != nil {
-		return nil, err
+
+		swtpmSock = filepath.Join(qm.swtpmTmpd, "swtpm-sock")
+
+		qm.swtpm = exec.Command("swtpm", "socket", "--tpm2",
+			"--ctrl", fmt.Sprintf("type=unixio,path=%s", swtpmSock),
+			"--terminate", "--tpmstate", fmt.Sprintf("dir=%s", qm.swtpmTmpd))
+		cmd := qm.swtpm.(*exec.ExecCmd)
+		cmd.Stderr = os.Stderr
+
+		if pdeathsig {
+			cmd.SysProcAttr = &syscall.SysProcAttr{
+				Pdeathsig: syscall.SIGTERM,
+			}
+		}
+		if err = qm.swtpm.Start(); err != nil {
+			return nil, err
+		}
 	}
 
 	qmCmd, extraFiles, err := platform.CreateQEMUCommand(qc.flight.opts.Board, qm.id, qc.flight.opts.BIOSImage, qm.consolePath, confPath, qc.flight.opts.DiskImage, conf.IsIgnition(), options)
@@ -126,8 +129,11 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 
 	// Default to user mode networking
 	qmCmd = append(qmCmd, "-netdev", "user,id=eth0,hostfwd=tcp:127.0.0.1:0-:22", "-device", platform.Virtio(qc.flight.opts.Board, "net", "netdev=eth0"))
+
 	// Bind the TPM device
-	qmCmd = append(qmCmd, "-chardev", fmt.Sprintf("socket,id=chrtpm,path=%s", swtpmSock), "-tpmdev", "emulator,id=tpm0,chardev=chrtpm", "-device", "tpm-tis,tpmdev=tpm0")
+	if qc.flight.opts.Swtpm {
+		qmCmd = append(qmCmd, "-chardev", fmt.Sprintf("socket,id=chrtpm,path=%s", swtpmSock), "-tpmdev", "emulator,id=tpm0,chardev=chrtpm", "-device", "tpm-tis,tpmdev=tpm0")
+	}
 
 	plog.Debugf("NewMachine: %q", qmCmd)
 
@@ -135,7 +141,7 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 
 	qc.mu.Unlock()
 
-	cmd = qm.qemu.(*exec.ExecCmd)
+	cmd := qm.qemu.(*exec.ExecCmd)
 	cmd.Stderr = os.Stderr
 
 	if pdeathsig {

--- a/platform/machine/unprivqemu/machine.go
+++ b/platform/machine/unprivqemu/machine.go
@@ -69,11 +69,13 @@ func (m *machine) Reboot() error {
 }
 
 func (m *machine) Destroy() {
-	if err := m.swtpm.Kill(); err != nil {
-		plog.Errorf("Error killing swtpm of %v: %v", m.ID(), err)
-	}
-	if err := os.RemoveAll(m.swtpmTmpd); err != nil {
-		plog.Errorf("Error removing swtpm dir: %v", err)
+	if m.swtpmTmpd != "" {
+		if err := m.swtpm.Kill(); err != nil {
+			plog.Errorf("Error killing swtpm of %v: %v", m.ID(), err)
+		}
+		if err := os.RemoveAll(m.swtpmTmpd); err != nil {
+			plog.Errorf("Error removing swtpm dir: %v", err)
+		}
 	}
 	if err := m.qemu.Kill(); err != nil {
 		plog.Errorf("Error killing instance %v: %v", m.ID(), err)


### PR DESCRIPTION
Architectures like s390x and pcc64le do not seem to have support for the virtual
TPM device in qemu. The kola tests fail to run today because it requires TPM support
by default.

With the --qemu-swtpm option specified, kola tests can be run on qemu images without TPM when setting it to false. For the tests that require TPM such as rhcos.luks.tpm, they can be blacklisted in the config. By default TPM is enabled for qemu.