### PR TITLE
README: redirect FCOS/RHCOS users to cosa in CL branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+<font size="+2"><b>:rotating_light: Mantle for Fedora CoreOS and RHEL
+CoreOS has been merged into
+[coreos-assembler](https://github.com/coreos/coreos-assembler/).
+:rotating_light:
+<br>
+This `cl` branch is for CoreOS Container Linux.</b></font>
+
 # Mantle: Gluing Container Linux together
 
 This repository is a collection of utilities for developing Container Linux. Most of the


### PR DESCRIPTION
Update README for `cl` branch, since that'll become the GitHub default.