### PR TITLE
kola: Remove --qemu-bios argument

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -41,11 +41,6 @@ var (
 		"fcos":  "v3",
 		"rhcos": "v3",
 	}
-
-	kolaDefaultBIOS = map[string]string{
-		"amd64-usr": "bios-256k.bin",
-		"arm64-usr": sdk.BuildRoot() + "/images/arm64-usr/latest/coreos_production_qemu_uefi_efi_code.fd",
-	}
 )
 
 func init() {
@@ -141,7 +136,6 @@ func init() {
 	// QEMU-specific options
 	sv(&kola.QEMUOptions.Board, "board", defaultTargetBoard, "target board")
 	sv(&kola.QEMUOptions.DiskImage, "qemu-image", "", "path to CoreOS disk image")
-	sv(&kola.QEMUOptions.BIOSImage, "qemu-bios", "", "BIOS to use for QEMU vm")
 	bv(&kola.QEMUOptions.Swtpm, "qemu-swtpm", true, "Create temporary software TPM")
 }
 
@@ -176,9 +170,6 @@ func syncOptions() error {
 		kola.QEMUOptions.DiskImage = image
 	}
 
-	if kola.QEMUOptions.BIOSImage == "" {
-		kola.QEMUOptions.BIOSImage = kolaDefaultBIOS[kola.QEMUOptions.Board]
-	}
 	units, _ := root.PersistentFlags().GetStringSlice("debug-systemd-units")
 	for _, unit := range units {
 		kola.Options.SystemdDropins = append(kola.Options.SystemdDropins, platform.SystemdDropin{

--- a/platform/machine/qemu/cluster.go
+++ b/platform/machine/qemu/cluster.go
@@ -95,7 +95,7 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		consolePath: filepath.Join(dir, "console.txt"),
 	}
 
-	qmCmd, extraFiles, err := platform.CreateQEMUCommand(qc.flight.opts.Board, qm.id, qc.flight.opts.BIOSImage, qm.consolePath, confPath, qc.flight.opts.DiskImage, conf.IsIgnition(), options)
+	qmCmd, extraFiles, err := platform.CreateQEMUCommand(qc.flight.opts.Board, qm.id, qm.consolePath, confPath, qc.flight.opts.DiskImage, conf.IsIgnition(), options)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/machine/unprivqemu/cluster.go
+++ b/platform/machine/unprivqemu/cluster.go
@@ -117,7 +117,7 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		}
 	}
 
-	qmCmd, extraFiles, err := platform.CreateQEMUCommand(qc.flight.opts.Board, qm.id, qc.flight.opts.BIOSImage, qm.consolePath, confPath, qc.flight.opts.DiskImage, conf.IsIgnition(), options)
+	qmCmd, extraFiles, err := platform.CreateQEMUCommand(qc.flight.opts.Board, qm.id, qm.consolePath, confPath, qc.flight.opts.DiskImage, conf.IsIgnition(), options)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/machine/unprivqemu/flight.go
+++ b/platform/machine/unprivqemu/flight.go
@@ -30,10 +30,6 @@ type Options struct {
 	DiskImage string
 	Board     string
 
-	// BIOSImage is name of the BIOS file to pass to QEMU.
-	// It can be a plain name, or a full path.
-	BIOSImage string
-
 	//Option to create a temporary software TPM - true by default
 	Swtpm bool
 

--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -156,7 +156,7 @@ func baseQemuArgs(board string) []string {
 	}
 }
 
-func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImagePath string, isIgnition bool, options MachineOptions) ([]string, []*os.File, error) {
+func CreateQEMUCommand(board, uuid, consolePath, confPath, diskImagePath string, isIgnition bool, options MachineOptions) ([]string, []*os.File, error) {
 	// As we expand this list of supported native + board
 	// archs combos we should coordinate with the
 	// coreos-assembler folks as they utilize something
@@ -193,10 +193,6 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 		"-object", "rng-random,filename=/dev/urandom,id=rng0",
 		"-device", Virtio(board, "rng", "rng=rng0"),
 	)
-
-	if board != "s390x-usr" && board != "ppc64le-usr" {
-		qmCmd = append(qmCmd, "-bios", biosImage)
-	}
 
 	if isIgnition {
 		// -fw_cfg is not supported for s390x, instead guestfs utility is used


### PR DESCRIPTION
What we really need here is to port the uefi/uefi-secure stuff
from `cosa run`.  In the meantime this is mostly CL cruft; delete
it in prep for a qemu refactoring.