### PR TITLE
kola: Also check for fatal dracut errors

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -81,6 +81,10 @@ var (
 			skipFlag: &[]register.Flag{register.NoEmergencyShellCheck}[0],
 		},
 		{
+			desc:  "dracut fatal",
+			match: regexp.MustCompile("dracut: Refusing to continue"),
+		},
+		{
 			desc:  "kernel panic",
 			match: regexp.MustCompile("Kernel panic - not syncing: (.*)"),
 		},


### PR DESCRIPTION
I had the fips test hang, and this might have helped.  What
I really want to do is change things so we *stream* (or poll)
the console and more quickly detect fatal errors.  But in
the meantime, let's add this error since it's definitely fatal.