### PR TITLE
Fix case statement in helper functions for fwcfg and swtpm

### DIFF
--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -225,8 +225,7 @@ func (builder *QemuBuilder) EnableUsermodeNetworking(forwardedPort uint) {
 // Ignition via the qemu -fw_cfg option.
 func (builder *QemuBuilder) supportsFwCfg() bool {
 	switch builder.Board {
-	case "s390x-usr":
-	case "ppc64le-usr":
+	case "s390x-usr", "ppc64le-usr":
 		return false
 	}
 	return true
@@ -237,8 +236,7 @@ func (builder *QemuBuilder) supportsSwtpm() bool {
 	// Yes, this is the same as supportsFwCfg *currently* but
 	// might not be in the future.
 	switch builder.Board {
-	case "s390x-usr":
-	case "ppc64le-usr":
+	case "s390x-usr", "ppc64le-usr":
 		return false
 	}
 	return true


### PR DESCRIPTION
A minor bug in the way case statements are written in golang. They either require a fallthrough in each case or all the cases specified in the same case statement. Chose the latter as the list is not too
big