### PR TITLE
kola: Add --qemu-size

### DIFF
--- a/cmd/kola/kola.go
+++ b/cmd/kola/kola.go
@@ -189,8 +189,9 @@ func writeProps() error {
 		ImageURL              string `json:"image"`
 	}
 	type QEMU struct {
-		Image string `json:"image"`
-		Swtpm bool   `json:"swtpm"`
+		Image     string `json:"image"`
+		ImageSize string `json:"imageSize"`
+		Swtpm     bool   `json:"swtpm"`
 	}
 	return enc.Encode(&struct {
 		Cmdline         []string  `json:"cmdline"`
@@ -253,8 +254,9 @@ func writeProps() error {
 			ImageURL:              kola.PacketOptions.ImageURL,
 		},
 		QEMU: QEMU{
-			Image: kola.QEMUOptions.DiskImage,
-			Swtpm: kola.QEMUOptions.Swtpm,
+			Image:     kola.QEMUOptions.DiskImage,
+			ImageSize: kola.QEMUOptions.DiskSize,
+			Swtpm:     kola.QEMUOptions.Swtpm,
 		},
 	})
 }

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -137,6 +137,7 @@ func init() {
 	sv(&kola.QEMUOptions.Board, "board", defaultTargetBoard, "target board")
 	sv(&kola.QEMUOptions.Firmware, "qemu-firmware", "bios", "Boot firmware: bios,uefi,uefi-secure")
 	sv(&kola.QEMUOptions.DiskImage, "qemu-image", "", "path to CoreOS disk image")
+	sv(&kola.QEMUOptions.DiskSize, "qemu-size", "", "Resize target disk via qemu-img resize [+]SIZE")
 	bv(&kola.QEMUOptions.Nvme, "qemu-nvme", false, "Use NVMe for main disk")
 	bv(&kola.QEMUOptions.Swtpm, "qemu-swtpm", true, "Create temporary software TPM")
 }

--- a/platform/machine/unprivqemu/cluster.go
+++ b/platform/machine/unprivqemu/cluster.go
@@ -100,6 +100,7 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	primaryDisk := platform.Disk{
 		BackingFile: qc.flight.opts.DiskImage,
 		Channel:     channel,
+		Size:        qc.flight.opts.DiskSize,
 	}
 
 	builder.AddPrimaryDisk(&primaryDisk)

--- a/platform/machine/unprivqemu/flight.go
+++ b/platform/machine/unprivqemu/flight.go
@@ -28,8 +28,10 @@ const (
 type Options struct {
 	// DiskImage is the full path to the disk image to boot in QEMU.
 	DiskImage string
-	Board     string
-	Firmware  string
+	// DiskSize if non-empty will expand the disk
+	DiskSize string
+	Board    string
+	Firmware string
 
 	Nvme bool
 


### PR DESCRIPTION
In some cases we want to test expanding the disk to a specific
size.  Mainly writing this for `cosa kola spawn -- --qemu-size 32G`
for example.