### PR TITLE
Add ExcludeArchitectures option for kola tests to exclude tests on certain arches

### DIFF
--- a/cmd/kola/kola.go
+++ b/cmd/kola/kola.go
@@ -251,6 +251,7 @@ func runList(cmd *cobra.Command, args []string) {
 			test.Platforms,
 			test.ExcludePlatforms,
 			test.Architectures,
+			test.ExcludeArchitectures,
 			test.Distros,
 			test.ExcludeDistros}
 		item.updateValues()
@@ -281,12 +282,13 @@ func runList(cmd *cobra.Command, args []string) {
 }
 
 type item struct {
-	Name             string
-	Platforms        []string
-	ExcludePlatforms []string `json:"-"`
-	Architectures    []string
-	Distros          []string
-	ExcludeDistros   []string `json:"-"`
+	Name                 string
+	Platforms            []string
+	ExcludePlatforms     []string `json:"-"`
+	Architectures        []string
+	ExcludeArchitectures []string `json:"-"`
+	Distros              []string
+	ExcludeDistros       []string `json:"-"`
 }
 
 func (i *item) updateValues() {

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -263,7 +263,7 @@ func filterTests(tests map[string]*register.Test, pattern, pltfrm string, versio
 				isExcluded = true
 				break
 			}
-			allowedArchitecture, _ := isAllowed(architecture(platform), t.Architectures, []string{})
+			allowedArchitecture, _ := isAllowed(architecture(platform), t.Architectures, t.ExcludeArchitectures)
 			allowed = allowed || (allowedPlatform && allowedArchitecture)
 		}
 		if isExcluded || !allowed {

--- a/kola/register/register.go
+++ b/kola/register/register.go
@@ -45,18 +45,19 @@ var (
 // statically declare state of the platform.TestCluster before the test
 // function is run.
 type Test struct {
-	Name             string // should be unique
-	Run              func(cluster.TestCluster)
-	NativeFuncs      map[string]func() error
-	UserData         *conf.UserData
-	UserDataV3       *conf.UserData
-	ClusterSize      int
-	Platforms        []string // whitelist of platforms to run test against -- defaults to all
-	ExcludePlatforms []string // blacklist of platforms to ignore -- defaults to none
-	Distros          []string // whitelist of distributions to run test against -- defaults to all
-	ExcludeDistros   []string // blacklist of distributions to ignore -- defaults to none
-	Architectures    []string // whitelist of machine architectures supported -- defaults to all
-	Flags            []Flag   // special-case options for this test
+	Name                 string // should be unique
+	Run                  func(cluster.TestCluster)
+	NativeFuncs          map[string]func() error
+	UserData             *conf.UserData
+	UserDataV3           *conf.UserData
+	ClusterSize          int
+	Platforms            []string // whitelist of platforms to run test against -- defaults to all
+	ExcludePlatforms     []string // blacklist of platforms to ignore -- defaults to none
+	Distros              []string // whitelist of distributions to run test against -- defaults to all
+	ExcludeDistros       []string // blacklist of distributions to ignore -- defaults to none
+	Architectures        []string // whitelist of machine architectures supported -- defaults to all
+	ExcludeArchitectures []string // blacklist of architectures to ignore -- defaults to none
+	Flags                []Flag   // special-case options for this test
 
 	// FailFast skips any sub-test that occurs after a sub-test has
 	// failed.

--- a/kola/tests/rhcos/luks.go
+++ b/kola/tests/rhcos/luks.go
@@ -10,12 +10,13 @@ import (
 
 func init() {
 	register.Register(&register.Test{
-		Run:         luksTPMTest,
-		ClusterSize: 1,
-		Name:        `rhcos.luks.tpm`,
-		Flags:       []register.Flag{},
-		Distros:     []string{"rhcos"},
-		Platforms:   []string{"qemu-unpriv"},
+		Run:                  luksTPMTest,
+		ClusterSize:          1,
+		Name:                 `rhcos.luks.tpm`,
+		Flags:                []register.Flag{},
+		Distros:              []string{"rhcos"},
+		Platforms:            []string{"qemu-unpriv"},
+		ExcludeArchitectures: []string{"s390x", "ppc64le"}, // no TPM support for s390x, ppc64le in qemu
 		UserData: conf.Ignition(`{
 			"ignition": {
 				"version": "2.2.0"


### PR DESCRIPTION
Based on the comments in https://github.com/coreos/coreos-assembler/pull/977#issuecomment-562677361, it makes sense to have an option to hardcode excluding certain tests which might never be supported for certain architectures. One good example is the rhcos.luks.tpm test which will probably never by supported on s390x. For powerpc , there is no concrete plans although there is talk of some effort soon.