### PR TITLE
kola/qemu: Fix leaking qemu instances

### DIFF
--- a/platform/machine/unprivqemu/cluster.go
+++ b/platform/machine/unprivqemu/cluster.go
@@ -114,6 +114,7 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	if err != nil {
 		return nil, err
 	}
+	qm.inst = *inst
 
 	err = util.Retry(6, 5*time.Second, func() error {
 		var err error

--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -111,17 +111,20 @@ func (inst *QemuInstance) SSHAddress() (string, error) {
 }
 
 func (inst *QemuInstance) Destroy() {
+	if inst.qemu != nil {
+		if err := inst.qemu.Kill(); err != nil {
+			plog.Errorf("Error killing qemu instance %v: %v", inst.Pid(), err)
+		}
+		inst.qemu.Wait() // Ignore errors
+	}
 	if inst.swtpmTmpd != "" {
 		if inst.swtpm != nil {
 			inst.swtpm.Kill() // Ignore errors
 		}
+		// And ensure it's cleaned up
+		inst.swtpm.Wait()
 		if err := os.RemoveAll(inst.swtpmTmpd); err != nil {
 			plog.Errorf("Error removing swtpm dir: %v", err)
-		}
-	}
-	if inst.qemu != nil {
-		if err := inst.qemu.Kill(); err != nil {
-			plog.Errorf("Error killing qemu instance %v: %v", inst.Pid(), err)
 		}
 	}
 }


### PR DESCRIPTION
First, actually assign the `inst` struct that we return.  Now,
let's call `Wait()` synchronously to ensure that the processes
are dead.

Prep for further fixes around `--parallel` with qemu.