### PR TITLE
qemu: Only set serial= if not already provided

### DIFF
--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -404,8 +404,16 @@ func (builder *QemuBuilder) addDiskImpl(disk *Disk, primary bool) error {
 	if primary {
 		diskOpts = append(diskOpts, "serial=primary-disk")
 	} else {
-		// Note that diskId is incremented by addQcow2DiskFd
-		diskOpts = append(diskOpts, "serial="+fmt.Sprintf("disk%d", builder.diskId))
+		foundserial := false
+		for _, opt := range diskOpts {
+			if strings.HasPrefix(opt, "serial=") {
+				foundserial = true
+			}
+		}
+		if !foundserial {
+			// Note that diskId is incremented by addQcow2DiskFd
+			diskOpts = append(diskOpts, "serial="+fmt.Sprintf("disk%d", builder.diskId))
+		}
 	}
 	channel := disk.Channel
 	if channel == "" {


### PR DESCRIPTION
Regression from 73831285bf5f85af95bb202f0349545f45ac278f which
broke `coreos.ignition.mount.disks` because we were overriding
the provided serial.