### PR TITLE
platform/api/aliyun: add re-use capabilities to some functions

### DIFF
--- a/cmd/ore/aliyun/aliyun.go
+++ b/cmd/ore/aliyun/aliyun.go
@@ -21,7 +21,6 @@ import (
 	"github.com/coreos/pkg/capnslog"
 	"github.com/spf13/cobra"
 
-	"github.com/coreos/mantle/auth"
 	"github.com/coreos/mantle/cli"
 	"github.com/coreos/mantle/platform/api/aliyun"
 )
@@ -40,9 +39,6 @@ var (
 
 func init() {
 	defaultConfigPath := os.Getenv("ALIYUN_CONFIG_FILE")
-	if defaultConfigPath == "" {
-		defaultConfigPath = "~/" + auth.AliyunConfigPath
-	}
 
 	Aliyun.PersistentFlags().StringVar(&options.ConfigPath, "config-file", defaultConfigPath, "config file (default \""+defaultConfigPath+"\")")
 	Aliyun.PersistentFlags().StringVar(&options.Profile, "profile", "", "profile (default \"default\")")

--- a/cmd/ore/aliyun/create-image.go
+++ b/cmd/ore/aliyun/create-image.go
@@ -63,6 +63,20 @@ func init() {
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
+	// Check if image exists first when force not enabled
+	if !force {
+		images, err := API.GetImages(name)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "getting images: %v", err)
+			os.Exit(1)
+		}
+
+		for _, image := range images.Images.Image {
+			fmt.Println(image.ImageId)
+			return nil
+		}
+	}
+
 	if sizeInspect {
 		imageInfo, err := util.GetImageInfo(path)
 		if err != nil {


### PR DESCRIPTION
Adds the ability for the following functions to re-use existing objects
when force is not specified:
 - ImportImage
 - UploadFile