### PR TITLE
[rhcos-4.2] kola/tests/ignition: update resource test to use different bucket

### DIFF
--- a/kola/tests/ignition/resource.go
+++ b/kola/tests/ignition/resource.go
@@ -125,7 +125,7 @@ func init() {
 			      "filesystem": "root",
 			      "path": "/var/resource/http",
 			      "contents": {
-				  "source": "http://s3-us-west-2.amazonaws.com/kola-fixtures/resources/anonymous"
+				  "source": "http://rh-kola-fixtures.s3.amazonaws.com/resources/anonymous"
 			      },
 			      "mode": 420
 			  },
@@ -133,7 +133,7 @@ func init() {
 			      "filesystem": "root",
 			      "path": "/var/resource/https",
 			      "contents": {
-				  "source": "https://s3-us-west-2.amazonaws.com/kola-fixtures/resources/anonymous"
+				  "source": "https://rh-kola-fixtures.s3.amazonaws.com/resources/anonymous"
 			      },
 			      "mode": 420
 			  },
@@ -141,7 +141,7 @@ func init() {
 			      "filesystem": "root",
 			      "path": "/var/resource/s3-anon",
 			      "contents": {
-				  "source": "s3://kola-fixtures/resources/anonymous"
+				  "source": "s3://rh-kola-fixtures/resources/anonymous"
 			      },
 			      "mode": 420
 			  }
@@ -157,21 +157,21 @@ func init() {
 			  {
 			      "path": "/var/resource/http",
 			      "contents": {
-				  "source": "http://s3-us-west-2.amazonaws.com/kola-fixtures/resources/anonymous"
+				  "source": "http://rh-kola-fixtures.s3.amazonaws.com/resources/anonymous"
 			      },
 			      "mode": 420
 			  },
 			  {
 			      "path": "/var/resource/https",
 			      "contents": {
-				  "source": "https://s3-us-west-2.amazonaws.com/kola-fixtures/resources/anonymous"
+				  "source": "https://rh-kola-fixtures.s3.amazonaws.com/resources/anonymous"
 			      },
 			      "mode": 420
 			  },
 			  {
 			      "path": "/var/resource/s3-anon",
 			      "contents": {
-				  "source": "s3://kola-fixtures/resources/anonymous"
+				  "source": "s3://rh-kola-fixtures/resources/anonymous"
 			      },
 			      "mode": 420
 			  }
@@ -190,7 +190,7 @@ func init() {
 		      "version": "2.1.0",
 		      "config": {
 		          "append": [{
-		              "source": "s3://kola-fixtures/resources/authenticated-var.ign"
+		              "source": "s3://rh-kola-fixtures/resources/authenticated-var.ign"
 		          }]
 		      }
 		  },
@@ -200,7 +200,7 @@ func init() {
 			      "filesystem": "root",
 			      "path": "/var/resource/s3-auth",
 			      "contents": {
-				  "source": "s3://kola-fixtures/resources/authenticated"
+				  "source": "s3://rh-kola-fixtures/resources/authenticated"
 			      },
 			      "mode": 420
 			  }
@@ -212,7 +212,7 @@ func init() {
 		      "version": "3.0.0",
 		      "config": {
 		          "merge": [{
-		              "source": "s3://kola-fixtures/resources/authenticated-var-v3.ign"
+		              "source": "s3://rh-kola-fixtures/resources/authenticated-var-v3.ign"
 		          }]
 		      }
 		  },
@@ -221,7 +221,7 @@ func init() {
 			  {
 			      "path": "/var/resource/s3-auth",
 			      "contents": {
-				  "source": "s3://kola-fixtures/resources/authenticated"
+				  "source": "s3://rh-kola-fixtures/resources/authenticated"
 			      },
 			      "mode": 420
 			  }
@@ -251,7 +251,7 @@ func init() {
 			      "filesystem": "root",
 			      "path": "/var/resource/original",
 			      "contents": {
-				  "source": "http://s3-us-west-2.amazonaws.com/kola-fixtures/resources/versioned?versionId=null"
+				  "source": "https://rh-kola-fixtures.s3.amazonaws.com/resources/versioned?versionId=Ym98GTx0npVaJznSAd0I1eUjFoZMP8Zo"
 			      },
 			      "mode": 420
 			  },
@@ -259,7 +259,7 @@ func init() {
 			      "filesystem": "root",
 			      "path": "/var/resource/latest",
 			      "contents": {
-				  "source": "http://s3-us-west-2.amazonaws.com/kola-fixtures/resources/versioned?versionId=RDWqxfnlcJOSDf1.5jy6ZP.oK9Bt7_Id"
+				  "source": "https://rh-kola-fixtures.s3.amazonaws.com/resources/versioned"
 			      },
 			      "mode": 420
 			  }
@@ -275,14 +275,14 @@ func init() {
 			  {
 			      "path": "/var/resource/original",
 			      "contents": {
-				  "source": "http://s3-us-west-2.amazonaws.com/kola-fixtures/resources/versioned?versionId=null"
+				  "source": "https://rh-kola-fixtures.s3.amazonaws.com/resources/versioned?versionId=Ym98GTx0npVaJznSAd0I1eUjFoZMP8Zo"
 			      },
 			      "mode": 420
 			  },
 			  {
 			      "path": "/var/resource/latest",
 			      "contents": {
-				  "source": "http://s3-us-west-2.amazonaws.com/kola-fixtures/resources/versioned?versionId=RDWqxfnlcJOSDf1.5jy6ZP.oK9Bt7_Id"
+				  "source": "https://rh-kola-fixtures.s3.amazonaws.com/resources/versioned"
 			      },
 			      "mode": 420
 			  }
@@ -350,14 +350,14 @@ func resourceS3(c cluster.TestCluster) {
 
 	// verify that the objects are inaccessible anonymously
 	for _, objectName := range []string{"authenticated", "authenticated.ign"} {
-		_, _, err := m.SSH("curl -sf https://s3-us-west-2.amazonaws.com/kola-fixtures/resources/" + objectName)
+		_, _, err := m.SSH("curl -sf https://rh-kola-fixtures.s3.amazonaws.com/resources/" + objectName)
 		if err == nil {
 			c.Fatal("anonymously fetching authenticated resource should have failed, but did not")
 		}
 	}
 
 	// ...but that the anonymous object is accessible
-	c.MustSSH(m, "curl -sf https://s3-us-west-2.amazonaws.com/kola-fixtures/resources/anonymous")
+	c.MustSSH(m, "curl -sf https://rh-kola-fixtures.s3.amazonaws.com/resources/anonymous")
 }
 
 func resourceS3Versioned(c cluster.TestCluster) {


### PR DESCRIPTION
The CL AWS account which hosted the `kola-fixtures` bucket is going
away. Move the test to a new bucket in a different account.

Backports coreos/coreos-assembler#1778