### PR TITLE
kola: Add --qemu-nvme

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -136,6 +136,7 @@ func init() {
 	// QEMU-specific options
 	sv(&kola.QEMUOptions.Board, "board", defaultTargetBoard, "target board")
 	sv(&kola.QEMUOptions.DiskImage, "qemu-image", "", "path to CoreOS disk image")
+	bv(&kola.QEMUOptions.Nvme, "qemu-nvme", false, "Use NVMe for main disk")
 	bv(&kola.QEMUOptions.Swtpm, "qemu-swtpm", true, "Create temporary software TPM")
 }
 

--- a/platform/machine/unprivqemu/cluster.go
+++ b/platform/machine/unprivqemu/cluster.go
@@ -96,8 +96,13 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	builder.Uuid = qm.id
 	builder.ConsoleToFile(qm.consolePath)
 
+	channel := "virtio"
+	if qc.flight.opts.Nvme {
+		channel = "nvme"
+	}
 	primaryDisk := platform.Disk{
 		BackingFile: qc.flight.opts.DiskImage,
+		Channel:     channel,
 	}
 
 	builder.AddPrimaryDisk(&primaryDisk)

--- a/platform/machine/unprivqemu/flight.go
+++ b/platform/machine/unprivqemu/flight.go
@@ -30,6 +30,8 @@ type Options struct {
 	DiskImage string
 	Board     string
 
+	Nvme bool
+
 	//Option to create a temporary software TPM - true by default
 	Swtpm bool
 


### PR DESCRIPTION
We need to test NVMe, we had a regression here.  See
https://github.com/coreos/coreos-assembler/pull/906/commits/be564b7d79466fafb92e2b9d6657cfa3c6b65fae

Part of draining `cosa run` bits into mantle.