### PR TITLE
cmd/kola/options: Fix error when running on non-qemu platforms

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -188,7 +188,7 @@ func syncOptions() error {
 		cosaBuild = &tmpBuild
 	}
 
-	if kola.QEMUOptions.DiskImage == "" {
+	if kolaPlatform == "qemu-unpriv" && kola.QEMUOptions.DiskImage == "" {
 		if cosaBuild != nil {
 			kola.QEMUOptions.DiskImage = filepath.Join(filepath.Dir(kola.Options.CosaBuild), cosaBuild.Images.QEMU.Path)
 		} else {


### PR DESCRIPTION
The new `cosa-build` parameter checks were erroring when both it and
`qemu-image` were not present even when running on non `qemu` platforms.