### PR TITLE
ore/aws/copy-image: stream results back to stdout

### DIFF
--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -542,13 +542,11 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imageName, 
 		amis := map[string]string{}
 		if len(destRegions) > 0 {
 			plog.Printf("Replicating AMI %v...", imageID)
-			copiedAmis, err := api.CopyImage(imageID, destRegions)
+			err := api.CopyImage(imageID, destRegions, func(region string, ami aws.ImageData) {
+				amis[region] = ami.AMI
+			})
 			if err != nil {
 				return nil, fmt.Errorf("couldn't copy image: %v", err)
-			}
-
-			for region, data := range copiedAmis {
-				amis[region] = data.AMI
 			}
 		}
 		amis[part.BucketRegion] = imageID


### PR DESCRIPTION
Rather than accumulate all the results and then dump it all on stdout,
stream the output as line-separated JSON objects as the goroutines
complete.

This is technically a compatibility break since we change the format of
the output. However, I'm not aware of any clients which use `copy-image`
directly and not through cosa.

Prep for making use of this in cosa to speed up `cosa aws-replicate`.