### PR TITLE
kola/test/crio: don't try to pull local images during crictl create

### DIFF
--- a/kola/tests/crio/crio.go
+++ b/kola/tests/crio/crio.go
@@ -305,7 +305,7 @@ func crioNetwork(c cluster.TestCluster) {
 			return err
 		}
 
-		containerID, err := c.SSH(dest, fmt.Sprintf("sudo crictl create %s %s %s",
+		containerID, err := c.SSH(dest, fmt.Sprintf("sudo crictl create --no-pull %s %s %s",
 			podID, crioConfigContainer, crioConfigPod))
 		if err != nil {
 			return err
@@ -348,7 +348,7 @@ func crioNetwork(c cluster.TestCluster) {
 			return err
 		}
 
-		containerID, err := c.SSH(src, fmt.Sprintf("sudo crictl create %s %s %s",
+		containerID, err := c.SSH(src, fmt.Sprintf("sudo crictl create --no-pull %s %s %s",
 			podID, crioConfigContainer, crioConfigPod))
 		if err != nil {
 			return err
@@ -389,9 +389,10 @@ func crioNetworksReliably(c cluster.TestCluster) {
 		if err != nil {
 			c.Fatal(err)
 		}
+
 		cmdCreatePod := fmt.Sprintf("sudo crictl runp %s", crioConfigPod)
 		podID := c.MustSSH(m, cmdCreatePod)
-		containerID := c.MustSSH(m, fmt.Sprintf("sudo crictl create %s %s %s",
+		containerID := c.MustSSH(m, fmt.Sprintf("sudo crictl create --no-pull %s %s %s",
 			podID, crioConfigContainer, crioConfigPod))
 		output = output + string(c.MustSSH(m, fmt.Sprintf("sudo crictl exec %s ping -i 0.2 10.88.0.1 -w 1 >/dev/null && echo PASS || echo FAIL", containerID)))
 	}
@@ -453,7 +454,7 @@ func crioPodContinuesDuringServiceRestart(c cluster.TestCluster) {
 	}
 	cmdCreatePod := fmt.Sprintf("sudo crictl runp %s", crioConfigPod)
 	podID := c.MustSSH(m, cmdCreatePod)
-	containerID := c.MustSSH(m, fmt.Sprintf("sudo crictl create %s %s %s",
+	containerID := c.MustSSH(m, fmt.Sprintf("sudo crictl create --no-pull %s %s %s",
 		podID, crioConfigContainer, crioConfigPod))
 
 	cmd := fmt.Sprintf("sudo crictl exec %s bash -c \"sleep 25 && echo PASS > /tmp/test/restart-test\"", containerID)


### PR DESCRIPTION
When testing the change from `crictl` 1.14 to 1.16, it was observed
that the `crio.base` tests were failing.  It looks like the `crictl
create` operation is trying to pull images like `localhost/sleep` from
what it thinks is a proper registry at `http://localhost`.

Using the `--no-pull` option avoids this error and allows the tests to
pass successfully.

Regression in `crictl` reported https://github.com/kubernetes-sigs/cri-tools/issues/548