### PR TITLE
kola: Add -T/--no-test-exit-error

### DIFF
--- a/cmd/kola/kola.go
+++ b/cmd/kola/kola.go
@@ -126,7 +126,7 @@ func runRun(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	runErr := kola.RunTests(pattern, kolaPlatform, outputDir)
+	runErr := kola.RunTests(pattern, kolaPlatform, outputDir, !kola.Options.NoTestExitError)
 
 	// needs to be after RunTests() because harness empties the directory
 	if err := writeProps(); err != nil {

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -55,6 +55,7 @@ func init() {
 	root.PersistentFlags().StringVarP(&kola.Options.Distribution, "distro", "b", kolaDistros[0], "Distribution: "+strings.Join(kolaDistros, ", "))
 	root.PersistentFlags().IntVarP(&kola.TestParallelism, "parallel", "j", 1, "number of tests to run in parallel")
 	sv(&kola.TAPFile, "tapfile", "", "file to write TAP results to")
+	root.PersistentFlags().BoolVarP(&kola.Options.NoTestExitError, "no-test-exit-error", "T", false, "Don't exit with non-zero if tests fail")
 	sv(&kola.Options.BaseName, "basename", "kola", "Cluster name prefix")
 	ss("debug-systemd-unit", []string{}, "full-unit-name.service to enable SYSTEMD_LOG_LEVEL=debug on. Specify multiple times for multiple units.")
 	sv(&kola.UpdatePayloadFile, "update-payload", "", "Path to an update payload that should be made available to tests")

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -319,7 +319,7 @@ func versionOutsideRange(version, minVersion, endVersion semver.Version) bool {
 // register tests in their init() function.
 // outputDir is where various test logs and data will be written for
 // analysis after the test run. If it already exists it will be erased!
-func RunTests(pattern, pltfrm, outputDir string) error {
+func RunTests(pattern, pltfrm, outputDir string, propagateTestErrors bool) error {
 	var versionStr string
 
 	// Avoid incurring cost of starting machine in getClusterSemver when
@@ -381,6 +381,10 @@ func RunTests(pattern, pltfrm, outputDir string) error {
 
 	suite := harness.NewSuite(opts, htests)
 	err = suite.Run()
+	caughtTestError := err != nil
+	if !propagateTestErrors {
+		err = nil
+	}
 
 	if TAPFile != "" {
 		src := filepath.Join(outputDir, "test.tap")
@@ -389,7 +393,7 @@ func RunTests(pattern, pltfrm, outputDir string) error {
 		}
 	}
 
-	if err != nil {
+	if caughtTestError {
 		fmt.Printf("FAIL, output in %v\n", outputDir)
 	} else {
 		fmt.Printf("PASS, output in %v\n", outputDir)

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -158,6 +158,8 @@ type Options struct {
 	IgnitionVersion string
 	SystemdDropins  []SystemdDropin
 
+	NoTestExitError bool
+
 	// OSContainer is an image pull spec that can be given to the pivot service
 	// in RHCOS machines to perform machine content upgrades.
 	// When specified additional files & units will be automatically generated


### PR DESCRIPTION
Today the fcos pipeline uses `kola run || :` and then inspects
the output JSON, but that may mask other errors not from tests.
Add an explicit way to `exit 0` even if tests fail, but we still
exit non-zero if e.g. we can't write to the output directory.