### PR TITLE
qemu: Move Options struct into unprivqemu

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -61,7 +61,7 @@ var (
 	GCEOptions       = gcloudapi.Options{Options: &Options}    // glue to set platform options from main
 	OpenStackOptions = openstackapi.Options{Options: &Options} // glue to set platform options from main
 	PacketOptions    = packetapi.Options{Options: &Options}    // glue to set platform options from main
-	QEMUOptions      = qemu.Options{Options: &Options}         // glue to set platform options from main
+	QEMUOptions      = unprivqemu.Options{Options: &Options}   // glue to set platform options from main
 
 	TestParallelism int    //glue var to set test parallelism from main
 	TAPFile         string // if not "", write TAP results here

--- a/platform/machine/qemu/flight.go
+++ b/platform/machine/qemu/flight.go
@@ -20,38 +20,23 @@ import (
 
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/local"
+	"github.com/coreos/mantle/platform/machine/unprivqemu"
 )
 
 const (
 	Platform platform.Name = "qemu"
 )
 
-// Options contains QEMU-specific options for the flight.
-type Options struct {
-	// DiskImage is the full path to the disk image to boot in QEMU.
-	DiskImage string
-	Board     string
-
-	// BIOSImage is name of the BIOS file to pass to QEMU.
-	// It can be a plain name, or a full path.
-	BIOSImage string
-
-	//Option to create a temporary software TPM - true by default
-	Swtpm bool
-
-	*platform.Options
-}
-
 type flight struct {
 	*local.LocalFlight
-	opts *Options
+	opts *unprivqemu.Options
 }
 
 var (
 	plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "platform/machine/qemu")
 )
 
-func NewFlight(opts *Options) (platform.Flight, error) {
+func NewFlight(opts *unprivqemu.Options) (platform.Flight, error) {
 	lf, err := local.NewLocalFlight(opts.Options, Platform)
 	if err != nil {
 		return nil, err

--- a/platform/machine/unprivqemu/flight.go
+++ b/platform/machine/unprivqemu/flight.go
@@ -18,23 +18,38 @@ import (
 	"github.com/coreos/pkg/capnslog"
 
 	"github.com/coreos/mantle/platform"
-	"github.com/coreos/mantle/platform/machine/qemu"
 )
 
 const (
 	Platform platform.Name = "qemu"
 )
 
+// Options contains QEMU-specific options for the flight.
+type Options struct {
+	// DiskImage is the full path to the disk image to boot in QEMU.
+	DiskImage string
+	Board     string
+
+	// BIOSImage is name of the BIOS file to pass to QEMU.
+	// It can be a plain name, or a full path.
+	BIOSImage string
+
+	//Option to create a temporary software TPM - true by default
+	Swtpm bool
+
+	*platform.Options
+}
+
 type flight struct {
 	*platform.BaseFlight
-	opts *qemu.Options
+	opts *Options
 }
 
 var (
 	plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "platform/machine/qemu")
 )
 
-func NewFlight(opts *qemu.Options) (platform.Flight, error) {
+func NewFlight(opts *Options) (platform.Flight, error) {
 	bf, err := platform.NewBaseFlight(opts.Options, Platform, "")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Today the unprivqemu code inherits this from qemu; flip
that dependency around as preparation for removal of the qemu
path.