### PR TITLE
kola: Remove Distros{fcos,rhcos} from tests - it's the default

### DIFF
--- a/kola/tests/coretest/core.go
+++ b/kola/tests/coretest/core.go
@@ -52,7 +52,6 @@ func init() {
 			"Useradd":        register.CreateNativeFuncWrap(TestUseradd),
 			"MachineID":      register.CreateNativeFuncWrap(TestMachineID),
 		},
-		Distros: []string{"fcos", "rhcos"},
 	})
 	// TODO: Enable DockerPing/DockerEcho once fixed
 	// TODO: Only enable PodmanPing on non qemu-unpriv. Needs:

--- a/kola/tests/ignition/execution.go
+++ b/kola/tests/ignition/execution.go
@@ -54,7 +54,6 @@ func init() {
                                ]
                              }
                            }`),
-		Distros: []string{"fcos", "rhcos"},
 	})
 }
 

--- a/kola/tests/ignition/mount.go
+++ b/kola/tests/ignition/mount.go
@@ -190,7 +190,6 @@ func init() {
 		Run:         testMountDisks,
 		ClusterSize: 0,
 		Platforms:   []string{"qemu"},
-		Distros:     []string{"fcos", "rhcos"},
 	})
 	// create new partiitons with disk `vda`
 	register.RegisterTest(&register.Test{
@@ -341,7 +340,6 @@ func init() {
 		}`),
 		ClusterSize: 1,
 		Platforms:   []string{"qemu"},
-		Distros:     []string{"fcos", "rhcos"},
 	})
 }
 

--- a/kola/tests/ignition/passwd.go
+++ b/kola/tests/ignition/passwd.go
@@ -73,7 +73,6 @@ func init() {
 		               ]
 		             }
 		           }`),
-		Distros: []string{"fcos", "rhcos"},
 	})
 	register.RegisterTest(&register.Test{
 		Name:        "coreos.ignition.v2.users",
@@ -121,7 +120,6 @@ func init() {
 		               ]
 		             }
 		           }`),
-		Distros: []string{"fcos", "rhcos"},
 	})
 }
 

--- a/kola/tests/ignition/resource.go
+++ b/kola/tests/ignition/resource.go
@@ -105,7 +105,6 @@ func init() {
 		},
 		// https://github.com/coreos/bugs/issues/2205
 		ExcludePlatforms: []string{"do", "qemu-unpriv"},
-		Distros:          []string{"fcos", "rhcos"},
 	})
 	register.RegisterTest(&register.Test{
 		Name:        "coreos.ignition.resource.remote",
@@ -177,7 +176,6 @@ func init() {
 		      ]
 		  }
 	      }`),
-		Distros: []string{"fcos", "rhcos"},
 	})
 	register.RegisterTest(&register.Test{
 		Name:        "coreos.ignition.resource.s3",
@@ -227,7 +225,6 @@ func init() {
 		      ]
 		  }
 	      }`),
-		Distros: []string{"fcos", "rhcos"},
 	})
 	// TODO: once Ignition supports this on all channels/distros
 	//       this test should be rolled into coreos.ignition.resources.remote

--- a/kola/tests/ignition/security.go
+++ b/kola/tests/ignition/security.go
@@ -80,7 +80,6 @@ func init() {
 		// DO: https://github.com/coreos/bugs/issues/2205
 		// Packet & QEMU: https://github.com/coreos/ignition/issues/645
 		ExcludePlatforms: []string{"do", "packet", "qemu"},
-		Distros:          []string{"fcos", "rhcos"},
 	})
 }
 

--- a/kola/tests/ignition/sethostname.go
+++ b/kola/tests/ignition/sethostname.go
@@ -68,7 +68,6 @@ func init() {
 		ClusterSize:      1,
 		UserData:         configV2,
 		UserDataV3:       configV3,
-		Distros:          []string{"fcos", "rhcos"},
 		ExcludePlatforms: []string{"azure"},
 	})
 }

--- a/kola/tests/ignition/ssh.go
+++ b/kola/tests/ignition/ssh.go
@@ -30,6 +30,5 @@ func init() {
 		Flags:            []register.Flag{register.NoSSHKeyInMetadata},
 		UserData:         conf.Ignition(`{"ignition":{"version":"2.0.0"}}`),
 		UserDataV3:       conf.Ignition(`{"ignition":{"version":"3.0.0"}}`),
-		Distros:          []string{"fcos", "rhcos"},
 	})
 }

--- a/kola/tests/misc/auth.go
+++ b/kola/tests/misc/auth.go
@@ -24,7 +24,6 @@ func init() {
 		Run:         AuthVerify,
 		ClusterSize: 1,
 		Name:        "coreos.auth.verify",
-		Distros:     []string{"fcos", "rhcos"},
 	})
 }
 

--- a/kola/tests/misc/selinux.go
+++ b/kola/tests/misc/selinux.go
@@ -29,19 +29,16 @@ func init() {
 		Run:         SelinuxEnforce,
 		ClusterSize: 1,
 		Name:        "coreos.selinux.enforce",
-		Distros:     []string{"fcos", "rhcos"},
 	})
 	register.RegisterTest(&register.Test{
 		Run:         SelinuxBoolean,
 		ClusterSize: 1,
 		Name:        "coreos.selinux.boolean",
-		Distros:     []string{"fcos", "rhcos"},
 	})
 	register.RegisterTest(&register.Test{
 		Run:         SelinuxBooleanPersist,
 		ClusterSize: 1,
 		Name:        "rhcos.selinux.boolean.persist",
-		Distros:     []string{"fcos", "rhcos"},
 	})
 	register.RegisterTest(&register.Test{
 		Run:         SelinuxManage,

--- a/kola/tests/ostree/basic.go
+++ b/kola/tests/ostree/basic.go
@@ -42,7 +42,6 @@ func init() {
 		Run:         ostreeRemoteTest,
 		ClusterSize: 1,
 		Name:        "ostree.remote",
-		Distros:     []string{"fcos", "rhcos"},
 		Flags:       []register.Flag{register.RequiresInternetAccess}, // need network to contact remote
 		FailFast:    true,
 	})

--- a/kola/tests/ostree/unlock.go
+++ b/kola/tests/ostree/unlock.go
@@ -29,7 +29,6 @@ func init() {
 		ClusterSize: 1,
 		Name:        "ostree.unlock",
 		Flags:       []register.Flag{register.RequiresInternetAccess}, // need network to pull RPM
-		Distros:     []string{"fcos", "rhcos"},
 		FailFast:    true,
 	})
 	register.RegisterTest(&register.Test{
@@ -37,7 +36,6 @@ func init() {
 		ClusterSize: 1,
 		Flags:       []register.Flag{register.RequiresInternetAccess}, // need network to pull RPM
 		Name:        "ostree.hotfix",
-		Distros:     []string{"fcos", "rhcos"},
 		FailFast:    true,
 	})
 

--- a/kola/tests/podman/podman.go
+++ b/kola/tests/podman/podman.go
@@ -38,7 +38,6 @@ func init() {
 		Run:         podmanBaseTest,
 		ClusterSize: 1,
 		Name:        `podman.base`,
-		Distros:     []string{"fcos", "rhcos"},
 	})
 	// These remaining tests use networking, and hence don't work reliably on RHCOS
 	// right now due to due to https://bugzilla.redhat.com/show_bug.cgi?id=1757572

--- a/kola/tests/rpmostree/deployments.go
+++ b/kola/tests/rpmostree/deployments.go
@@ -29,7 +29,6 @@ func init() {
 		Run:         rpmOstreeUpgradeRollback,
 		ClusterSize: 1,
 		Name:        "rpmostree.upgrade-rollback",
-		Distros:     []string{"fcos", "rhcos"},
 		FailFast:    true,
 	})
 	register.RegisterTest(&register.Test{
@@ -109,9 +108,7 @@ func init() {
     ]
   }
 }`),
-
-		Distros: []string{"fcos", "rhcos"},
-		Flags:   []register.Flag{register.RequiresInternetAccess}, // these need network to retrieve bits
+		Flags: []register.Flag{register.RequiresInternetAccess}, // these need network to retrieve bits
 	})
 }
 

--- a/kola/tests/rpmostree/status.go
+++ b/kola/tests/rpmostree/status.go
@@ -30,7 +30,6 @@ func init() {
 		Run:         rpmOstreeStatus,
 		ClusterSize: 1,
 		Name:        "rpmostree.status",
-		Distros:     []string{"fcos", "rhcos"},
 	})
 }
 


### PR DESCRIPTION
No reason to specify it now that we dropped CL support, so
remove it from all the tests.