### PR TITLE
qemu: Always add serial= for disks

### DIFF
--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -403,6 +403,9 @@ func (builder *QemuBuilder) addDiskImpl(disk *Disk, primary bool) error {
 	diskOpts := disk.DeviceOpts
 	if primary {
 		diskOpts = append(diskOpts, "serial=primary-disk")
+	} else {
+		// Note that diskId is incremented by addQcow2DiskFd
+		diskOpts = append(diskOpts, "serial="+fmt.Sprintf("disk%d", builder.diskId))
 	}
 	channel := disk.Channel
 	if channel == "" {


### PR DESCRIPTION
This is used for device enumeration order, and is required for NVMe
drives apparently.  Hit this while trying to use a NVMe device as
a target for coreos-install testing (not primary disk).