### PR TITLE
qemu: Automatically turn off swtpm on !x86_64 here

### DIFF
--- a/platform/machine/unprivqemu/cluster.go
+++ b/platform/machine/unprivqemu/cluster.go
@@ -91,6 +91,7 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	defer builder.Close()
 	builder.Uuid = qm.id
 	builder.Firmware = qc.flight.opts.Firmware
+	builder.Swtpm = qc.flight.opts.Swtpm
 	builder.ConsoleToFile(qm.consolePath)
 
 	channel := "virtio"

--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -545,7 +545,8 @@ func (builder *QemuBuilder) Exec() (*QemuInstance, error) {
 		panic("Ignition specified but no primary disk")
 	}
 
-	if builder.Swtpm {
+	// TPM devices aren't on s390x/ppc64le at least
+	if builder.Swtpm && builder.Board == "amd64-usr" {
 		inst.swtpmTmpd, err = ioutil.TempDir("", "kola-swtpm")
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
I think we should have done this instead of
https://github.com/coreos/coreos-assembler/pull/973

This way invoking `kola` rather than `cosa kola` does the right thing.
Part of de-duping cosa and mantle.