### PR TITLE
kola: Rework syncOptions

### DIFF
--- a/cmd/kola/kola.go
+++ b/cmd/kola/kola.go
@@ -117,9 +117,6 @@ func main() {
 
 func preRun(cmd *cobra.Command, args []string) {
 	err := syncOptions()
-	if err == nil {
-		err = syncCosaOptions()
-	}
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -390,7 +387,7 @@ func preRunUpgrade(cmd *cobra.Command, args []string) error {
 		errors.New("Error: missing required argument --cosa-build")
 	}
 
-	err := syncOptions()
+	err := syncOptionsImpl(false)
 	if err != nil {
 		return err
 	}

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -142,7 +142,7 @@ func init() {
 }
 
 // Sync up the command line options if there is dependency
-func syncOptions() error {
+func syncOptionsImpl(useCosa bool) error {
 	kola.PacketOptions.Board = kola.QEMUOptions.Board
 	kola.PacketOptions.GSOptions = &kola.GCEOptions
 
@@ -169,10 +169,8 @@ func syncOptions() error {
 		return err
 	}
 
-	if kola.Options.CosaBuild != "" {
-		var err error
-		kola.CosaBuild, err = cosa.ParseBuild(kola.Options.CosaBuild)
-		if err != nil {
+	if useCosa && kola.Options.CosaBuild != "" {
+		if err := syncCosaOptions(); err != nil {
 			return err
 		}
 	}
@@ -201,11 +199,18 @@ func syncOptions() error {
 	return nil
 }
 
+// syncOptions updates default values of options based on provided ones
+func syncOptions() error {
+	return syncOptionsImpl(true)
+}
+
 // syncCosaOptions parses the cosa build and sets unset platform-specific
 // options that can be derived from the cosa build metadata
 func syncCosaOptions() error {
-	if kola.CosaBuild == nil {
-		return nil
+	var err error
+	kola.CosaBuild, err = cosa.ParseBuild(kola.Options.CosaBuild)
+	if err != nil {
+		return err
 	}
 
 	switch kolaPlatform {


### PR DESCRIPTION
Prep for adding more commands which need `syncOptions`; rather
than having `syncOptions` and `syncCosaOptions`, make the upgrade
test the exception that skips the latter.