### PR TITLE
Support excluding and blacklisting basic tests' subtest per arch

### DIFF
--- a/cmd/kolet/kolet.go
+++ b/cmd/kolet/kolet.go
@@ -58,13 +58,13 @@ func main() {
 			Run: run,
 		}
 		for nativeName := range testObj.NativeFuncs {
-			nativeFunc := testObj.NativeFuncs[nativeName]
+			nativeFuncWrap := testObj.NativeFuncs[nativeName]
 			nativeRun := func(cmd *cobra.Command, args []string) {
 				if len(args) != 0 {
 					cmd.Usage()
 					os.Exit(2)
 				}
-				if err := nativeFunc(); err != nil {
+				if err := nativeFuncWrap.NativeFunc(); err != nil {
 					plog.Fatal(err)
 				}
 				// Explicitly exit successfully.

--- a/kola/register/register.go
+++ b/kola/register/register.go
@@ -40,6 +40,17 @@ var (
 	}
 )
 
+// Wrapper for the NativeFunc which includes an optional string of arches to exclude for each native test
+type NativeFuncWrap struct {
+	NativeFunc           func() error
+	ExcludeArchitectures []string
+}
+
+// Simple constructor for returning NativeFuncWrap structure
+func CreateNativeFuncWrap(f func() error, excludearches ...string) NativeFuncWrap {
+	return NativeFuncWrap{f, excludearches}
+}
+
 // Test provides the main test abstraction for kola. The run function is
 // the actual testing function while the other fields provide ways to
 // statically declare state of the platform.TestCluster before the test
@@ -47,7 +58,7 @@ var (
 type Test struct {
 	Name                 string // should be unique
 	Run                  func(cluster.TestCluster)
-	NativeFuncs          map[string]func() error
+	NativeFuncs          map[string]NativeFuncWrap
 	UserData             *conf.UserData
 	UserDataV3           *conf.UserData
 	ClusterSize          int

--- a/kola/tests/coretest/core.go
+++ b/kola/tests/coretest/core.go
@@ -43,14 +43,14 @@ func init() {
 		Name:        "basic",
 		Run:         LocalTests,
 		ClusterSize: 1,
-		NativeFuncs: map[string]func() error{
-			"PortSSH":        TestPortSsh,
-			"DbusPerms":      TestDbusPerms,
-			"NetworkScripts": TestNetworkScripts,
-			"ServicesActive": TestServicesActive,
-			"ReadOnly":       TestReadOnlyFs,
-			"Useradd":        TestUseradd,
-			"MachineID":      TestMachineID,
+		NativeFuncs: map[string]register.NativeFuncWrap{
+			"PortSSH":        register.CreateNativeFuncWrap(TestPortSsh),
+			"DbusPerms":      register.CreateNativeFuncWrap(TestDbusPerms),
+			"NetworkScripts": register.CreateNativeFuncWrap(TestNetworkScripts, []string{"s390x"}...),
+			"ServicesActive": register.CreateNativeFuncWrap(TestServicesActive),
+			"ReadOnly":       register.CreateNativeFuncWrap(TestReadOnlyFs),
+			"Useradd":        register.CreateNativeFuncWrap(TestUseradd),
+			"MachineID":      register.CreateNativeFuncWrap(TestMachineID),
 		},
 		Distros: []string{"fcos", "rhcos"},
 	})
@@ -62,9 +62,9 @@ func init() {
 		Run:         InternetTests,
 		ClusterSize: 1,
 		Flags:       []register.Flag{register.RequiresInternetAccess},
-		NativeFuncs: map[string]func() error{
-			"PodmanEcho":     TestPodmanEcho,
-			"PodmanWgetHead": TestPodmanWgetHead,
+		NativeFuncs: map[string]register.NativeFuncWrap{
+			"PodmanEcho":     register.CreateNativeFuncWrap(TestPodmanEcho),
+			"PodmanWgetHead": register.CreateNativeFuncWrap(TestPodmanWgetHead),
 		},
 		Distros: []string{"fcos"},
 	})
@@ -72,8 +72,8 @@ func init() {
 		Name:        "rootfs.uuid",
 		Run:         LocalTests,
 		ClusterSize: 1,
-		NativeFuncs: map[string]func() error{
-			"RandomUUID": TestFsRandomUUID,
+		NativeFuncs: map[string]register.NativeFuncWrap{
+			"RandomUUID": register.CreateNativeFuncWrap(TestFsRandomUUID),
 		},
 		// FIXME run on RHCOS once it has https://github.com/coreos/ignition-dracut/pull/93
 		Distros: []string{"fcos"},
@@ -82,8 +82,8 @@ func init() {
 		Name:        "rhcos.services-disabled",
 		Run:         LocalTests,
 		ClusterSize: 1,
-		NativeFuncs: map[string]func() error{
-			"ServicesDisabled": TestServicesDisabledRHCOS,
+		NativeFuncs: map[string]register.NativeFuncWrap{
+			"ServicesDisabled": register.CreateNativeFuncWrap(TestServicesDisabledRHCOS),
 		},
 		Distros: []string{"rhcos"},
 	})

--- a/kola/tests/ignition/resource.go
+++ b/kola/tests/ignition/resource.go
@@ -100,8 +100,8 @@ func init() {
 		Name:        "coreos.ignition.resource.local",
 		Run:         resourceLocal,
 		ClusterSize: 1,
-		NativeFuncs: map[string]func() error{
-			"Serve": Serve,
+		NativeFuncs: map[string]register.NativeFuncWrap{
+			"Serve": register.CreateNativeFuncWrap(Serve),
 		},
 		// https://github.com/coreos/bugs/issues/2205
 		ExcludePlatforms: []string{"do", "qemu-unpriv"},

--- a/kola/tests/ignition/security.go
+++ b/kola/tests/ignition/security.go
@@ -73,9 +73,9 @@ func init() {
 		Name:        "coreos.ignition.security.tls",
 		Run:         securityTLS,
 		ClusterSize: 1,
-		NativeFuncs: map[string]func() error{
-			"TLSServe":   TLSServe,
-			"TLSServeV3": TLSServeV3,
+		NativeFuncs: map[string]register.NativeFuncWrap{
+			"TLSServe":   register.CreateNativeFuncWrap(TLSServe),
+			"TLSServeV3": register.CreateNativeFuncWrap(TLSServeV3),
 		},
 		// DO: https://github.com/coreos/bugs/issues/2205
 		// Packet & QEMU: https://github.com/coreos/ignition/issues/645


### PR DESCRIPTION
Support to exclude/blacklist native tests run by kolet. Following up on #1132, this is a way to exclude a certain native test instead of excluding the whole set of tests

Closes: #1132