### PR TITLE
cmd/plume/containerlinux: disable Azure partitions

### DIFF
--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -38,12 +38,6 @@ var (
 			SubscriptionName:     "BizSpark",
 			AdditionalContainers: []string{"pre-publish"},
 		},
-		azureEnvironmentSpec{
-			SubscriptionName: "BlackForest",
-		},
-		azureEnvironmentSpec{
-			SubscriptionName: "Mooncake",
-		},
 	}
 	awsPartitions = []awsPartitionSpec{
 		awsPartitionSpec{


### PR DESCRIPTION
We're no longer uploading to BlackForest & Mooncake.