### PR TITLE
kola: Add a --cosa-build argument

### DIFF
--- a/cosa/build.go
+++ b/cosa/build.go
@@ -1,0 +1,47 @@
+// Copyright 2020 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cosa
+
+// Build is the coreos-assembler `meta.json` which defines a build.
+// This code was copied from openshift-installer's
+// https://github.com/openshift/installer/blob/a0350404997b0493d7bb16aa2875e5c42879b069/pkg/rhcos/builds.go
+// For now, copy-paste updates there.  Later, maybe consider making this a public API?
+type Build struct {
+	AMIs map[string]struct {
+		HVM string `json:"hvm"`
+	} `json:"amis"`
+	Azure struct {
+		Image string `json:"image"`
+		URL   string `json:"url"`
+	}
+	GCP struct {
+		Image string `json:"image"`
+		URL   string `json:"url"`
+	}
+	BaseURI string `json:"baseURI"`
+	Images  struct {
+		QEMU struct {
+			Path               string `json:"path"`
+			SHA256             string `json:"sha256"`
+			UncompressedSHA256 string `json:"uncompressed-sha256"`
+		} `json:"qemu"`
+		OpenStack struct {
+			Path               string `json:"path"`
+			SHA256             string `json:"sha256"`
+			UncompressedSHA256 string `json:"uncompressed-sha256"`
+		} `json:"openstack"`
+	} `json:"images"`
+	OSTreeVersion string `json:"ostree-version"`
+}

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -158,6 +158,8 @@ type Options struct {
 	IgnitionVersion string
 	SystemdDropins  []SystemdDropin
 
+	CosaBuild string
+
 	NoTestExitError bool
 
 	// OSContainer is an image pull spec that can be given to the pivot service


### PR DESCRIPTION
This starts the ball rolling on having mantle understand cosa,
which is key for long-term dedup of the projects.

The main motivation for this right now is that by decoding the
JSON into a Go struct, we are effectively doing a schema validation.

After this lands I'll make a separate PR to flesh out the struct
entirely, then change the decoder to error on unknown keys.

This also removes some CL cruft around the default disk image.